### PR TITLE
fix(vite): do not generate if there are no css chunks

### DIFF
--- a/packages/vite/src/global-build.ts
+++ b/packages/vite/src/global-build.ts
@@ -52,6 +52,9 @@ export function GlobalModeBuildPlugin({ uno, config, scan, tokens }: Context): P
         const keys = Object.keys(bundle)
           .filter(i => i.endsWith('.css'))
 
+        if (!keys.length)
+          return
+
         await Promise.all(tasks)
         const { css } = await uno.generate(tokens)
         let replaced = false


### PR DESCRIPTION
when using @vite/plugin-legacy, there are no css chunks in the bundle