### PR TITLE
feat(preset-mini,preset-wind): replace hex color parser

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -38,13 +38,13 @@ export interface ParsedColorValue {
    */
   no: string
   /**
-   * {@link RGBAColorValue}
+   * {@link CSSColorValue}
    */
-  rgba?: RGBAColorValue
+  cssColor: CSSColorValue | undefined
   /**
-   * Parsed rgba's alpha value.
+   * Parsed alpha value from opacity
    */
-  alpha?: number | string
+  alpha: string | number | undefined
 }
 
 export type PresetOptions = Record<string, any>

--- a/packages/preset-mini/src/rules/border.ts
+++ b/packages/preset-mini/src/rules/border.ts
@@ -1,6 +1,6 @@
 import type { CSSEntries, CSSObject, DynamicMatcher, Rule, RuleContext } from '@unocss/core'
 import type { Theme } from '../theme'
-import { cornerMap, directionMap, handler as h, parseColor } from '../utils'
+import { colorToString, cornerMap, directionMap, handler as h, parseColor } from '../utils'
 
 export const borders: Rule[] = [
   // compound
@@ -57,36 +57,31 @@ const borderColorResolver = (direction: string): DynamicMatcher => ([, body]: st
   if (!data)
     return
 
-  const { alpha, opacity, color, rgba } = data
+  const { alpha, color, cssColor } = data
 
-  if (!color)
-    return
-
-  if (rgba) {
+  if (cssColor) {
     if (alpha != null) {
       return {
-        [`border${direction}-color`]: `rgba(${rgba.join(',')})`,
+        [`border${direction}-color`]: colorToString(cssColor, alpha),
+      }
+    }
+    if (direction === '') {
+      return {
+        '--un-border-opacity': cssColor.alpha ?? 1,
+        [`border${direction}-color`]: colorToString(cssColor, `var(--un-border${direction}-opacity)`),
       }
     }
     else {
-      if (direction === '') {
-        return {
-          '--un-border-opacity': (opacity && h.cssvar(opacity)) ?? 1,
-          [`border${direction}-color`]: `rgba(${rgba.join(',')},var(--un-border${direction}-opacity))`,
-        }
-      }
-      else {
-        return {
-          '--un-border-opacity': (opacity && h.cssvar(opacity)) ?? 1,
-          [`--un-border${direction}-opacity`]: 'var(--un-border-opacity)',
-          [`border${direction}-color`]: `rgba(${rgba.join(',')},var(--un-border${direction}-opacity))`,
-        }
+      return {
+        '--un-border-opacity': cssColor.alpha ?? 1,
+        [`--un-border${direction}-opacity`]: 'var(--un-border-opacity)',
+        [`border${direction}-color`]: colorToString(cssColor, `var(--un-border${direction}-opacity)`),
       }
     }
   }
-  else {
+  else if (color) {
     return {
-      [`border${direction}-color`]: color.replace('%alpha', `${alpha || 1}`),
+      [`border${direction}-color`]: color.replace('%alpha', `${alpha ?? 1}`),
     }
   }
 }

--- a/packages/preset-mini/src/rules/shadow.ts
+++ b/packages/preset-mini/src/rules/shadow.ts
@@ -1,7 +1,7 @@
 import type { Rule } from '@unocss/core'
 import { CONTROL_SHORTCUT_NO_MERGE, toArray } from '@unocss/core'
 import type { Theme } from '../theme'
-import { colorResolver, handler as h } from '../utils'
+import { colorResolver, colorToString, handler as h, parseCssColor } from '../utils'
 import { varEmpty } from './static'
 
 export const shadowBase = {
@@ -16,10 +16,13 @@ export const colorableShadows = (shadows: string | string[], colorVar: string) =
   const colored = []
   shadows = toArray(shadows)
   for (let i = 0; i < shadows.length; i++) {
-    const [size, color] = shadows[i].split(/\s(\S+)$/)
+    const [size, color] = shadows[i].split(/\s+(\S+)$/)
     if (color.split('(').length !== color.split(')').length)
       return shadows
-    colored.push(`${size} var(${colorVar}, ${color})`)
+    const cssColor = parseCssColor(color)
+    if (cssColor == null)
+      return shadows
+    colored.push(`${size} var(${colorVar}, ${colorToString(cssColor)})`)
   }
   return colored
 }

--- a/packages/preset-mini/src/rules/shadow.ts
+++ b/packages/preset-mini/src/rules/shadow.ts
@@ -1,7 +1,7 @@
 import type { Rule } from '@unocss/core'
 import { CONTROL_SHORTCUT_NO_MERGE } from '@unocss/core'
 import type { Theme } from '../theme'
-import { colorableShadows, colorResolver, handler as h } from '../utils'
+import { colorResolver, colorableShadows, handler as h } from '../utils'
 import { varEmpty } from './static'
 
 export const shadowBase = {

--- a/packages/preset-mini/src/rules/shadow.ts
+++ b/packages/preset-mini/src/rules/shadow.ts
@@ -1,7 +1,7 @@
 import type { Rule } from '@unocss/core'
-import { CONTROL_SHORTCUT_NO_MERGE, toArray } from '@unocss/core'
+import { CONTROL_SHORTCUT_NO_MERGE } from '@unocss/core'
 import type { Theme } from '../theme'
-import { colorResolver, colorToString, handler as h, parseCssColor } from '../utils'
+import { colorableShadows, colorResolver, handler as h } from '../utils'
 import { varEmpty } from './static'
 
 export const shadowBase = {
@@ -10,21 +10,6 @@ export const shadowBase = {
   '--un-ring-shadow': '0 0 #0000',
   '--un-shadow-inset': varEmpty,
   '--un-shadow': '0 0 #0000',
-}
-
-export const colorableShadows = (shadows: string | string[], colorVar: string) => {
-  const colored = []
-  shadows = toArray(shadows)
-  for (let i = 0; i < shadows.length; i++) {
-    const [size, color] = shadows[i].split(/\s+(\S+)$/)
-    if (color.split('(').length !== color.split(')').length)
-      return shadows
-    const cssColor = parseCssColor(color)
-    if (cssColor == null)
-      return shadows
-    colored.push(`${size} var(${colorVar}, ${colorToString(cssColor)})`)
-  }
-  return colored
 }
 
 export const boxShadows: Rule<Theme>[] = [

--- a/packages/preset-mini/src/rules/typography.ts
+++ b/packages/preset-mini/src/rules/typography.ts
@@ -1,7 +1,7 @@
 import type { Rule } from '@unocss/core'
 import { toArray } from '@unocss/core'
 import type { Theme } from '../theme'
-import { colorableShadows, colorResolver, handler as h } from '../utils'
+import { colorResolver, colorableShadows, handler as h } from '../utils'
 
 const weightMap: Record<string, string> = {
   thin: '100',

--- a/packages/preset-mini/src/rules/typography.ts
+++ b/packages/preset-mini/src/rules/typography.ts
@@ -1,8 +1,7 @@
 import type { Rule } from '@unocss/core'
 import { toArray } from '@unocss/core'
 import type { Theme } from '../theme'
-import { colorResolver, handler as h } from '../utils'
-import { colorableShadows } from './shadow'
+import { colorableShadows, colorResolver, handler as h } from '../utils'
 
 const weightMap: Record<string, string> = {
   thin: '100',

--- a/packages/preset-mini/src/utils/colors.ts
+++ b/packages/preset-mini/src/utils/colors.ts
@@ -212,8 +212,8 @@ function parseCssSpaceColorValues(componentString: string) {
 }
 
 function getComponent(str: string, separator: string) {
-  const component = str.trim()
-  if (component === '')
+  str = str.trim()
+  if (str === '')
     return
 
   const l = str.length
@@ -236,7 +236,7 @@ function getComponent(str: string, separator: string) {
             return
 
           return [
-            str.slice(0, i).trim(),
+            component,
             str.slice(i + 1).trim(),
           ]
         }
@@ -244,7 +244,7 @@ function getComponent(str: string, separator: string) {
   }
 
   return [
-    str.trim(),
+    str,
     '',
   ]
 }

--- a/packages/preset-mini/src/utils/colors.ts
+++ b/packages/preset-mini/src/utils/colors.ts
@@ -22,6 +22,9 @@ export function parseCssColor(str = ''): CSSColorValue | undefined {
   const { type: casedType, components, alpha } = color
   const type = casedType.toLowerCase()
 
+  if (components.length === 0)
+    return
+
   if (['rgba', 'hsla'].includes(type) && alpha === undefined)
     return
 
@@ -118,63 +121,15 @@ function cssColorKeyword(str: string): CSSColorValue | undefined {
   }
 }
 
-function getComponent(separator: string, str: string) {
-  const component = str.trim()
-  if (component === '')
-    return
-
-  const l = str.length
-  let parenthesis = 0
-  for (let i = 0; i < l; i++) {
-    switch (str[i]) {
-      case '(':
-        parenthesis++
-        break
-
-      case ')':
-        if (--parenthesis < 0)
-          return
-        break
-
-      case separator:
-        if (parenthesis === 0) {
-          const component = str.slice(0, i).trim()
-          if (component === '')
-            return
-
-          return [
-            str.slice(0, i).trim(),
-            str.slice(i + 1).trim(),
-          ]
-        }
-    }
-  }
-
-  return [
-    str.trim(),
-    '',
-  ]
-}
-
 function parseCssCommaColorFunction(color: string): CSSColorValue | undefined {
   const match = color.match(/^(rgb|rgba|hsl|hsla)\((.+)\)$/i)
   if (!match)
     return
 
   const [, type, componentString] = match
-  const components = []
-  let cs = componentString
   // With min 3 (rgb) and max 4 (rgba), try to get 5 components
-  for (let c = 5; c > 0 && cs !== ''; --c) {
-    const componentValue = getComponent(',', cs)
-    if (!componentValue)
-      return
-    const [component, rest] = componentValue
-    components.push(component)
-    cs = rest
-  }
-
-  if ([3, 4].includes(components.length)) {
+  const components = getComponents(componentString, ',', 5)
+  if (components && [3, 4].includes(components.length)) {
     return {
       type,
       components: components.slice(0, 3),
@@ -218,16 +173,9 @@ function parseCssColorFunction(color: string): CSSColorValue | undefined {
 }
 
 function parseCssSpaceColorValues(componentString: string) {
-  let cs = componentString
-  const components = []
-  while (cs !== '') {
-    const cc = getComponent(' ', cs)
-    if (!cc)
-      return
-    const [component, rest] = cc
-    components.push(component)
-    cs = rest
-  }
+  const components = getComponents(componentString)
+  if (!components)
+    return
 
   let totalComponents = components.length
 
@@ -240,23 +188,16 @@ function parseCssSpaceColorValues(componentString: string) {
   }
 
   // (fn 1 2 3/ 4) or (fn 1 2 3 /4)
-  if (components[totalComponents - 2].endsWith('/') || components[totalComponents - 1].startsWith('/')) {
+  if (components[totalComponents - 2] != null && (components[totalComponents - 2].endsWith('/') || components[totalComponents - 1].startsWith('/'))) {
     const removed = components.splice(totalComponents - 2)
     components.push(removed.join(' '))
     --totalComponents
   }
 
   // maybe (fn 1 2 3/4)
-  cs = components[totalComponents - 1]
-  const withAlpha = []
-  while (cs !== '') {
-    const cc = getComponent('/', cs)
-    if (!cc)
-      return
-    const [component, rest] = cc
-    withAlpha.push(component)
-    cs = rest
-  }
+  const withAlpha = getComponents(components[totalComponents - 1], '/', 3)
+  if (!withAlpha)
+    return
 
   // without alpha
   if (withAlpha.length === 1 || withAlpha[withAlpha.length - 1] === '')
@@ -268,4 +209,63 @@ function parseCssSpaceColorValues(componentString: string) {
     components,
     alpha,
   }
+}
+
+function getComponent(str: string, separator: string) {
+  const component = str.trim()
+  if (component === '')
+    return
+
+  const l = str.length
+  let parenthesis = 0
+  for (let i = 0; i < l; i++) {
+    switch (str[i]) {
+      case '(':
+        parenthesis++
+        break
+
+      case ')':
+        if (--parenthesis < 0)
+          return
+        break
+
+      case separator:
+        if (parenthesis === 0) {
+          const component = str.slice(0, i).trim()
+          if (component === '')
+            return
+
+          return [
+            str.slice(0, i).trim(),
+            str.slice(i + 1).trim(),
+          ]
+        }
+    }
+  }
+
+  return [
+    str.trim(),
+    '',
+  ]
+}
+
+export function getComponents(str: string, separator?: string, limit?: number) {
+  separator = separator ?? ' '
+  if (separator.length !== 1)
+    return
+  limit = limit ?? 10
+  const components = []
+  let i = 0
+  while (str !== '') {
+    if (++i > limit)
+      return
+    const componentPair = getComponent(str, separator)
+    if (!componentPair)
+      return
+    const [component, rest] = componentPair
+    components.push(component)
+    str = rest
+  }
+  if (components.length > 0)
+    return components
 }

--- a/packages/preset-mini/src/utils/colors.ts
+++ b/packages/preset-mini/src/utils/colors.ts
@@ -107,7 +107,6 @@ function parseHexColor(str: string): CSSColorValue | undefined {
 function cssColorKeyword(str: string): CSSColorValue | undefined {
   const color = {
     rebeccapurple: [102, 51, 153, 1],
-    transparent: [0, 0, 0, 0],
   }[str]
 
   if (color != null) {

--- a/packages/preset-wind/src/rules/background.ts
+++ b/packages/preset-wind/src/rules/background.ts
@@ -1,5 +1,5 @@
 import type { Rule, RuleContext } from '@unocss/core'
-import { handler as h, parseColor, positionMap } from '@unocss/preset-mini/utils'
+import { colorToString, handler as h, parseColor, positionMap } from '@unocss/preset-mini/utils'
 import type { Theme } from '@unocss/preset-mini'
 
 const bgGradientColorResolver = (mode: 'from' | 'to' | 'via') =>
@@ -9,17 +9,17 @@ const bgGradientColorResolver = (mode: 'from' | 'to' | 'via') =>
     if (!data)
       return
 
-    const { alpha, color, rgba } = data
+    const { alpha, color, cssColor } = data
 
     if (!color)
       return
 
     let colorString = color
-    if (rgba) {
+    if (cssColor) {
       if (alpha != null)
-        colorString = `rgba(${rgba.join(',')})`
+        colorString = colorToString(cssColor, alpha)
       else
-        colorString = `rgba(${rgba.join(',')}, var(--un-${mode}-opacity, 1))`
+        colorString = colorToString(cssColor, `var(--un-${mode}-opacity, ${cssColor.alpha ?? 1})`)
     }
 
     switch (mode) {

--- a/packages/preset-wind/src/rules/filters.ts
+++ b/packages/preset-wind/src/rules/filters.ts
@@ -1,8 +1,8 @@
 import type { CSSValues, Rule, RuleContext } from '@unocss/core'
 import { CONTROL_SHORTCUT_NO_MERGE } from '@unocss/core'
 import type { Theme } from '@unocss/preset-mini'
-import { colorResolver, handler as h } from '@unocss/preset-mini/utils'
-import { colorableShadows, varEmpty } from '@unocss/preset-mini/rules'
+import { colorableShadows, colorResolver, handler as h } from '@unocss/preset-mini/utils'
+import { varEmpty } from '@unocss/preset-mini/rules'
 
 const filterBase = {
   '--un-blur': varEmpty,

--- a/packages/preset-wind/src/rules/filters.ts
+++ b/packages/preset-wind/src/rules/filters.ts
@@ -1,7 +1,7 @@
 import type { CSSValues, Rule, RuleContext } from '@unocss/core'
 import { CONTROL_SHORTCUT_NO_MERGE } from '@unocss/core'
 import type { Theme } from '@unocss/preset-mini'
-import { colorableShadows, colorResolver, handler as h } from '@unocss/preset-mini/utils'
+import { colorResolver, colorableShadows, handler as h } from '@unocss/preset-mini/utils'
 import { varEmpty } from '@unocss/preset-mini/rules'
 
 const filterBase = {

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -185,9 +185,9 @@ exports[`attributify > fixture2 1`] = `
 [peer=\\"\\"]:focus~[peer-focus~=\\"scale-75\\"],
 [peer=\\"\\"]:not(:placeholder-shown)~[peer-not-placeholder-shown~=\\"scale-75\\"]{--un-scale-x:0.75;--un-scale-y:0.75;transform:var(--un-transform);}
 [select-none=\\"\\"]{user-select:none;}
-[bg-gradient~=\\"from-yellow-400\\"]{--un-gradient-from:rgba(250,204,21, var(--un-from-opacity, 1));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
-[bg-gradient~=\\"to-pink-500\\"]{--un-gradient-to:rgba(236,72,153, var(--un-to-opacity, 1));}
-[bg-gradient~=\\"via-red-500\\"]{--un-gradient-stops:var(--un-gradient-from), rgba(239,68,68, var(--un-via-opacity, 1)), var(--un-gradient-to, rgba(255, 255, 255, 0));}
+[bg-gradient~=\\"from-yellow-400\\"]{--un-gradient-from:rgba(250,204,21,var(--un-from-opacity, 1));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
+[bg-gradient~=\\"to-pink-500\\"]{--un-gradient-to:rgba(236,72,153,var(--un-to-opacity, 1));}
+[bg-gradient~=\\"via-red-500\\"]{--un-gradient-stops:var(--un-gradient-from), rgba(239,68,68,var(--un-via-opacity, 1)), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 [bg-gradient~=\\"to-r\\"]{--un-gradient-shape:to right;--un-gradient:var(--un-gradient-shape), var(--un-gradient-stops);background-image:linear-gradient(var(--un-gradient));}
 [p-10=\\"\\"]{padding:2.5rem;}
 [px-4=\\"\\"]{padding-left:1rem;padding-right:1rem;}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -228,7 +228,7 @@ exports[`preset-mini > targets 1`] = `
 .underline-1rem{text-decoration-thickness:1rem;}
 .underline-auto{text-decoration-thickness:auto;}
 .decoration-purple\\\\/50{-webkit-text-decoration-color:rgba(192,132,252,0.5);text-decoration-color:rgba(192,132,252,0.5);}
-.decoration-transparent{-webkit-text-decoration-color:rgba(0,0,0,var(--un-line-opacity));--un-line-opacity:0;text-decoration-color:rgba(0,0,0,var(--un-line-opacity));}
+.decoration-transparent{-webkit-text-decoration-color:transparent;text-decoration-color:transparent;}
 .underline-red-500{-webkit-text-decoration-color:rgba(239,68,68,var(--un-line-opacity));--un-line-opacity:1;text-decoration-color:rgba(239,68,68,var(--un-line-opacity));}
 .underline-op80{--un-line-opacity:0.8;}
 .decoration-offset-0\\\\.6rem,
@@ -304,7 +304,7 @@ exports[`preset-mini > targets 1`] = `
 .text-red-100,
 .text-red100{--un-text-opacity:1;color:rgba(254,226,226,var(--un-text-opacity));}
 .placeholder-shown-color-transparent:placeholder-shown,
-.placeholder\\\\:color-transparent::placeholder{--un-text-opacity:0;color:rgba(0,0,0,var(--un-text-opacity));}
+.placeholder\\\\:color-transparent::placeholder{color:transparent;}
 .selection\\\\:color-\\\\[var\\\\(--select-color\\\\)\\\\]::selection{color:var(--select-color);}
 .text-\\\\[\\\\#124\\\\]{--un-text-opacity:1;color:rgba(17,34,68,var(--un-text-opacity));}
 .text-\\\\[2em\\\\]{color:2em;}
@@ -329,7 +329,7 @@ exports[`preset-mini > targets 1`] = `
 .shadow-current{--un-shadow-color:currentColor;}
 .shadow-green-500{--un-shadow-opacity:1;--un-shadow-color:rgba(34,197,94,var(--un-shadow-opacity));}
 .shadow-green-900\\\\/50{--un-shadow-color:rgba(20,83,45,0.5);}
-.shadow-transparent{--un-shadow-opacity:0;--un-shadow-color:rgba(0,0,0,var(--un-shadow-opacity));}
+.shadow-transparent{--un-shadow-color:transparent;}
 .shadow-op-50{--un-shadow-opacity:0.5;}
 .shadow-inset{--un-shadow-inset:inset;}
 .ring,

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -68,16 +68,16 @@ exports[`preset-mini > targets 1`] = `
 .placeholder-opacity-60::placeholder{opacity:0.6;}
 .bg-\\\\[\\\\#153\\\\]\\\\/10,
 .bg-\\\\[\\\\#1533\\\\]\\\\/10{background-color:rgba(17,85,51,0.1);}
-.bg-\\\\[\\\\#1533\\\\]{background-color:rgba(17,85,51,0.2);}
-.bg-\\\\[rgba\\\\(1\\\\2c 2\\\\2c 3\\\\2c 0\\\\.5\\\\)\\\\]{background-color:rgba(1,2,3,0.5);}
+.bg-\\\\[\\\\#1533\\\\]{--un-bg-opacity:0.2;background-color:rgba(17,85,51,var(--un-bg-opacity));}
+.bg-\\\\[rgba\\\\(1\\\\2c 2\\\\2c 3\\\\2c 0\\\\.5\\\\)\\\\]{--un-bg-opacity:0.5;background-color:rgba(1,2,3,var(--un-bg-opacity));}
 .bg-\\\\#452233\\\\/40,
 .bg-hex-452233\\\\/40{background-color:rgba(69,34,51,0.4);}
 .bg-\\\\$test-variable{background-color:var(--test-variable);}
 .bg-red-100{--un-bg-opacity:1;background-color:rgba(254,226,226,var(--un-bg-opacity));}
 .bg-teal-100\\\\/55{background-color:rgba(204,251,241,0.55);}
 .bg-teal-200\\\\:55{background-color:rgba(153,246,228,0.55);}
-.bg-teal-300\\\\:\\\\[\\\\.55\\\\]{background-color:rgba(94,234,212,0.55);}
-.bg-teal-400\\\\/\\\\[\\\\.55\\\\]{background-color:rgba(45,212,191,0.55);}
+.bg-teal-300\\\\:\\\\[\\\\.55\\\\]{background-color:rgba(94,234,212,.55);}
+.bg-teal-400\\\\/\\\\[\\\\.55\\\\]{background-color:rgba(45,212,191,.55);}
 .bg-teal-500\\\\/\\\\[55\\\\%\\\\]{background-color:rgba(20,184,166,55%);}
 .file\\\\:bg-violet-50::file-selector-button{--un-bg-opacity:1;background-color:rgba(245,243,255,var(--un-bg-opacity));}
 .focus-within\\\\:has-first\\\\:checked\\\\:bg-gray\\\\/20:focus-within:has(:first-child):checked,
@@ -153,7 +153,7 @@ exports[`preset-mini > targets 1`] = `
 .border-red-200\\\\/10{border-color:rgba(254,202,202,0.1);}
 .border-red-300\\\\/20{border-color:rgba(252,165,165,0.2);}
 .border-red2{--un-border-opacity:1;border-color:rgba(254,202,202,var(--un-border-opacity));}
-.border-x-\\\\[rgb\\\\(1\\\\2c 2\\\\2c 3\\\\)\\\\]\\\\/\\\\[0\\\\.5\\\\]{border-left-color:rgb(1,2,3);border-right-color:rgb(1,2,3);}
+.border-x-\\\\[rgb\\\\(1\\\\2c 2\\\\2c 3\\\\)\\\\]\\\\/\\\\[0\\\\.5\\\\]{border-left-color:rgba(1,2,3,0.5);border-right-color:rgba(1,2,3,0.5);}
 .border-x-\\\\$color{border-left-color:var(--color);border-right-color:var(--color);}
 .border-y-red{--un-border-opacity:1;--un-border-top-opacity:var(--un-border-opacity);border-top-color:rgba(248,113,113,var(--un-border-top-opacity));--un-border-bottom-opacity:var(--un-border-opacity);border-bottom-color:rgba(248,113,113,var(--un-border-bottom-opacity));}
 .border-b-blue{--un-border-opacity:1;--un-border-bottom-opacity:var(--un-border-opacity);border-bottom-color:rgba(96,165,250,var(--un-border-bottom-opacity));}
@@ -228,7 +228,7 @@ exports[`preset-mini > targets 1`] = `
 .underline-1rem{text-decoration-thickness:1rem;}
 .underline-auto{text-decoration-thickness:auto;}
 .decoration-purple\\\\/50{-webkit-text-decoration-color:rgba(192,132,252,0.5);text-decoration-color:rgba(192,132,252,0.5);}
-.decoration-transparent{-webkit-text-decoration-color:transparent;text-decoration-color:transparent;}
+.decoration-transparent{-webkit-text-decoration-color:rgba(0,0,0,var(--un-line-opacity));--un-line-opacity:0;text-decoration-color:rgba(0,0,0,var(--un-line-opacity));}
 .underline-red-500{-webkit-text-decoration-color:rgba(239,68,68,var(--un-line-opacity));--un-line-opacity:1;text-decoration-color:rgba(239,68,68,var(--un-line-opacity));}
 .underline-op80{--un-line-opacity:0.8;}
 .decoration-offset-0\\\\.6rem,
@@ -244,7 +244,7 @@ exports[`preset-mini > targets 1`] = `
 .text-shadow{--un-text-shadow:0 0 1px var(--un-text-shadow-color, rgba(0,0,0,0.2)),0 0 1px var(--un-text-shadow-color, rgba(1,0,5,0.1));text-shadow:var(--un-text-shadow);}
 .text-shadow-\\\\$var{text-shadow:var(--var);}
 .text-shadow-lg{--un-text-shadow:3px 3px 6px var(--un-text-shadow-color, rgba(0,0,0,0.26)),0 0 5px var(--un-text-shadow-color, rgba(15,3,86,0.22));text-shadow:var(--un-text-shadow);}
-.text-shadow-none{--un-text-shadow:0 0 var(--un-text-shadow-color, #0000);text-shadow:var(--un-text-shadow);}
+.text-shadow-none{--un-text-shadow:0 0 var(--un-text-shadow-color, rgba(0,0,0,0));text-shadow:var(--un-text-shadow);}
 .text-shadow-color-red-300{--un-text-shadow-opacity:1;--un-text-shadow-color:rgba(252,165,165,var(--un-text-shadow-opacity));}
 .text-shadow-color-op-30{--un-text-shadow-opacity:0.3;}
 .case-upper{text-transform:uppercase;}
@@ -256,28 +256,28 @@ exports[`preset-mini > targets 1`] = `
 .c-\\\\[\\\\#157\\\\],
 .c-\\\\#157,
 .c-hex-157{--un-text-opacity:1;color:rgba(17,85,119,var(--un-text-opacity));}
-.c-\\\\[\\\\#157\\\\]\\\\/\\\\$opacity-variable{--un-text-opacity:var(--opacity-variable);color:rgba(17,85,119,var(--un-text-opacity));}
+.c-\\\\[\\\\#157\\\\]\\\\/\\\\$opacity-variable{color:rgba(17,85,119,var(--opacity-variable));}
 .c-\\\\[\\\\#157\\\\]\\\\/10,
 .c-\\\\#157\\\\/10,
 .c-hex-157\\\\/10{color:rgba(17,85,119,0.1);}
 .c-\\\\[\\\\#2573\\\\],
 .c-\\\\#2573,
-.c-hex-2573{color:rgba(34,85,119,0.2);}
-.c-\\\\[\\\\#2573\\\\]\\\\/\\\\$opacity-variable{--un-text-opacity:var(--opacity-variable);color:rgba(34,85,119,var(--un-text-opacity));}
+.c-hex-2573{--un-text-opacity:0.2;color:rgba(34,85,119,var(--un-text-opacity));}
+.c-\\\\[\\\\#2573\\\\]\\\\/\\\\$opacity-variable{color:rgba(34,85,119,var(--opacity-variable));}
 .c-\\\\[\\\\#2573\\\\]\\\\/10,
 .c-\\\\#2573\\\\/10,
 .c-hex-2573\\\\/10{color:rgba(34,85,119,0.1);}
 .c-\\\\[\\\\#335577\\\\],
 .c-\\\\#335577,
 .c-hex-335577{--un-text-opacity:1;color:rgba(51,85,119,var(--un-text-opacity));}
-.c-\\\\[\\\\#335577\\\\]\\\\/\\\\$opacity-variable{--un-text-opacity:var(--opacity-variable);color:rgba(51,85,119,var(--un-text-opacity));}
+.c-\\\\[\\\\#335577\\\\]\\\\/\\\\$opacity-variable{color:rgba(51,85,119,var(--opacity-variable));}
 .c-\\\\[\\\\#335577\\\\]\\\\/10,
 .c-\\\\#335577\\\\/10,
 .c-hex-335577\\\\/10{color:rgba(51,85,119,0.1);}
 .c-\\\\[\\\\#44557733\\\\],
 .c-\\\\#44557733,
-.c-hex-44557733{color:rgba(68,85,119,0.2);}
-.c-\\\\[\\\\#44557733\\\\]\\\\/\\\\$opacity-variable{--un-text-opacity:var(--opacity-variable);color:rgba(68,85,119,var(--un-text-opacity));}
+.c-hex-44557733{--un-text-opacity:0.2;color:rgba(68,85,119,var(--un-text-opacity));}
+.c-\\\\[\\\\#44557733\\\\]\\\\/\\\\$opacity-variable{color:rgba(68,85,119,var(--opacity-variable));}
 .c-\\\\[\\\\#44557733\\\\]\\\\/10,
 .c-\\\\#44557733\\\\/10,
 .c-hex-44557733\\\\/10{color:rgba(68,85,119,0.1);}
@@ -304,7 +304,7 @@ exports[`preset-mini > targets 1`] = `
 .text-red-100,
 .text-red100{--un-text-opacity:1;color:rgba(254,226,226,var(--un-text-opacity));}
 .placeholder-shown-color-transparent:placeholder-shown,
-.placeholder\\\\:color-transparent::placeholder{color:transparent;}
+.placeholder\\\\:color-transparent::placeholder{--un-text-opacity:0;color:rgba(0,0,0,var(--un-text-opacity));}
 .selection\\\\:color-\\\\[var\\\\(--select-color\\\\)\\\\]::selection{color:var(--select-color);}
 .text-\\\\[\\\\#124\\\\]{--un-text-opacity:1;color:rgba(17,34,68,var(--un-text-opacity));}
 .text-\\\\[2em\\\\]{color:2em;}
@@ -324,12 +324,12 @@ exports[`preset-mini > targets 1`] = `
 .shadow-none,
 .shadow-xl{--un-ring-offset-shadow:0 0 #0000;--un-ring-shadow:0 0 #0000;--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow:0 0 #0000;}
 .shadow{--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 var(--un-shadow-color, rgba(0,0,0,0.1)),var(--un-shadow-inset) 0 1px 2px -1px var(--un-shadow-color, rgba(0,0,0,0.1));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
-.shadow-none{--un-shadow:0 0 var(--un-shadow-color, #0000);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow-none{--un-shadow:0 0 var(--un-shadow-color, rgba(0,0,0,0));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-xl{--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px var(--un-shadow-color, rgba(0,0,0,0.1)),var(--un-shadow-inset) 0 8px 10px -6px var(--un-shadow-color, rgba(0,0,0,0.1));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-current{--un-shadow-color:currentColor;}
 .shadow-green-500{--un-shadow-opacity:1;--un-shadow-color:rgba(34,197,94,var(--un-shadow-opacity));}
 .shadow-green-900\\\\/50{--un-shadow-color:rgba(20,83,45,0.5);}
-.shadow-transparent{--un-shadow-color:transparent;}
+.shadow-transparent{--un-shadow-opacity:0;--un-shadow-color:rgba(0,0,0,var(--un-shadow-opacity));}
 .shadow-op-50{--un-shadow-opacity:0.5;}
 .shadow-inset{--un-shadow-inset:inset;}
 .ring,

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`targets 1`] = `
 "/* layer: default */
+.border-custom-b{border-color:rgba(var(--custom), 1);}
+.border-custom-b\\\\/0{border-color:rgba(var(--custom), 0);}
 .border-custom-b\\\\/10{border-color:rgba(var(--custom), 0.1);}
 .bg-custom-b{background-color:rgba(var(--custom), 1);}
 .text-custom-a{color:var(--custom);}

--- a/test/__snapshots__/preset-wind.test.ts.snap
+++ b/test/__snapshots__/preset-wind.test.ts.snap
@@ -166,7 +166,7 @@ exports[`preset-wind > targets 1`] = `
 .divide-\\\\$variable>:not([hidden])~:not([hidden]){border-color:var(--variable);}
 .divide-current>:not([hidden])~:not([hidden]){border-color:currentColor;}
 .divide-green-500>:not([hidden])~:not([hidden]){--un-divide-opacity:1;border-color:rgba(34,197,94,var(--un-divide-opacity));}
-.divide-transparent>:not([hidden])~:not([hidden]){border-color:transparent;}
+.divide-transparent>:not([hidden])~:not([hidden]){--un-divide-opacity:0;border-color:rgba(0,0,0,var(--un-divide-opacity));}
 .divide-opacity-50>:not([hidden])~:not([hidden]){--un-divide-opacity:0.5;}
 .divide-dashed>:not([hidden])~:not([hidden]){border-style:dashed;}
 .divide-dotted>:not([hidden])~:not([hidden]){border-style:dotted;}
@@ -180,30 +180,30 @@ exports[`preset-wind > targets 1`] = `
 .stops-\\\\[blue\\\\2c pink\\\\]{--un-gradient-stops:blue,pink;}
 .bg-gradient-from-current,
 .from-current{--un-gradient-from:currentColor;--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
-.bg-gradient-from-green-600{--un-gradient-from:rgba(22,163,74, var(--un-from-opacity, 1));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
+.bg-gradient-from-green-600{--un-gradient-from:rgba(22,163,74,var(--un-from-opacity, 1));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-from-green-600\\\\/60{--un-gradient-from:rgba(22,163,74,0.6);--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-from-transparent,
-.from-transparent{--un-gradient-from:transparent;--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
+.from-transparent{--un-gradient-from:rgba(0,0,0,var(--un-from-opacity, 0));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .from-\\\\$bg-from{--un-gradient-from:var(--bg-from);--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
-.from-green-500{--un-gradient-from:rgba(34,197,94, var(--un-from-opacity, 1));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
+.from-green-500{--un-gradient-from:rgba(34,197,94,var(--un-from-opacity, 1));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .from-green-500\\\\/50{--un-gradient-from:rgba(34,197,94,0.5);--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-to-current,
 .to-current{--un-gradient-to:currentColor;}
-.bg-gradient-to-green-600{--un-gradient-to:rgba(22,163,74, var(--un-to-opacity, 1));}
+.bg-gradient-to-green-600{--un-gradient-to:rgba(22,163,74,var(--un-to-opacity, 1));}
 .bg-gradient-to-green-600\\\\/60{--un-gradient-to:rgba(22,163,74,0.6);}
 .bg-gradient-to-transparent,
-.to-transparent{--un-gradient-to:transparent;}
+.to-transparent{--un-gradient-to:rgba(0,0,0,var(--un-to-opacity, 0));}
 .to-\\\\$bg-to{--un-gradient-to:var(--bg-to);}
-.to-green-500{--un-gradient-to:rgba(34,197,94, var(--un-to-opacity, 1));}
+.to-green-500{--un-gradient-to:rgba(34,197,94,var(--un-to-opacity, 1));}
 .to-green-500\\\\/50{--un-gradient-to:rgba(34,197,94,0.5);}
 .bg-gradient-via-current,
 .via-current{--un-gradient-stops:var(--un-gradient-from), currentColor, var(--un-gradient-to, rgba(255, 255, 255, 0));}
-.bg-gradient-via-green-600{--un-gradient-stops:var(--un-gradient-from), rgba(22,163,74, var(--un-via-opacity, 1)), var(--un-gradient-to, rgba(255, 255, 255, 0));}
+.bg-gradient-via-green-600{--un-gradient-stops:var(--un-gradient-from), rgba(22,163,74,var(--un-via-opacity, 1)), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-via-green-600\\\\/40{--un-gradient-stops:var(--un-gradient-from), rgba(22,163,74,0.4), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-via-transparent,
-.via-transparent{--un-gradient-stops:var(--un-gradient-from), transparent, var(--un-gradient-to, rgba(255, 255, 255, 0));}
+.via-transparent{--un-gradient-stops:var(--un-gradient-from), rgba(0,0,0,var(--un-via-opacity, 0)), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .via-\\\\$bg-via{--un-gradient-stops:var(--un-gradient-from), var(--bg-via), var(--un-gradient-to, rgba(255, 255, 255, 0));}
-.via-green-500{--un-gradient-stops:var(--un-gradient-from), rgba(34,197,94, var(--un-via-opacity, 1)), var(--un-gradient-to, rgba(255, 255, 255, 0));}
+.via-green-500{--un-gradient-stops:var(--un-gradient-from), rgba(34,197,94,var(--un-via-opacity, 1)), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .via-green-500\\\\/30{--un-gradient-stops:var(--un-gradient-from), rgba(34,197,94,0.3), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-via-opacity-40{--un-via-opacity:0.4;}
 .via-opacity-30{--un-via-opacity:0.3;}

--- a/test/__snapshots__/preset-wind.test.ts.snap
+++ b/test/__snapshots__/preset-wind.test.ts.snap
@@ -166,7 +166,7 @@ exports[`preset-wind > targets 1`] = `
 .divide-\\\\$variable>:not([hidden])~:not([hidden]){border-color:var(--variable);}
 .divide-current>:not([hidden])~:not([hidden]){border-color:currentColor;}
 .divide-green-500>:not([hidden])~:not([hidden]){--un-divide-opacity:1;border-color:rgba(34,197,94,var(--un-divide-opacity));}
-.divide-transparent>:not([hidden])~:not([hidden]){--un-divide-opacity:0;border-color:rgba(0,0,0,var(--un-divide-opacity));}
+.divide-transparent>:not([hidden])~:not([hidden]){border-color:transparent;}
 .divide-opacity-50>:not([hidden])~:not([hidden]){--un-divide-opacity:0.5;}
 .divide-dashed>:not([hidden])~:not([hidden]){border-style:dashed;}
 .divide-dotted>:not([hidden])~:not([hidden]){border-style:dotted;}
@@ -183,7 +183,7 @@ exports[`preset-wind > targets 1`] = `
 .bg-gradient-from-green-600{--un-gradient-from:rgba(22,163,74,var(--un-from-opacity, 1));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-from-green-600\\\\/60{--un-gradient-from:rgba(22,163,74,0.6);--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-from-transparent,
-.from-transparent{--un-gradient-from:rgba(0,0,0,var(--un-from-opacity, 0));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
+.from-transparent{--un-gradient-from:transparent;--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .from-\\\\$bg-from{--un-gradient-from:var(--bg-from);--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .from-green-500{--un-gradient-from:rgba(34,197,94,var(--un-from-opacity, 1));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .from-green-500\\\\/50{--un-gradient-from:rgba(34,197,94,0.5);--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
@@ -192,7 +192,7 @@ exports[`preset-wind > targets 1`] = `
 .bg-gradient-to-green-600{--un-gradient-to:rgba(22,163,74,var(--un-to-opacity, 1));}
 .bg-gradient-to-green-600\\\\/60{--un-gradient-to:rgba(22,163,74,0.6);}
 .bg-gradient-to-transparent,
-.to-transparent{--un-gradient-to:rgba(0,0,0,var(--un-to-opacity, 0));}
+.to-transparent{--un-gradient-to:transparent;}
 .to-\\\\$bg-to{--un-gradient-to:var(--bg-to);}
 .to-green-500{--un-gradient-to:rgba(34,197,94,var(--un-to-opacity, 1));}
 .to-green-500\\\\/50{--un-gradient-to:rgba(34,197,94,0.5);}
@@ -201,7 +201,7 @@ exports[`preset-wind > targets 1`] = `
 .bg-gradient-via-green-600{--un-gradient-stops:var(--un-gradient-from), rgba(22,163,74,var(--un-via-opacity, 1)), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-via-green-600\\\\/40{--un-gradient-stops:var(--un-gradient-from), rgba(22,163,74,0.4), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-via-transparent,
-.via-transparent{--un-gradient-stops:var(--un-gradient-from), rgba(0,0,0,var(--un-via-opacity, 0)), var(--un-gradient-to, rgba(255, 255, 255, 0));}
+.via-transparent{--un-gradient-stops:var(--un-gradient-from), transparent, var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .via-\\\\$bg-via{--un-gradient-stops:var(--un-gradient-from), var(--bg-via), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .via-green-500{--un-gradient-stops:var(--un-gradient-from), rgba(34,197,94,var(--un-via-opacity, 1)), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .via-green-500\\\\/30{--un-gradient-stops:var(--un-gradient-from), rgba(34,197,94,0.3), var(--un-gradient-to, rgba(255, 255, 255, 0));}

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -41,11 +41,17 @@ describe('color utils', () => {
     expect(parseCssColor('color(fancy 0 1 2 3 4 5/6)')).eql({ type: 'fancy', components: ['0', '1', '2', '3', '4', '5'], alpha: '6' })
     expect(parseCssColor('color(fancy 0 1 2 3 4 5//6)')).eql(undefined)
 
+    expect(parseCssColor('color(over-limit 2 3 4 5 6 7 8 9 10)')).eql({ type: 'over-limit', components: ['2', '3', '4', '5', '6', '7', '8', '9', '10'], alpha: undefined })
+    expect(parseCssColor('color(over-limit 2 3 4 5 6 7 8 / 9)')).eql({ type: 'over-limit', components: ['2', '3', '4', '5', '6', '7', '8'], alpha: '9' })
+    expect(parseCssColor('color(over-limit 2 3 4 5 6 7 8 9 10 11)')).eql(undefined)
+    expect(parseCssColor('color(over-limit 2 3 4 5 6 7 8 9 / 10)')).eql(undefined)
+
     expect(parseCssColor('color(lite 0)')).eql({ type: 'lite', components: ['0'], alpha: undefined })
     expect(parseCssColor('color(lite 0 / 1)')).eql({ type: 'lite', components: ['0'], alpha: '1' })
     expect(parseCssColor('color(lite 0 /1)')).eql({ type: 'lite', components: ['0'], alpha: '1' })
     expect(parseCssColor('color(lite 0/ 1)')).eql({ type: 'lite', components: ['0'], alpha: '1' })
     expect(parseCssColor('color(lite 0/1)')).eql({ type: 'lite', components: ['0'], alpha: '1' })
+    expect(parseCssColor('color(lite)')).eql(undefined)
     expect(parseCssColor('color(lite 0//1)')).eql(undefined)
 
     expect(parseCssColor('color(vary calc(0.1 / 5) calc(0.2 / 5) / calc(0.3 / 5))')).eql({ type: 'vary', components: ['calc(0.1 / 5)', 'calc(0.2 / 5)'], alpha: 'calc(0.3 / 5)' })

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -14,8 +14,6 @@ describe('color utils', () => {
     expect(hex2rgba('#12')).eql(undefined)
     expect(hex2rgba('#12123')).eql(undefined)
 
-    expect(parseCssColor('transparent')).eql({ type: 'rgb', components: [0, 0, 0], alpha: 0 })
-
     expect(parseCssColor('rgb(0,1,2)')).eql({ type: 'rgb', components: ['0', '1', '2'], alpha: undefined })
     expect(parseCssColor('rgba(0,1,2,3)')).eql({ type: 'rgba', components: ['0', '1', '2'], alpha: '3' })
     expect(parseCssColor('rgba(0,(1),2,3)')).eql({ type: 'rgba', components: ['0', '(1)', '2'], alpha: '3' })

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -1,4 +1,4 @@
-import { hex2rgba, parseCssColor } from '@unocss/preset-mini/utils'
+import { colorToString, hex2rgba, parseCssColor } from '@unocss/preset-mini/utils'
 import { describe, expect, it } from 'vitest'
 
 describe('color utils', () => {
@@ -13,7 +13,9 @@ describe('color utils', () => {
     expect(hex2rgba('95723489')).eql([149, 114, 52, 0.54])
     expect(hex2rgba('#12')).eql(undefined)
     expect(hex2rgba('#12123')).eql(undefined)
+  })
 
+  it('parses css colors', () => {
     expect(parseCssColor('rgb(0,1,2)')).eql({ type: 'rgb', components: ['0', '1', '2'], alpha: undefined })
     expect(parseCssColor('rgba(0,1,2,3)')).eql({ type: 'rgba', components: ['0', '1', '2'], alpha: '3' })
     expect(parseCssColor('rgba(0,(1),2,3)')).eql({ type: 'rgba', components: ['0', '(1)', '2'], alpha: '3' })
@@ -51,5 +53,35 @@ describe('color utils', () => {
     expect(parseCssColor('color(vary calc(0.1 / 5) calc(0.2 / 5)/ calc(0.3 / 5))')).eql({ type: 'vary', components: ['calc(0.1 / 5)', 'calc(0.2 / 5)'], alpha: 'calc(0.3 / 5)' })
     expect(parseCssColor('color(vary calc(0.1 / 5) calc(0.2 / 5)/calc(0.3 / 5))')).eql({ type: 'vary', components: ['calc(0.1 / 5)', 'calc(0.2 / 5)'], alpha: 'calc(0.3 / 5)' })
     expect(parseCssColor('color(vary calc(0.1 / 5) calc(0.2 / 5)//calc(0.3 / 5))')).eql(undefined)
+  })
+
+  it('generate css color string', () => {
+    const fn = (x: string) => colorToString(parseCssColor(x)!)
+
+    expect(fn('rgb(0,1,2)')).eql('rgba(0,1,2)')
+    expect(fn('rgba(0,1,2,3)')).eql('rgba(0,1,2,3)')
+    expect(fn('rgba(0,(1),2,3)')).eql('rgba(0,(1),2,3)')
+
+    expect(fn('rgba(0 1 2 / 3)')).eql('rgba(0,1,2,3)')
+    expect(fn('rgba(0 1 2/ 3)')).eql('rgba(0,1,2,3)')
+    expect(fn('rgba(0 1 2 /3)')).eql('rgba(0,1,2,3)')
+    expect(fn('rgba(0 1 2/3)')).eql('rgba(0,1,2,3)')
+
+    expect(fn('color(rgba 0 1 2 / 3)')).eql('rgba(0,1,2,3)')
+    expect(fn('color(fancy 0 1 2 3 4 5 / 6)')).eql('color(fancy 0 1 2 3 4 5 / 6)')
+    expect(fn('color(fancy 0 1 2 3 4 5 /6)')).eql('color(fancy 0 1 2 3 4 5 / 6)')
+    expect(fn('color(fancy 0 1 2 3 4 5/ 6)')).eql('color(fancy 0 1 2 3 4 5 / 6)')
+    expect(fn('color(fancy 0 1 2 3 4 5/6)')).eql('color(fancy 0 1 2 3 4 5 / 6)')
+
+    expect(fn('color(lite 0)')).eql('color(lite 0)')
+    expect(fn('color(lite 0 / 1)')).eql('color(lite 0 / 1)')
+    expect(fn('color(lite 0 /1)')).eql('color(lite 0 / 1)')
+    expect(fn('color(lite 0/ 1)')).eql('color(lite 0 / 1)')
+    expect(fn('color(lite 0/1)')).eql('color(lite 0 / 1)')
+
+    expect(fn('color(vary calc(0.1 / 5) calc(0.2 / 5) / calc(0.3 / 5))')).eql('color(vary calc(0.1 / 5) calc(0.2 / 5) / calc(0.3 / 5))')
+    expect(fn('color(vary calc(0.1 / 5) calc(0.2 / 5) /calc(0.3 / 5))')).eql('color(vary calc(0.1 / 5) calc(0.2 / 5) / calc(0.3 / 5))')
+    expect(fn('color(vary calc(0.1 / 5) calc(0.2 / 5)/ calc(0.3 / 5))')).eql('color(vary calc(0.1 / 5) calc(0.2 / 5) / calc(0.3 / 5))')
+    expect(fn('color(vary calc(0.1 / 5) calc(0.2 / 5)/calc(0.3 / 5))')).eql('color(vary calc(0.1 / 5) calc(0.2 / 5) / calc(0.3 / 5))')
   })
 })

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -6,6 +6,8 @@ const targets = [
   // custom colors
   'text-custom-a',
   'bg-custom-b',
+  'border-custom-b',
+  'border-custom-b/0',
   'border-custom-b/10',
 
   // wind - placeholder


### PR DESCRIPTION
- update color parsers
  - `ParsedColorValue` no longer return color's alpha, only parsed opacity
  - color/opacity shorthand (`c-red-100/10`) no longer generate opacity variable
- parse shadows' color theme value
  - with the new parser, the shadow color values are no longer limited to unspaced rgb as per #459
- add custom color test case