### PR TITLE
feat(preset-uno): sass mix color function

### DIFF
--- a/packages/preset-uno/src/index.ts
+++ b/packages/preset-uno/src/index.ts
@@ -1,12 +1,27 @@
-import { presetWind } from '@unocss/preset-wind'
+import type { Preset } from '@unocss/core'
 import type { PresetMiniOptions, Theme } from '@unocss/preset-mini'
-
-export { theme, colors } from '@unocss/preset-wind'
+import { rules, shortcuts, theme, variants } from '@unocss/preset-wind'
+import { variantColorMix } from './variants/mix'
 
 export type { Theme }
 
 export interface PresetUnoOptions extends PresetMiniOptions {}
 
-export const presetUno = presetWind
+export const presetUno = (options: PresetUnoOptions = {}): Preset<Theme> => {
+  options.dark = options.dark ?? 'class'
+  options.attributifyPseudo = options.attributifyPseudo ?? false
+
+  return {
+    name: '@unocss/preset-uno',
+    theme,
+    rules,
+    shortcuts,
+    variants: [
+      ...variants(options),
+      variantColorMix,
+    ],
+    options,
+  }
+}
 
 export default presetUno

--- a/packages/preset-uno/src/variants/mix.ts
+++ b/packages/preset-uno/src/variants/mix.ts
@@ -3,6 +3,15 @@ import { parseCssColor } from '@unocss/preset-mini/utils'
 
 const mixComponent = (v1: string | number, v2: string | number, w: string | number) => `calc(${v2} + (${v1} - ${v2}) * ${w} / 100)`
 
+/**
+ * Returns RGB color that's a mixture of color1 and color2. Support RGB color values.
+ * https://sass-lang.com/documentation/modules/color#mix
+ *
+ * @param {string | CSSColorValue} color1
+ * @param {string | CSSColorValue} color2
+ * @param {string | number} weight - How many of color2 will be used to mix into color1. Value of 0 will resulting in color1, value of 100 color2.
+ * @return {CSSColorValue | undefined}
+ */
 const mixColor = (color1: string | CSSColorValue, color2: string | CSSColorValue, weight: string | number): CSSColorValue | undefined => {
   const colors = [color1, color2]
   const cssColors: CSSColorValue[] = []
@@ -24,8 +33,19 @@ const mixColor = (color1: string | CSSColorValue, color2: string | CSSColorValue
   }
 }
 
+/**
+ * Mix color with white. @see {@link mixColor}
+ */
 const tint = (color: string | CSSColorValue, weight: string | number) => mixColor('#fff', color, weight)
+
+/**
+ * Mix color with black. @see {@link mixColor}
+ */
 const shade = (color: string | CSSColorValue, weight: string | number) => mixColor('#000', color, weight)
+
+/**
+ * Mix color with black or white, according to weight. @see {@link mixColor}
+ */
 const shift = (color: string | CSSColorValue, weight: string | number) => parseInt(`${weight}`, 10) > 0 ? shade(color, weight) : tint(color, `-${weight}`)
 const fns: Record<string, (color: string | CSSColorValue, weight: string | number) => CSSColorValue | undefined> = { tint, shade, shift }
 

--- a/packages/preset-uno/src/variants/mix.ts
+++ b/packages/preset-uno/src/variants/mix.ts
@@ -1,0 +1,54 @@
+import type { CSSColorValue, Variant } from '@unocss/core'
+import { parseCssColor } from '@unocss/preset-mini/utils'
+
+const mixComponent = (v1: string | number, v2: string | number, w: string | number) => `calc(${v2} + (${v1} - ${v2}) * ${w} / 100)`
+
+const mixColor = (color1: string | CSSColorValue, color2: string | CSSColorValue, weight: string | number): CSSColorValue | undefined => {
+  const colors = [color1, color2]
+  const cssColors: CSSColorValue[] = []
+  for (let c = 0; c < 2; ++c) {
+    const color = (typeof colors[c] === 'string' ? parseCssColor(colors[c] as string) : colors[c]) as CSSColorValue | undefined
+    if (!color || !['rgb', 'rgba'].includes(color.type))
+      return
+    cssColors.push(color)
+  }
+
+  const newComponents = []
+  for (let x = 0; x < 3; ++x)
+    newComponents.push(mixComponent(cssColors[0].components[x], cssColors[1].components[x], weight))
+
+  return {
+    type: 'rgb',
+    components: newComponents,
+    alpha: mixComponent(cssColors[0].alpha ?? 1, cssColors[1].alpha ?? 1, weight),
+  }
+}
+
+const tint = (color: string | CSSColorValue, weight: string | number) => mixColor('#fff', color, weight)
+const shade = (color: string | CSSColorValue, weight: string | number) => mixColor('#000', color, weight)
+const shift = (color: string | CSSColorValue, weight: string | number) => parseInt(`${weight}`, 10) > 0 ? shade(color, weight) : tint(color, `-${weight}`)
+const fns: Record<string, (color: string | CSSColorValue, weight: string | number) => CSSColorValue | undefined> = { tint, shade, shift }
+
+export const variantColorMix: Variant = (matcher) => {
+  const m = matcher.match(/^mix-(tint|shade|shift)-(-?\d{1,3})[-:]/)
+  if (m) {
+    return {
+      matcher: matcher.slice(m[0].length),
+      body: (body) => {
+        body.forEach((v) => {
+          if (v[1]) {
+            const color = parseCssColor(`${v[1]}`)
+            if (color) {
+              const mixed = fns[m[1]](color, m[2])
+              if (mixed) {
+                const { alpha, components } = mixed
+                v[1] = `rgb(${components.join(',')},${alpha})`
+              }
+            }
+          }
+        })
+        return body
+      },
+    }
+  }
+}

--- a/packages/preset-uno/src/variants/mix.ts
+++ b/packages/preset-uno/src/variants/mix.ts
@@ -49,6 +49,11 @@ const shade = (color: string | CSSColorValue, weight: string | number) => mixCol
 const shift = (color: string | CSSColorValue, weight: string | number) => parseInt(`${weight}`, 10) > 0 ? shade(color, weight) : tint(color, `-${weight}`)
 const fns: Record<string, (color: string | CSSColorValue, weight: string | number) => CSSColorValue | undefined> = { tint, shade, shift }
 
+/**
+ * Shade the color if the weight is positive, tint the color otherwise.
+ * Shading mixes the color with black, Tinting mixes the color with white.
+ * @see {@link mixColor}
+ */
 export const variantColorMix: Variant = (matcher) => {
   const m = matcher.match(/^mix-(tint|shade|shift)-(-?\d{1,3})[-:]/)
   if (m) {

--- a/packages/preset-uno/src/variants/mix.ts
+++ b/packages/preset-uno/src/variants/mix.ts
@@ -4,12 +4,12 @@ import { parseCssColor } from '@unocss/preset-mini/utils'
 const mixComponent = (v1: string | number, v2: string | number, w: string | number) => `calc(${v2} + (${v1} - ${v2}) * ${w} / 100)`
 
 /**
- * Returns RGB color that's a mixture of color1 and color2. Support RGB color values.
+ * Returns RGB color from a mixture of color1 and color2. Support RGB color values.
  * https://sass-lang.com/documentation/modules/color#mix
  *
  * @param {string | CSSColorValue} color1
  * @param {string | CSSColorValue} color2
- * @param {string | number} weight - How many of color2 will be used to mix into color1. Value of 0 will resulting in color1, value of 100 color2.
+ * @param {string | number} weight - How many of color2 will be used to mix into color1. Value of 0 will resulting in color2, value of 100 color1.
  * @return {CSSColorValue | undefined}
  */
 const mixColor = (color1: string | CSSColorValue, color2: string | CSSColorValue, weight: string | number): CSSColorValue | undefined => {

--- a/packages/preset-wind/src/index.ts
+++ b/packages/preset-wind/src/index.ts
@@ -1,16 +1,15 @@
 import type { Preset } from '@unocss/core'
 import type { PresetMiniOptions, Theme } from '@unocss/preset-mini'
-import { variants as miniVariants } from '@unocss/preset-mini/variants'
 import { rules } from './rules'
-import { containerShortcuts } from './rules/container'
+import { shortcuts } from './shortcuts'
 import { theme } from './theme'
-import { placeholderModifier, variantColorsScheme, variantSpaceAndDivide } from './variants'
+import { variants } from './variants'
 
 export { colors } from '@unocss/preset-mini'
 
 export type { Theme } from '@unocss/preset-mini'
 
-export { theme }
+export { rules, shortcuts, theme, variants }
 
 export interface UnoOptions extends PresetMiniOptions { }
 
@@ -22,15 +21,8 @@ export const presetWind = (options: UnoOptions = {}): Preset<Theme> => {
     name: '@unocss/preset-wind',
     theme,
     rules,
-    shortcuts: [
-      ...containerShortcuts,
-    ],
-    variants: [
-      placeholderModifier,
-      variantSpaceAndDivide,
-      ...miniVariants(options),
-      ...variantColorsScheme,
-    ],
+    shortcuts,
+    variants: variants(options),
     options,
   }
 }

--- a/packages/preset-wind/src/shortcuts.ts
+++ b/packages/preset-wind/src/shortcuts.ts
@@ -1,0 +1,5 @@
+import { containerShortcuts } from './rules/container'
+
+export const shortcuts = [
+  ...containerShortcuts,
+]

--- a/packages/preset-wind/src/variants/default.ts
+++ b/packages/preset-wind/src/variants/default.ts
@@ -1,0 +1,13 @@
+import type { Variant } from '@unocss/core'
+import { variants as miniVariants } from '@unocss/preset-mini/variants'
+import type { Theme, UnoOptions } from '..'
+import { variantColorsScheme } from './dark'
+import { variantSpaceAndDivide } from './misc'
+import { placeholderModifier } from './placeholder'
+
+export const variants = (options: UnoOptions): Variant<Theme>[] => [
+  placeholderModifier,
+  variantSpaceAndDivide,
+  ...miniVariants(options),
+  ...variantColorsScheme,
+]

--- a/packages/preset-wind/src/variants/index.ts
+++ b/packages/preset-wind/src/variants/index.ts
@@ -1,4 +1,5 @@
 /* @export-submodules */
 export * from './dark'
+export * from './default'
 export * from './misc'
 export * from './placeholder'

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -4,6 +4,10 @@ exports[`targets 1`] = `
 "/* layer: default */
 .border-custom-b\\\\/10{border-color:rgba(var(--custom), 0.1);}
 .bg-custom-b{background-color:rgba(var(--custom), 1);}
+.mix-shade-50-c-red-400{--un-text-opacity:1;color:rgb(calc(248 + (0 - 248) * 50 / 100),calc(113 + (0 - 113) * 50 / 100),calc(113 + (0 - 113) * 50 / 100),calc(var(--un-text-opacity) + (1 - var(--un-text-opacity)) * 50 / 100));}
+.mix-shift--50-c-red-600{--un-text-opacity:1;color:rgb(calc(220 + (255 - 220) * --50 / 100),calc(38 + (255 - 38) * --50 / 100),calc(38 + (255 - 38) * --50 / 100),calc(var(--un-text-opacity) + (1 - var(--un-text-opacity)) * --50 / 100));}
+.mix-shift-50-c-red-600{--un-text-opacity:1;color:rgb(calc(220 + (0 - 220) * 50 / 100),calc(38 + (0 - 38) * 50 / 100),calc(38 + (0 - 38) * 50 / 100),calc(var(--un-text-opacity) + (1 - var(--un-text-opacity)) * 50 / 100));}
+.mix-tint-50-c-red-400{--un-text-opacity:1;color:rgb(calc(248 + (255 - 248) * 50 / 100),calc(113 + (255 - 113) * 50 / 100),calc(113 + (255 - 113) * 50 / 100),calc(var(--un-text-opacity) + (1 - var(--un-text-opacity)) * 50 / 100));}
 .text-custom-a{color:var(--custom);}
 .focus\\\\:placeholder-red-300:focus::placeholder{--un-placeholder-opacity:1;color:rgba(252,165,165,var(--un-placeholder-opacity));}
 .placeholder-inherit::placeholder{color:inherit;}

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -3,6 +3,12 @@ import presetUno from '@unocss/preset-uno'
 import { expect, test } from 'vitest'
 
 const targets = [
+  // variants - mix
+  'mix-tint-50-c-red-400',
+  'mix-shade-50-c-red-400',
+  'mix-shift-50-c-red-600',
+  'mix-shift--50-c-red-600',
+
   // custom colors
   'text-custom-a',
   'bg-custom-b',


### PR DESCRIPTION
Alternative for https://github.com/antfu/unocss/pull/570 by adding to preset-uno instead

It's breaking now since `presetUno` is no longer alias for `presetWind`. See https://github.com/antfu/unocss/pull/225#issuecomment-990499591