### PR TITLE
feat(preset-mini): prioritize `active` pseudo

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -117,6 +117,10 @@ export interface RuleMeta {
    */
   noMerge?: boolean
   /**
+   * Fine tune sort
+   */
+  sort?: number
+  /**
    * Internal rules will only be matched for shortcuts but not the user code.
    * @default false
    */
@@ -165,9 +169,13 @@ export interface VariantHandler {
    */
   parent?: string | [string, number] | undefined
   /**
-   * Variant ordering.
+   * Order in which the variant is applied to selector.
    */
   order?: number
+  /**
+   * Order in which the variant is sorted within single rule.
+   */
+  sort?: number
   /**
    * Override layer to the output css.
    */
@@ -402,6 +410,7 @@ export interface UtilObject {
   entries: CSSEntries
   parent: string | undefined
   layer: string | undefined
+  sort: number | undefined
 }
 
 export interface GenerateOptions {

--- a/packages/preset-mini/src/variants/pseudo.ts
+++ b/packages/preset-mini/src/variants/pseudo.ts
@@ -76,6 +76,11 @@ const PseudoElementsRE = new RegExp(`^(${PseudoElementsStr})[:-]`)
 const PseudoClassesRE = new RegExp(`^(${PseudoClassesStr})[:-]`)
 const PseudoClassFunctionsRE = new RegExp(`^(${PseudoClassFunctionsStr})-(${PseudoClassesStr})[:-]`)
 
+const sortValue = (pseudo: string) => {
+  if (pseudo === 'active')
+    return 1
+}
+
 const taggedPseudoClassMatcher = (tag: string, parent: string, combinator: string) => {
   const re = new RegExp(`^${tag}-((?:(${PseudoClassFunctionsStr})-)?(${PseudoClassesStr}))[:-]`)
   const rawRe = new RegExp(`^${escapeRegExp(parent)}:`)
@@ -90,6 +95,7 @@ const taggedPseudoClassMatcher = (tag: string, parent: string, combinator: strin
         selector: s => rawRe.test(s)
           ? s.replace(rawRe, `${parent}${pseudo}:`)
           : `${parent}${pseudo}${combinator}${s}`,
+        sort: sortValue(match[3]),
       }
     }
   }
@@ -114,6 +120,7 @@ export const variantPseudoClasses: VariantObject = {
       return {
         matcher: input.slice(match[0].length),
         selector: s => `${s}${pseudo}`,
+        sort: sortValue(match[1]),
       }
     }
   },

--- a/test/__snapshots__/order.test.ts.snap
+++ b/test/__snapshots__/order.test.ts.snap
@@ -1,9 +1,17 @@
 // Vitest Snapshot v1
 
-exports[`order > variant 1`] = `
+exports[`order > variant ordering 1`] = `
 "/* layer: default */
 .dark .group .dark\\\\:group\\\\:foo-3{name:foo-3;}
 .dark .group .group\\\\:dark\\\\:foo-4{name:foo-4;}
 .group .light .light\\\\:group\\\\:foo-1{name:foo-1;}
 .light .group .group\\\\:light\\\\:foo-2{name:foo-2;}"
+`;
+
+exports[`order > variant sorting 1`] = `
+"/* layer: default */
+pre .pre\\\\:foo-1,
+any .any\\\\:foo-1,
+zzz .zzz\\\\:foo-1,
+post .post\\\\:foo-1{foo:foo-1;}"
 `;

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -660,8 +660,9 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .skew-y-10deg,
 .skew-y-2grad,
 .skew-y-3\\\\.14rad,
-.active\\\\:scale-4:active,
+.hover\\\\:scale-4:hover,
 .scale-\\\\$variable,
+.active\\\\:scale-4:active,
 .scale-x-\\\\$variable,
 .transform{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-transform:translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z)) rotate(var(--un-rotate)) rotateX(var(--un-rotate-x)) rotateY(var(--un-rotate-y)) rotateZ(var(--un-rotate-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z));}
 .-translate-full{--un-translate-x:-100%;--un-translate-y:-100%;transform:var(--un-transform);}
@@ -699,6 +700,7 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .skew-y-10deg{--un-skew-y:10deg;transform:var(--un-transform);}
 .skew-y-2grad{--un-skew-y:2grad;transform:var(--un-transform);}
 .skew-y-3\\\\.14rad{--un-skew-y:3.14rad;transform:var(--un-transform);}
+.hover\\\\:scale-4:hover,
 .active\\\\:scale-4:active{--un-scale-x:0.04;--un-scale-y:0.04;transform:var(--un-transform);}
 .scale-\\\\$variable{--un-scale-x:var(--variable);--un-scale-y:var(--variable);transform:var(--un-transform);}
 .scale-x-\\\\$variable{--un-scale-x:var(--variable);transform:var(--un-transform);}

--- a/test/order.test.ts
+++ b/test/order.test.ts
@@ -27,7 +27,7 @@ describe('order', () => {
     expect(css).toContain('bar2')
   })
 
-  test('variant', async() => {
+  test('variant ordering', async() => {
     const uno = createGenerator({
       rules: [
         [/^foo-.$/, ([m]) => ({ name: m })],
@@ -52,6 +52,40 @@ describe('order', () => {
       'group:light:foo-2',
       'dark:group:foo-3',
       'group:dark:foo-4',
+    ].join(' ')
+    const { css } = await uno.generate(code)
+    const { css: css2 } = await uno.generate(code)
+    expect(css).toMatchSnapshot()
+    expect(css).toEqual(css2)
+  })
+
+  test('variant sorting', async() => {
+    const uno = createGenerator({
+      rules: [
+        [/^foo-.$/, ([m]) => ({ foo: m })],
+      ],
+      presets: [],
+      variants: [
+        (input: string) => {
+          const m = input.match(/^(\w+):/)
+          if (m) {
+            return {
+              matcher: input.slice(m[0].length),
+              selector: s => `${m[1]} ${s}`,
+              sort: {
+                pre: -1,
+                post: 1,
+              }[m[1]],
+            }
+          }
+        },
+      ],
+    })
+    const code = [
+      'any:foo-1',
+      'post:foo-1',
+      'pre:foo-1',
+      'zzz:foo-1',
     ].join(' ')
     const { css } = await uno.generate(code)
     const { css: css2 } = await uno.generate(code)

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -655,6 +655,7 @@ export const presetMiniTargets: string[] = [
 
   // variants
   'active:scale-4',
+  'hover:scale-4',
   'hover:translate-x-3',
   'peer-checked:translate-x-[var(--reveal)]',
   '!hover:px-10',


### PR DESCRIPTION
Building on top of #586, this PR prioritizes active pseudo (2nd commit: https://github.com/unocss/unocss/commit/00f5fe3660732dae389a89a1f130ba86d370e35e) so it is applied after `hover`. However, I'm not to sure how to best addresss this issue, since this introduces a non-default sort (see also #70). Maybe add a standalone dummy variant in preset-wind/uno to set the sort?

Something like:

```ts
export const activePseudoSortMarker: VariantFunction = (input: string) => {
  const match = input.match(^/active[:-]/)
  if (match) {
    return {
      matcher: input, // do nothing
      selector: s => s, // do nothing
      sort: 1, // <--- only set this
    }
  }
}
```

This PR would close #583.