### PR TITLE
feat(preset-mini): add `h-screen-<breakpoint>` rule

### DIFF
--- a/packages/preset-mini/src/rules/size.ts
+++ b/packages/preset-mini/src/rules/size.ts
@@ -34,6 +34,7 @@ function getSizeValue(minmax: string, hw: string, theme: Theme, prop: string) {
 export const sizes: Rule<Theme>[] = [
   [/^(min-|max-)?([wh])-(.+)$/, ([, m, w, s], { theme }) => ({ [getPropName(m, w)]: getSizeValue(m, w, theme, s) })],
   [/^(min-|max-)?(block|inline)-(.+)$/, ([, m, w, s], { theme }) => ({ [getPropName(m, w)]: getSizeValue(m, w, theme, s) })],
+  [/^(min-|max-)?(h)-screen-(.+)$/, ([, m, w, s], { theme }) => ({ [getPropName(m, w)]: theme.verticalBreakpoints?.[s] })],
   [/^(min-|max-)?(w)-screen-(.+)$/, ([, m, w, s], { theme }) => ({ [getPropName(m, w)]: theme.breakpoints?.[s] })],
 ]
 

--- a/packages/preset-mini/src/theme/default.ts
+++ b/packages/preset-mini/src/theme/default.ts
@@ -1,6 +1,6 @@
 import { colors } from './colors'
 import { fontFamily, fontSize, letterSpacing, lineHeight, textIndent, textShadow, textStrokeWidth, wordSpacing } from './font'
-import { borderRadius, boxShadow, breakpoints, easing } from './misc'
+import { borderRadius, boxShadow, breakpoints, easing, verticalBreakpoints } from './misc'
 import { blur, dropShadow } from './filters'
 import { height, maxHeight, maxWidth, width } from './size'
 import type { Theme } from './types'
@@ -24,6 +24,7 @@ export const theme: Theme = {
   fontFamily,
   fontSize,
   breakpoints,
+  verticalBreakpoints,
   borderRadius,
   lineHeight,
   letterSpacing,

--- a/packages/preset-mini/src/theme/misc.ts
+++ b/packages/preset-mini/src/theme/misc.ts
@@ -7,6 +7,8 @@ export const breakpoints = {
   '2xl': '1536px',
 }
 
+export const verticalBreakpoints = { ...breakpoints }
+
 export const borderRadius = {
   'DEFAULT': '0.25rem',
   'none': '0px',

--- a/packages/preset-mini/src/theme/types.ts
+++ b/packages/preset-mini/src/theme/types.ts
@@ -20,6 +20,7 @@ export interface Theme {
   minBlockSize?: Record<string, string>
   borderRadius?: Record<string, string>
   breakpoints?: Record<string, string>
+  verticalBreakpoints?: Record<string, string>
   colors?: Record<string, string | Record<string, string>>
   fontFamily?: Record<string, string>
   fontSize?: Record<string, [string, string]>

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -494,6 +494,8 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .min-inline-full{min-inline-size:100%;}
 .min-inline-lg{min-inline-size:32rem;}
 .min-inline-none{min-inline-size:none;}
+.h-screen-lg{height:1024px;}
+.h-screen-sm{height:640px;}
 .max-w-screen-lg{max-width:1024px;}
 .min-w-screen-lg{min-width:1024px;}
 .aspect-\\\\[auto_16\\\\/9\\\\],

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -345,6 +345,8 @@ export const presetMiniTargets: string[] = [
   'w-21',
   'w-1/4',
   'w-lg',
+  'h-screen-sm',
+  'h-screen-lg',
   'max-h-[1px]',
   'max-w-none',
   'max-w-20',


### PR DESCRIPTION
Closes #591.