### PR TITLE
refactor(preset-mini,preset-wind): move svg variant to preset-wind

### DIFF
--- a/packages/preset-mini/src/variants/combinators.ts
+++ b/packages/preset-mini/src/variants/combinators.ts
@@ -1,5 +1,4 @@
 import type { Variant, VariantHandler } from '@unocss/core'
-import { variantMatcher } from '../utils'
 
 const scopeMatcher = (strict: boolean, name: string, template: string) => {
   const re = strict
@@ -26,5 +25,4 @@ export const variantCombinators: Variant[] = [
   scopeMatcher(true, 'parent', '&&-c>&&-s'),
   scopeMatcher(true, 'previous', '&&-c+&&-s'),
   scopeMatcher(true, 'peer', '&&-c~&&-s'),
-  variantMatcher('svg', input => `${input} svg`),
 ]

--- a/packages/preset-wind/src/variants/combinators.ts
+++ b/packages/preset-wind/src/variants/combinators.ts
@@ -1,0 +1,6 @@
+import type { Variant } from '@unocss/core'
+import { variantMatcher } from '@unocss/preset-mini/utils'
+
+export const variantCombinators: Variant[] = [
+  variantMatcher('svg', input => `${input} svg`),
+]

--- a/packages/preset-wind/src/variants/default.ts
+++ b/packages/preset-wind/src/variants/default.ts
@@ -1,6 +1,7 @@
 import type { Variant } from '@unocss/core'
 import { variants as miniVariants } from '@unocss/preset-mini/variants'
 import type { Theme, UnoOptions } from '..'
+import { variantCombinators } from './combinators'
 import { variantColorsScheme } from './dark'
 import { variantSpaceAndDivide } from './misc'
 import { placeholderModifier } from './placeholder'
@@ -9,5 +10,6 @@ export const variants = (options: UnoOptions): Variant<Theme>[] => [
   placeholderModifier,
   variantSpaceAndDivide,
   ...miniVariants(options),
+  ...variantCombinators,
   ...variantColorsScheme,
 ]

--- a/packages/preset-wind/src/variants/index.ts
+++ b/packages/preset-wind/src/variants/index.ts
@@ -1,4 +1,5 @@
 /* @export-submodules */
+export * from './combinators'
 export * from './dark'
 export * from './default'
 export * from './misc'

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -105,7 +105,6 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .fill-\\\\[1rem\\\\]{fill:1rem;}
 .fill-current{fill:currentColor;}
 .fill-green-400{--un-fill-opacity:1;fill:rgba(74,222,128,var(--un-fill-opacity));}
-.svg\\\\:fill-red svg{--un-fill-opacity:1;fill:rgba(248,113,113,var(--un-fill-opacity));}
 .fill-opacity-80{--un-fill-opacity:0.8;}
 .fill-none{fill:none;}
 .stroke-size-\\\\[1rem\\\\],

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -101,6 +101,7 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .peer:checked~.peer-checked\\\\:bg-blue-500{--un-bg-opacity:1;background-color:rgba(59,130,246,var(--un-bg-opacity));}
 .previous:checked+.previous-checked\\\\:bg-red-500{--un-bg-opacity:1;background-color:rgba(239,68,68,var(--un-bg-opacity));}
 .bg-opacity-45{--un-bg-opacity:0.45;}
+.all-\\\\[svg\\\\]\\\\:fill-red svg{--un-fill-opacity:1;fill:rgba(248,113,113,var(--un-fill-opacity));}
 .fill-\\\\[\\\\#123\\\\]{--un-fill-opacity:1;fill:rgba(17,34,51,var(--un-fill-opacity));}
 .fill-\\\\[1rem\\\\]{fill:1rem;}
 .fill-current{fill:currentColor;}

--- a/test/__snapshots__/preset-wind.test.ts.snap
+++ b/test/__snapshots__/preset-wind.test.ts.snap
@@ -236,6 +236,7 @@ exports[`preset-wind > targets 1`] = `
 .bg-no-repeat{background-repeat:no-repeat;}
 .bg-repeat-space{background-position:space;}
 .bg-origin-border{background-origin:border-box;}
+.svg\\\\:fill-red svg{--un-fill-opacity:1;fill:rgba(248,113,113,var(--un-fill-opacity));}
 .object-none{object-fit:none;}
 .object-cb,
 .object-center-bottom{object-position:center bottom;}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -686,6 +686,7 @@ export const presetMiniTargets: string[] = [
   'previous-[.scope]-[combinator:test-3]',
   'sibling-[div:hover]-[combinator:test-4]',
   'group-[div:hover]-[combinator:test-4]',
+  'all-[svg]:fill-red',
 
   // variants combinators
   'all:m-auto',

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -691,7 +691,6 @@ export const presetMiniTargets: string[] = [
   'all:m-auto',
   'children:m-auto',
   'next:mt-0',
-  'svg:fill-red',
 
   // variants layer
   'layer-1:translate-0',

--- a/test/preset-wind-targets.ts
+++ b/test/preset-wind-targets.ts
@@ -315,6 +315,9 @@ export const presetWindiTargets: string[] = [
   '.dark:text-xl',
   '@dark:text-xl',
 
+  // variants combinators
+  'svg:fill-red',
+
   // variants - placeholder
   'placeholder-red-400',
   'placeholder-inherit',


### PR DESCRIPTION
With #568 merged, the `svg` variant can be moved to preset-wind as a compatibility rule.

As for the new syntax for preset-mini only is: `all-[svg]-x`
