### PR TITLE
feat(runtime): add new runtime that only registers the available presets

### DIFF
--- a/packages/runtime/src/cdn/presets.ts
+++ b/packages/runtime/src/cdn/presets.ts
@@ -1,0 +1,16 @@
+import presetAttributify from '@unocss/preset-attributify'
+import presetMini from '@unocss/preset-mini'
+import presetUno from '@unocss/preset-uno'
+import presetWind from '@unocss/preset-wind'
+import { presetTypography } from '@unocss/preset-typography'
+import init from '../index'
+
+init({
+  availablePresets: {
+    presetAttributify,
+    presetMini,
+    presetTypography,
+    presetUno,
+    presetWind,
+  },
+})

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,4 +1,4 @@
-import type { UnoGenerator, UserConfig, UserConfigDefaults } from '@unocss/core'
+import type { Preset, UnoGenerator, UserConfig, UserConfigDefaults } from '@unocss/core'
 import { createGenerator } from '@unocss/core'
 import { autoPrefixer } from './utils'
 
@@ -20,6 +20,10 @@ export interface RuntimeOptions {
    * Callback when the runtime is ready. Returning false will prevent default extraction
    */
   ready?: (runtime: RuntimeContext) => false | any
+  /**
+   * Registered built-in presets
+   */
+  availablePresets?: Record<string, Preset>
 }
 
 export type RuntimeInspectorCallback = (element: Element) => boolean
@@ -87,7 +91,11 @@ export default function init(inlineConfig: RuntimeOptions = {}) {
 
   const config = window.__unocss || {}
   const runtime = config?.runtime
-  const defaultConfig = Object.assign(inlineConfig.defaults || {}, runtime)
+  const defaultConfig = Object.assign(
+    { availablePresets: inlineConfig.availablePresets },
+    inlineConfig.defaults || {},
+    runtime,
+  )
   if (runtime?.autoPrefix) {
     let postprocess = defaultConfig.postprocess
     if (!postprocess)


### PR DESCRIPTION
Mainly to be able to use the typography without introducing permutation for the existing runtime presets