### PR TITLE
feat(runtime): add `full` runtime

### DIFF
--- a/packages/runtime/src/cdn/full.ts
+++ b/packages/runtime/src/cdn/full.ts
@@ -1,0 +1,14 @@
+import presetAttributify from '@unocss/preset-attributify'
+import presetUno from '@unocss/preset-uno'
+import { presetTypography } from '@unocss/preset-typography'
+import init from '../index'
+
+init({
+  defaults: {
+    presets: [
+      presetAttributify(),
+      presetUno(),
+      presetTypography(),
+    ],
+  },
+})


### PR DESCRIPTION
Currently included presets are 
- attributify
- uno
- typography

I tried adding web-fonts but the file size jumped way high. Let me know if it should be added anyway