### PR TITLE
feat(preset-mini): add generic scope class variant

### DIFF
--- a/packages/preset-mini/src/variants/default.ts
+++ b/packages/preset-mini/src/variants/default.ts
@@ -5,7 +5,7 @@ import { variantBreakpoints } from './breakpoints'
 import { variantCombinators } from './combinators'
 import { variantColorsMediaOrClass } from './dark'
 import { variantLanguageDirections } from './directions'
-import { variantImportant, variantLayer, variantNegative } from './misc'
+import { variantImportant, variantLayer, variantNegative, variantScope } from './misc'
 import { variantMotions, variantOrientations, variantPrint } from './media'
 import { partClasses, variantPseudoClassFunctions, variantPseudoClasses, variantPseudoElements, variantTaggedPseudoClasses } from './pseudo'
 
@@ -25,4 +25,5 @@ export const variants = (options: PresetMiniOptions): Variant<Theme>[] => [
   partClasses,
   ...variantColorsMediaOrClass(options),
   ...variantLanguageDirections,
+  variantScope,
 ]

--- a/packages/preset-mini/src/variants/misc.ts
+++ b/packages/preset-mini/src/variants/misc.ts
@@ -12,6 +12,18 @@ export const variantLayer: Variant = {
   },
 }
 
+export const variantScope: Variant = {
+  match(matcher) {
+    const match = matcher.match(/^scope-([_\d\w]+)[:-]/)
+    if (match) {
+      return {
+        matcher: matcher.slice(match[0].length),
+        selector: s => `.${match[1]} $$ ${s}`,
+      }
+    }
+  },
+}
+
 export const variantImportant: Variant = {
   match(matcher) {
     if (matcher.startsWith('!')) {

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -71,6 +71,7 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .m-block-auto{margin-block-start:auto;margin-block-end:auto;}
 .mbs-\\\\[-10\\\\.2\\\\%\\\\]{margin-block-start:-10.2%;}
 .mbs-\\\\$height{margin-block-start:var(--height);}
+.unocss .scope-unocss\\\\:block{display:block;}
 .contents{display:contents;}
 .disabled\\\\:op50:disabled{opacity:0.5;}
 .op-10{opacity:0.1;}
@@ -628,6 +629,7 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .perspect-origin-center{-webkit-perspective-origin:center;perspective-origin:center;}
 .perspect-origin-top-right{-webkit-perspective-origin:top right;perspective-origin:top right;}
 .-translate-full,
+.scope_class .scope-scope_class\\\\:translate-0,
 .translate-full,
 .-translate-x-full,
 .-translate-y-1\\\\/2,
@@ -668,6 +670,7 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .scale-x-\\\\$variable,
 .transform{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-transform:translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z)) rotate(var(--un-rotate)) rotateX(var(--un-rotate-x)) rotateY(var(--un-rotate-y)) rotateZ(var(--un-rotate-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z));}
 .-translate-full{--un-translate-x:-100%;--un-translate-y:-100%;transform:var(--un-transform);}
+.scope_class .scope-scope_class\\\\:translate-0{--un-translate-x:0rem;--un-translate-y:0rem;transform:var(--un-transform);}
 .translate-full{--un-translate-x:100%;--un-translate-y:100%;transform:var(--un-transform);}
 .-translate-x-full{--un-translate-x:-100%;transform:var(--un-transform);}
 .-translate-y-1\\\\/2{--un-translate-y:-50%;transform:var(--un-transform);}

--- a/test/__snapshots__/scope.test.ts.snap
+++ b/test/__snapshots__/scope.test.ts.snap
@@ -10,6 +10,7 @@ exports[`scope 1`] = `
 .foo-scope .pl-10px{padding-left:10px;}
 .dark .foo-scope .dark\\\\:hover\\\\:text-xl:hover,
 .dark .foo-scope .dark\\\\:text-xl{font-size:1.25rem;line-height:1.75rem;}
+.variant .foo-scope .scope-variant\\\\:c-red{--un-text-opacity:1;color:rgba(248,113,113,var(--un-text-opacity));}
 @media (min-width: 640px){
 .foo-scope .sm\\\\:text-red-100{--un-text-opacity:1;color:rgba(254,226,226,var(--un-text-opacity));}
 .foo-scope .sm\\\\:text-red-200\\\\/10{color:rgba(254,202,202,0.1);}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -757,6 +757,10 @@ export const presetMiniTargets: string[] = [
   'group-has-placeholder-shown:text-4xl',
   'focus-within:has-first:checked:bg-gray/20',
 
+  // variants scope
+  'scope-scope_class:translate-0',
+  'scope-unocss:block',
+
   // variants - tagged
   'group-focus:p-4',
   'peer-checked:bg-blue-500',

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -14,6 +14,7 @@ export const fixture = new Set([
   'sm:text-red-100',
   'sm:text-red-200/10',
   'md:!hidden',
+  'scope-variant:c-red',
 ])
 
 const uno = createGenerator({


### PR DESCRIPTION
Compared to the combinators, this variant includes the `$$` control and automatically set the match as class.