### PR TITLE
fix(preset-mini): strict hex color string

### DIFF
--- a/packages/preset-mini/src/utils/colors.ts
+++ b/packages/preset-mini/src/utils/colors.ts
@@ -76,7 +76,7 @@ function parseColor(str: string) {
 }
 
 function parseHexColor(str: string): CSSColorValue | undefined {
-  const [, body] = str.match(/^#?([\da-f]+)$/i) || []
+  const [, body] = str.match(/^#([\da-f]+)$/i) || []
   if (!body)
     return
 

--- a/packages/preset-mini/src/utils/utilities.ts
+++ b/packages/preset-mini/src/utils/utilities.ts
@@ -56,9 +56,9 @@ export const parseColor = (body: string, theme: Theme): ParsedColorValue | undef
   const bracketOrMain = bracket || main
 
   if (bracketOrMain.startsWith('#'))
-    color = bracketOrMain.slice(1)
+    color = bracketOrMain
   else if (bracketOrMain.startsWith('hex-'))
-    color = bracketOrMain.slice(4)
+    color = `#${bracketOrMain.slice(4)}`
   else if (main.startsWith('$'))
     color = h.cssvar(main)
 

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -4,13 +4,13 @@ import { describe, expect, it } from 'vitest'
 describe('color utils', () => {
   it('convert hex to rgb', () => {
     expect(hex2rgba('#fff')).eql([255, 255, 255])
-    expect(hex2rgba('fff')).eql([255, 255, 255])
+    expect(hex2rgba('fff')).eql(undefined)
     expect(hex2rgba('#000')).eql([0, 0, 0])
     expect(hex2rgba('#264512')).eql([38, 69, 18])
     expect(hex2rgba('#123')).eql([17, 34, 51])
     expect(hex2rgba('#abd3')).eql([170, 187, 221, 0.2])
     expect(hex2rgba('#95723489')).eql([149, 114, 52, 0.54])
-    expect(hex2rgba('95723489')).eql([149, 114, 52, 0.54])
+    expect(hex2rgba('95723489')).eql(undefined)
     expect(hex2rgba('#12')).eql(undefined)
     expect(hex2rgba('#12123')).eql(undefined)
   })


### PR DESCRIPTION
This PR makes `parseHexColor` (consequently, `parseCssColor`) requires the `#` prefix for hex colors.