### PR TITLE
feat(core): add ability to rerun config with existing tokens

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -247,6 +247,12 @@ export class UnoGenerator {
     }
   }
 
+  async regenerate(userConfig: UserConfig, options?: GenerateOptions, defaults?: UserConfigDefaults) {
+    const lastCache = new Set(this._cache.keys())
+    this.setConfig(userConfig, defaults ?? this.defaults)
+    return this.generate(lastCache, options)
+  }
+
   matchVariants(raw: string, current?: string): VariantMatchedResult {
     // process variants
     const usedVariants = new Set<Variant>()


### PR DESCRIPTION
This PR adds the ability for core to update config and then rerun `generate` with existing tokens. This should be useful in runtime for theme switching (see #629).

Alternatively, a simpler implementation is to add accessor to obtain the existing tokens in `_cache` and do the logic inside runtime preset.