### PR TITLE
feat(preset-mini,preset-wind): add basic opacity theme

### DIFF
--- a/packages/preset-mini/src/rules/border.ts
+++ b/packages/preset-mini/src/rules/border.ts
@@ -108,8 +108,8 @@ function handlerBorderColor([, a = '', c]: string[], { theme }: RuleContext<Them
   }
 }
 
-function handlerBorderOpacity([, a = '', opacity]: string[]): CSSEntries | undefined {
-  const v = h.bracket.percent(opacity)
+function handlerBorderOpacity([, a = '', opacity]: string[], { theme }: RuleContext<Theme>): CSSEntries | undefined {
+  const v = theme.opacity?.[opacity] ?? h.bracket.percent(opacity)
   if (a in directionMap && v != null)
     return directionMap[a].map(i => [`--un-border${i}-opacity`, v])
 }

--- a/packages/preset-mini/src/rules/color.ts
+++ b/packages/preset-mini/src/rules/color.ts
@@ -1,22 +1,23 @@
 import type { Rule } from '@unocss/core'
+import type { Theme } from '../theme'
 import { colorResolver, handler as h } from '../utils'
 
 /**
  * @example op10 op-30 opacity-100
  */
-export const opacity: Rule[] = [
-  [/^op(?:acity)?-?(.+)$/, ([, d]) => ({ opacity: h.bracket.percent.cssvar(d) })],
+export const opacity: Rule<Theme>[] = [
+  [/^op(?:acity)?-?(.+)$/, ([, d], { theme }) => ({ opacity: theme.opacity?.[d] ?? h.bracket.percent.cssvar(d) })],
 ]
 
 /**
  * @example c-red color-red5 text-red-300
  */
-export const textColors: Rule[] = [
+export const textColors: Rule<Theme>[] = [
   [/^(?:text|color|c)-(.+)$/, colorResolver('color', 'text')],
-  [/^(?:text|color|c)-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-text-opacity': h.bracket.percent(opacity) })],
+  [/^(?:text|color|c)-op(?:acity)?-?(.+)$/, ([, opacity], { theme }) => ({ '--un-text-opacity': theme.opacity?.[opacity] ?? h.bracket.percent(opacity) })],
 ]
 
-export const bgColors: Rule[] = [
+export const bgColors: Rule<Theme>[] = [
   [/^bg-(.+)$/, colorResolver('background-color', 'bg')],
-  [/^bg-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-bg-opacity': h.bracket.percent(opacity) })],
+  [/^bg-op(?:acity)?-?(.+)$/, ([, opacity], { theme }) => ({ '--un-bg-opacity': theme.opacity?.[opacity] ?? h.bracket.percent(opacity) })],
 ]

--- a/packages/preset-mini/src/rules/decoration.ts
+++ b/packages/preset-mini/src/rules/decoration.ts
@@ -19,7 +19,7 @@ export const textDecorations: Rule<Theme>[] = [
       }
     }
   }],
-  [/^(?:underline|decoration)-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-line-opacity': h.bracket.percent(opacity) })],
+  [/^(?:underline|decoration)-op(?:acity)?-?(.+)$/, ([, opacity], { theme }) => ({ '--un-line-opacity': theme.opacity?.[opacity] ?? h.bracket.percent(opacity) })],
 
   // offset
   [/^(?:underline|decoration)-offset-(.+)$/, ([, s], { theme }) => ({ 'text-underline-offset': theme.lineWidth?.[s] ?? h.auto.bracket.cssvar.px(s) })],

--- a/packages/preset-mini/src/rules/ring.ts
+++ b/packages/preset-mini/src/rules/ring.ts
@@ -35,11 +35,11 @@ export const rings: Rule<Theme>[] = [
 
   // colors
   [/^ring-(.+)$/, colorResolver('--un-ring-color', 'ring')],
-  [/^ring-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-ring-opacity': h.bracket.percent(opacity) })],
+  [/^ring-op(?:acity)?-?(.+)$/, ([, opacity], { theme }) => ({ '--un-ring-opacity': theme.opacity?.[opacity] ?? h.bracket.percent(opacity) })],
 
   // offset color
   [/^ring-offset-(.+)$/, colorResolver('--un-ring-offset-color', 'ring-offset')],
-  [/^ring-offset-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-ring-offset-opacity': h.bracket.percent(opacity) })],
+  [/^ring-offset-op(?:acity)?-?(.+)$/, ([, opacity], { theme }) => ({ '--un-ring-offset-opacity': theme.opacity?.[opacity] ?? h.bracket.percent(opacity) })],
 
   // style
   ['ring-inset', { '--un-ring-inset': 'inset' }],

--- a/packages/preset-mini/src/rules/shadow.ts
+++ b/packages/preset-mini/src/rules/shadow.ts
@@ -24,7 +24,7 @@ export const boxShadows: Rule<Theme>[] = [
 
   // color
   [/^shadow-(.+)$/, colorResolver('--un-shadow-color', 'shadow')],
-  [/^shadow-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-shadow-opacity': h.bracket.percent(opacity) })],
+  [/^shadow-op(?:acity)?-?(.+)$/, ([, opacity], { theme }) => ({ '--un-shadow-opacity': theme.opacity?.[opacity] ?? h.bracket.percent(opacity) })],
 
   // inset
   ['shadow-inset', { '--un-shadow-inset': 'inset' }],

--- a/packages/preset-mini/src/rules/svg.ts
+++ b/packages/preset-mini/src/rules/svg.ts
@@ -5,7 +5,7 @@ import { colorResolver, handler as h } from '../utils'
 export const svgUtilities: Rule<Theme>[] = [
   // fills
   [/^fill-(.+)$/, colorResolver('fill', 'fill')],
-  [/^fill-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-fill-opacity': h.bracket.percent(opacity) })],
+  [/^fill-op(?:acity)?-?(.+)$/, ([, opacity], { theme }) => ({ '--un-fill-opacity': theme.opacity?.[opacity] ?? h.bracket.percent(opacity) })],
   ['fill-none', { fill: 'none' }],
 
   // stroke size
@@ -17,7 +17,7 @@ export const svgUtilities: Rule<Theme>[] = [
 
   // stroke colors
   [/^stroke-(.+)$/, colorResolver('stroke', 'stroke')],
-  [/^stroke-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-stroke-opacity': h.bracket.percent(opacity) })],
+  [/^stroke-op(?:acity)?-?(.+)$/, ([, opacity], { theme }) => ({ '--un-stroke-opacity': theme.opacity?.[opacity] ?? h.bracket.percent(opacity) })],
 
   // line cap
   ['stroke-cap-square', { 'stroke-linecap': 'square' }],

--- a/packages/preset-mini/src/rules/typography.ts
+++ b/packages/preset-mini/src/rules/typography.ts
@@ -76,7 +76,7 @@ export const textStrokes: Rule<Theme>[] = [
 
   // colors
   [/^text-stroke-(.+)$/, colorResolver('-webkit-text-stroke-color', 'text-stroke')],
-  [/^text-stroke-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-text-stroke-opacity': h.bracket.percent(opacity) })],
+  [/^text-stroke-op(?:acity)?-?(.+)$/, ([, opacity], { theme }) => ({ '--un-text-stroke-opacity': theme.opacity?.[opacity] ?? h.bracket.percent(opacity) })],
 ]
 
 export const textShadows: Rule<Theme>[] = [
@@ -93,5 +93,5 @@ export const textShadows: Rule<Theme>[] = [
 
   // colors
   [/^text-shadow-color-(.+)$/, colorResolver('--un-text-shadow-color', 'text-shadow')],
-  [/^text-shadow-color-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-text-shadow-opacity': h.bracket.percent(opacity) })],
+  [/^text-shadow-color-op(?:acity)?-?(.+)$/, ([, opacity], { theme }) => ({ '--un-text-shadow-opacity': theme.opacity?.[opacity] ?? h.bracket.percent(opacity) })],
 ]

--- a/packages/preset-mini/src/theme/misc.ts
+++ b/packages/preset-mini/src/theme/misc.ts
@@ -9,6 +9,10 @@ export const breakpoints = {
 
 export const verticalBreakpoints = { ...breakpoints }
 
+export const opacity = {
+  DEFAULT: '1',
+}
+
 export const lineWidth = {
   DEFAULT: '1px',
   none: '0px',

--- a/packages/preset-mini/src/theme/types.ts
+++ b/packages/preset-mini/src/theme/types.ts
@@ -35,6 +35,7 @@ export interface Theme {
   lineWidth?: Record<string, string>
   spacing?: Record<string, string>
   duration?: Record<string, string>
+  opacity?: Record<string, string>
   // filters
   blur?: Record<string, string>
   dropShadow?: Record<string, string | string[]>

--- a/packages/preset-mini/src/utils/utilities.ts
+++ b/packages/preset-mini/src/utils/utilities.ts
@@ -94,6 +94,8 @@ export const parseColor = (body: string, theme: Theme): ParsedColorValue | undef
       color = colorData[no]
   }
 
+  opacity = theme.opacity?.[opacity || 'DEFAULT'] ?? opacity
+
   return {
     opacity,
     name,

--- a/packages/preset-wind/src/rules/behaviors.ts
+++ b/packages/preset-wind/src/rules/behaviors.ts
@@ -1,4 +1,5 @@
 import type { Rule } from '@unocss/core'
+import type { Theme } from '@unocss/preset-mini'
 import { colorResolver, handler as h } from '@unocss/preset-mini/utils'
 
 export const listStyle: Rule[] = [
@@ -20,14 +21,14 @@ export const listStyle: Rule[] = [
   ['list-none', { 'list-style-type': 'none' }],
 ]
 
-export const accents: Rule[] = [
+export const accents: Rule<Theme>[] = [
   [/^accent-(.+)$/, colorResolver('accent-color', 'accent')],
-  [/^accent-op(?:acity)?-?(.+)$/, ([, d]) => ({ '--un-accent-opacity': h.bracket.percent(d) })],
+  [/^accent-op(?:acity)?-?(.+)$/, ([, d], { theme }) => ({ '--un-accent-opacity': theme.opacity?.[d] ?? h.bracket.percent(d) })],
 ]
 
-export const carets: Rule[] = [
+export const carets: Rule<Theme>[] = [
   [/^caret-(.+)$/, colorResolver('caret-color', 'caret')],
-  [/^caret-op(?:acity)?-?(.+)$/, ([, d]) => ({ '--un-caret-opacity': h.bracket.percent(d) })],
+  [/^caret-op(?:acity)?-?(.+)$/, ([, d], { theme }) => ({ '--un-caret-opacity': theme.opacity?.[d] ?? h.bracket.percent(d) })],
 ]
 
 export const imageRenderings: Rule[] = [

--- a/packages/preset-wind/src/rules/divide.ts
+++ b/packages/preset-wind/src/rules/divide.ts
@@ -13,7 +13,7 @@ export const divides: Rule[] = [
 
   // color & opacity
   [/^divide-(.+)$/, colorResolver('border-color', 'divide')],
-  [/^divide-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-divide-opacity': h.bracket.percent(opacity) })],
+  [/^divide-op(?:acity)?-?(.+)$/, ([, opacity], { theme }: RuleContext<Theme>) => ({ '--un-divide-opacity': theme.opacity?.[opacity] ?? h.bracket.percent(opacity) })],
 
   // styles
   ['divide-solid', { 'border-style': 'solid' }],


### PR DESCRIPTION
- add in base `opacity-x`
- add in rules `x-opacity-y`
- theme opacity in `colorParser`