### PR TITLE
chore: typo

### DIFF
--- a/packages/transformer-variant-group/README.md
+++ b/packages/transformer-variant-group/README.md
@@ -28,7 +28,7 @@ Unocss({
 Will be transformed to:
 
 ```html
-<div class="hover:bg-gray-400 hover-font-medium font-light font-mono"/>
+<div class="hover:bg-gray-400 hover:font-medium font-light font-mono"/>
 ``` 
 
 ## License


### PR DESCRIPTION
Typo in https://github.com/unocss/unocss/blob/main/packages/transformer-variant-group/README.md is corrected