### PR TITLE
feat(preset-mini): support 1-value color

### DIFF
--- a/packages/preset-mini/src/utils/colors.ts
+++ b/packages/preset-mini/src/utils/colors.ts
@@ -16,7 +16,7 @@ export function hex2rgba(hex = ''): RGBAColorValue | undefined {
 
 export function parseCssColor(str = ''): CSSColorValue | undefined {
   const color = parseColor(str)
-  if (color == null)
+  if (color == null || color == false)
     return
 
   const { type: casedType, components, alpha } = color
@@ -28,7 +28,7 @@ export function parseCssColor(str = ''): CSSColorValue | undefined {
   if (['rgba', 'hsla'].includes(type) && alpha == null)
     return
 
-  if (cssColorFunctions.includes(type) && components.length !== 3)
+  if (cssColorFunctions.includes(type) && ![1, 3].includes(components.length))
     return
 
   return { type, components, alpha }
@@ -54,7 +54,7 @@ function parseColor(str: string) {
   if (!str)
     return
 
-  let color = parseHexColor(str)
+  let color: CSSColorValue | false | undefined = parseHexColor(str)
   if (color != null)
     return color
 
@@ -121,7 +121,7 @@ function cssColorKeyword(str: string): CSSColorValue | undefined {
   }
 }
 
-function parseCssCommaColorFunction(color: string): CSSColorValue | undefined {
+function parseCssCommaColorFunction(color: string): CSSColorValue | false | undefined {
   const match = color.match(/^(rgb|rgba|hsl|hsla)\((.+)\)$/i)
   if (!match)
     return
@@ -129,11 +129,16 @@ function parseCssCommaColorFunction(color: string): CSSColorValue | undefined {
   const [, type, componentString] = match
   // With min 3 (rgb) and max 4 (rgba), try to get 5 components
   const components = getComponents(componentString, ',', 5)
-  if (components && [3, 4].includes(components.length)) {
-    return {
-      type,
-      components: components.slice(0, 3),
-      alpha: components[3],
+  if (components) {
+    if ([3, 4].includes(components.length)) {
+      return {
+        type,
+        components: components.slice(0, 3),
+        alpha: components[3],
+      }
+    }
+    else if (components.length !== 1) {
+      return false
     }
   }
 }

--- a/packages/preset-mini/src/utils/colors.ts
+++ b/packages/preset-mini/src/utils/colors.ts
@@ -16,7 +16,7 @@ export function hex2rgba(hex = ''): RGBAColorValue | undefined {
 
 export function parseCssColor(str = ''): CSSColorValue | undefined {
   const color = parseColor(str)
-  if (color == null || color == false)
+  if (color == null || color === false)
     return
 
   const { type: casedType, components, alpha } = color

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -6,6 +6,9 @@ exports[`targets 1`] = `
 .border-custom-b\\\\/0{border-color:rgba(var(--custom), 0);}
 .border-custom-b\\\\/10{border-color:rgba(var(--custom), 0.1);}
 .bg-custom-b{background-color:rgba(var(--custom), 1);}
+.bg-info{--un-bg-opacity:1;background-color:hsla(200.1,100%,54.3%,var(--un-bg-opacity));}
+.bg-info\\\\/\\\\[10\\\\%\\\\]{background-color:hsla(200.1,100%,54.3%,10%);}
+.bg-info\\\\/10{background-color:hsla(200.1,100%,54.3%,0.1);}
 .mix-shade-50-c-red-400{--un-text-opacity:1;color:rgba(calc(248 + (0 - 248) * 50 / 100),calc(113 + (0 - 113) * 50 / 100),calc(113 + (0 - 113) * 50 / 100),calc(var(--un-text-opacity) + (1 - var(--un-text-opacity)) * 50 / 100));}
 .mix-shift--50-c-red-600{--un-text-opacity:1;color:rgba(calc(220 + (255 - 220) * 50 / 100),calc(38 + (255 - 38) * 50 / 100),calc(38 + (255 - 38) * 50 / 100),calc(var(--un-text-opacity) + (1 - var(--un-text-opacity)) * 50 / 100));}
 .mix-shift-50-c-red-600{--un-text-opacity:1;color:rgba(calc(220 + (0 - 220) * 50 / 100),calc(38 + (0 - 38) * 50 / 100),calc(38 + (0 - 38) * 50 / 100),calc(var(--un-text-opacity) + (1 - var(--un-text-opacity)) * 50 / 100));}

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -1,5 +1,5 @@
-import type { RuleContext } from 'unocss'
-import { createGenerator } from 'unocss'
+import type { RuleContext } from '@unocss/core'
+import { createGenerator } from '@unocss/core'
 import { colorResolver, colorToString, colorableShadows, hex2rgba, parseCssColor } from '@unocss/preset-mini/utils'
 import { describe, expect, it } from 'vitest'
 

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -1,4 +1,6 @@
-import { colorToString, colorableShadows, hex2rgba, parseCssColor } from '@unocss/preset-mini/utils'
+import type { RuleContext } from 'unocss'
+import { createGenerator } from 'unocss'
+import { colorResolver, colorToString, colorableShadows, hex2rgba, parseCssColor } from '@unocss/preset-mini/utils'
 import { describe, expect, it } from 'vitest'
 
 describe('color utils', () => {
@@ -19,6 +21,8 @@ describe('color utils', () => {
     expect(parseCssColor('rgb(0,1,2)')).eql({ type: 'rgb', components: ['0', '1', '2'], alpha: undefined })
     expect(parseCssColor('rgba(0,1,2,3)')).eql({ type: 'rgba', components: ['0', '1', '2'], alpha: '3' })
     expect(parseCssColor('rgba(0,(1),2,3)')).eql({ type: 'rgba', components: ['0', '(1)', '2'], alpha: '3' })
+    expect(parseCssColor('rgb(0)')).eql({ type: 'rgb', components: ['0'], alpha: undefined })
+    expect(parseCssColor('rgb(0,1)')).eql(undefined)
     expect(parseCssColor('rgba(0,1,2)')).eql(undefined)
     expect(parseCssColor('rgba(0,1,2,3,4)')).eql(undefined)
     expect(parseCssColor('rgba(0,)1(,2,3)')).eql(undefined)
@@ -28,10 +32,16 @@ describe('color utils', () => {
     expect(parseCssColor('rgba(0 1 2 /3)')).eql({ type: 'rgba', components: ['0', '1', '2'], alpha: '3' })
     expect(parseCssColor('rgba(0 1 2/3)')).eql({ type: 'rgba', components: ['0', '1', '2'], alpha: '3' })
     expect(parseCssColor('rgba(0 1 2//3)')).eql(undefined)
+    expect(parseCssColor('rgb(0)')).eql({ type: 'rgb', components: ['0'], alpha: undefined })
+    expect(parseCssColor('rgba(0 / 1)')).eql({ type: 'rgba', components: ['0'], alpha: '1' })
+    expect(parseCssColor('rgba(0 1)')).eql(undefined)
+    expect(parseCssColor('rgba(0 1 / 2)')).eql(undefined)
+    expect(parseCssColor('rgb(0 1 2)')).eql({ type: 'rgb', components: ['0', '1', '2'], alpha: undefined })
     expect(parseCssColor('rgba(0 1 2)')).eql(undefined)
     expect(parseCssColor('rgba(0 1 2 3)')).eql(undefined)
     expect(parseCssColor('rgba(0 1 2 3 4)')).eql(undefined)
 
+    expect(parseCssColor('color(rgb 0 1 2)')).eql({ type: 'rgb', components: ['0', '1', '2'], alpha: undefined })
     expect(parseCssColor('color(rgba 0 1 2)')).eql(undefined)
     expect(parseCssColor('color(rgba 0 1 2 / 3)')).eql({ type: 'rgba', components: ['0', '1', '2'], alpha: '3' })
 
@@ -112,5 +122,52 @@ describe('color utils', () => {
     expect(colorableShadows('1px #200', '--v')).eql(['1px #200'])
     expect(colorableShadows('inset 2px 3px 4px 5px #600', '--v')).eql(['inset 2px 3px 4px 5px var(--v, rgba(102,0,0))'])
     expect(colorableShadows('inset 2px 3px 4px 5px 6px #700', '--v')).eql(['inset 2px 3px 4px 5px 6px #700'])
+  })
+
+  it('parses color token', () => {
+    const context: RuleContext = {
+      theme: {
+        colors: {
+          info: 'hsl(200.1,100%,54.3%)',
+          warning: 'hsl(42.4 100% 50%)',
+          danger: 'hsl(var(--danger))',
+        },
+      },
+      rawSelector: '',
+      currentSelector: '',
+      generator: createGenerator(),
+      variantHandlers: [],
+      variantMatch: ['', '', []],
+      constructCSS: () => '',
+    }
+
+    const fn = (body: string) => colorResolver('prop', 'v')(['', body], context)
+
+    expect(fn('info')).eql({
+      '--un-v-opacity': 1,
+      'prop': 'hsla(200.1,100%,54.3%,var(--un-v-opacity))',
+    })
+
+    expect(fn('info/10')).eql({
+      prop: 'hsla(200.1,100%,54.3%,0.1)',
+    })
+
+    expect(fn('warning')).eql({
+      '--un-v-opacity': 1,
+      'prop': 'hsla(42.4,100%,50%,var(--un-v-opacity))',
+    })
+
+    expect(fn('warning/[20%]')).eql({
+      prop: 'hsla(42.4,100%,50%,20%)',
+    })
+
+    expect(fn('danger')).eql({
+      '--un-v-opacity': 1,
+      'prop': 'hsla(var(--danger),var(--un-v-opacity))',
+    })
+
+    expect(fn('danger/$o3')).eql({
+      prop: 'hsla(var(--danger),var(--o3))',
+    })
   })
 })

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -114,7 +114,7 @@ const uno = createGenerator({
         a: 'var(--custom)',
         b: 'rgba(var(--custom), %alpha)',
       },
-      info: "hsl(200.1, 100%, 54.3%)",
+      info: 'hsl(200.1, 100%, 54.3%)',
     },
   },
 })

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -12,6 +12,9 @@ const targets = [
   // custom colors
   'text-custom-a',
   'bg-custom-b',
+  'bg-info',
+  'bg-info/10',
+  'bg-info/[10%]',
   'border-custom-b',
   'border-custom-b/0',
   'border-custom-b/10',
@@ -111,6 +114,7 @@ const uno = createGenerator({
         a: 'var(--custom)',
         b: 'rgba(var(--custom), %alpha)',
       },
+      info: "hsl(200.1, 100%, 54.3%)",
     },
   },
 })


### PR DESCRIPTION
This PR adds support to use 1 value with the default color functions. Currently when using the css-approved color functions, only color with 3 components are accepted. Supporting 1 component allows possible use of single `var(x)` for the color value; *although* the component value is not validated.

Closes #623.
