### PR TITLE
fix: add missing `preset-wind` to typescript config file

### DIFF
--- a/packages/preset-wind/build.config.ts
+++ b/packages/preset-wind/build.config.ts
@@ -6,9 +6,6 @@ export default defineBuildConfig({
   ],
   clean: true,
   declaration: true,
-  externals: [
-    'unconfig',
-  ],
   rollup: {
     emitCJS: true,
   },

--- a/packages/preset-wind/build.config.ts
+++ b/packages/preset-wind/build.config.ts
@@ -6,6 +6,9 @@ export default defineBuildConfig({
   ],
   clean: true,
   declaration: true,
+  externals: [
+    'unconfig',
+  ],
   rollup: {
     emitCJS: true,
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
       "@unocss/preset-mini/variants": ["./packages/preset-mini/src/variants.ts"],
       "@unocss/preset-mini/utils": ["./packages/preset-mini/src/utils.ts"],
       "@unocss/preset-web-fonts": ["./packages/preset-web-fonts/src/index.ts"],
+      "@unocss/preset-wind": ["./packages/preset-wind/src/index.ts"],
       "@unocss/preset-uno": ["./packages/preset-uno/src/index.ts"],
       "@unocss/preset-icons": ["./packages/preset-icons/src/index.ts"],
       "@unocss/preset-attributify": ["./packages/preset-attributify/src/index.ts"],


### PR DESCRIPTION
This PR fix the build problem on windows