### PR TITLE
fix: add presetWind to unocss package

### DIFF
--- a/packages/unocss/src/index.ts
+++ b/packages/unocss/src/index.ts
@@ -7,6 +7,7 @@ export { default as presetIcons } from '@unocss/preset-icons'
 export { default as presetWebFonts } from '@unocss/preset-web-fonts'
 export { default as presetTypography } from '@unocss/preset-typography'
 export { default as presetMini } from '@unocss/preset-mini'
+export { default as presetWind } from '@unocss/preset-wind'
 export { default as transformerDirectives } from '@unocss/transformer-directives'
 export { default as transformerVariantGroup } from '@unocss/transformer-variant-group'
 


### PR DESCRIPTION
Looks like presetWind accidentally wasn't exported in unocss package