### PR TITLE
fix: windows problem building `preset-wind`

### DIFF
--- a/packages/preset-wind/build.config.ts
+++ b/packages/preset-wind/build.config.ts
@@ -8,5 +8,8 @@ export default defineBuildConfig({
   declaration: true,
   rollup: {
     emitCJS: true,
+    dts: {
+      respectExternal: false,
+    },
   },
 })


### PR DESCRIPTION
Released `unbuild 0.7.0` a few days ago.

Related to https://github.com/unocss/unocss/pull/659, just check the errors on windows on that PR.

/cc @hannoeru I can now build the project again on Windows :raised_hands: