### PR TITLE
fix: input file path(windows)

### DIFF
--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -36,8 +36,8 @@ export default defineConfig({
         'fs',
       ],
       input: [
-        'index.html',
-        '__play.html',
+        './index.html',
+        './__play.html',
       ],
     },
   },


### PR DESCRIPTION
Rollup could not parsing file path in windows.
`PS D:\projects\GitHub\unocss\playground> nr build

> playground@0.0.0 build D:\projects\GitHub\unocss\playground
> vite build

vite v2.8.6 building for production...
✓ 393 modules transformed.
rendering chunks (13)...[vite:build-html] The "fileName" or "name" properties of emitted files must be strings that are neither absolute nor relative paths, received "../../../../../D:\projects\GitHub\unocss\playground\index.html".
error during build:
Error: The "fileName" or "name" properties of emitted files must be strings that are neither absolute nor relative paths, received "../../../../../D:\projects\GitHub\unocss\playground\index.html".
    at error (D:\projects\GitHub\unocss\node_modules\.pnpm\rollup@2.70.1\node_modules\rollup\dist\shared\rollup.js:198:30)`

