### PR TITLE
feat(playground): apply transformers

### DIFF
--- a/playground/src/components/Preview.vue
+++ b/playground/src/components/Preview.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { isDark } from '../logics/dark'
-import { init, inputHTML, output } from '../logics/uno'
+import { init, output, transformedHTML } from '../logics/uno'
 
 const iframe = ref<HTMLIFrameElement>()
 
 const iframeData = reactive({
   source: 'unocss-playground',
   css: computed(() => output.value?.css || ''),
-  html: inputHTML,
+  html: transformedHTML,
   dark: isDark,
 })
 


### PR DESCRIPTION
Apply transformers in config
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/52692296/159429716-0072cbff-26ff-44da-91a1-026048160d25.png">
## known issues
- the group syntax is not underlined in the editor, not sure how to fix this
- apparently the variant group syntax will cause an error in the auto-complete module, [repro](https://unocss.antfu.me/?html=DwEwlgbgBAxgNgQwM5ILwCIAWB7CBTAJwC4AKAM22ygCMECBKdKAegD4g&config=JYWwDg9gTgLgBAbzgEwKYDNgDtUGEJaYDmcAvnOlBCHAOQCuWEAxgM6u0BQnqAHpLBQYAhvQA28NJhz5CwIgAoEnOHCjjUrAFxwA2itV7azeqxjUAtOrGpaAGkRxmEMdB20oqZLTIBdA-6kAJRAA&options=N4IgzgLgTglgxhEAuaBXApgXyA) (open console and change the input), seems like it has to do with regex generation, may need a fix
<img width="628" alt="image" src="https://user-images.githubusercontent.com/52692296/159430012-040545b9-6b5f-40ae-9d31-7d824ac7c212.png">
- transformers are provided with a fake plugin context that only contains the uno instance. this works with the existing official plugins, but may break on other community plugins that require other features from the plugin context