### PR TITLE
fix(attributify): allow important-only utils

### DIFF
--- a/packages/preset-attributify/src/extractor.ts
+++ b/packages/preset-attributify/src/extractor.ts
@@ -9,7 +9,7 @@ const strippedPrefixes = [
 
 const splitterRE = /[\s'"`;]+/g
 const elementRE = /<\w[\w:\.$-]*\s((?:'[\s\S]*?'|"[\s\S]*?"|`[\s\S]*?`|\{[\s\S]*?\}|[\s\S]*?)*?)>/g
-const valuedAttributeRE = /([?]|(?!\d|-{2}|-\d)[a-zA-Z0-9\u00A0-\uFFFF-_:%-]+)(?:=(["'])([^\2]*?)\2)?/g
+const valuedAttributeRE = /([?]|(?!\d|-{2}|-\d)[a-zA-Z0-9\u00A0-\uFFFF-_:!%-]+)(?:=(["'])([^\2]*?)\2)?/g
 
 export const extractorAttributify = (options?: AttributifyOptions): Extractor => {
   const ignoreAttributes = options?.ignoreAttributes ?? []

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -15,9 +15,9 @@ Set {
   "[bg~=\\"dark:hover:blue-600\\"]",
   "[text~=\\"sm\\"]",
   "[text~=\\"white\\"]",
-  "[flex~=\\"~\\"]",
-  "[flex~=\\"col\\"]",
+  "[!leading-4=\\"\\"]",
   "[flex~=\\"!~\\"]",
+  "[flex~=\\"col\\"]",
   "[p~=\\"t-2\\"]",
   "[pt~=\\"2\\"]",
   "[border~=\\"rounded-xl\\"]",
@@ -127,7 +127,6 @@ exports[`attributify > fixture1 1`] = `
 [un-children~=\\"m-auto\\"]>*{margin:auto;}
 [inline-block=\\"\\"]{display:inline-block;}
 [flex~=\\"\\\\!\\\\~\\"]{display:flex !important;}
-[flex~=\\"\\\\~\\"]{display:flex;}
 [flex~=\\"col\\"]{flex-direction:column;}
 [translate-x-100\\\\%=\\"\\"],
 [rotate-30=\\"\\"],
@@ -154,6 +153,7 @@ exports[`attributify > fixture1 1`] = `
 [font~=\\"mono\\"]{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\\"Liberation Mono\\",\\"Courier New\\",monospace;}
 [font~=\\"sans\\"]{font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,\\"Segoe UI\\",Roboto,\\"Helvetica Neue\\",Arial,\\"Noto Sans\\",sans-serif,\\"Apple Color Emoji\\",\\"Segoe UI Emoji\\",\\"Segoe UI Symbol\\",\\"Noto Color Emoji\\";}
 [text~=\\"sm\\"]{font-size:0.875rem;line-height:1.25rem;}
+[\\\\!leading-4=\\"\\"]{line-height:1rem !important;}
 [text~=\\"white\\"]{--un-text-opacity:1;color:rgba(255,255,255,var(--un-text-opacity));}
 [after~=\\"content-unocss\\"]::after{content:\\"unocss\\";}
 @media (min-width: 640px){
@@ -242,9 +242,9 @@ exports[`attributify > variant 1`] = `
   "dark:hover:bg-blue-600",
   "text-sm",
   "text-white",
-  "flex",
-  "flex-col",
+  "!leading-4",
   "!flex",
+  "flex-col",
   "p-t-2",
   "pt-2",
   "border-rounded-xl",

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -13,8 +13,8 @@ describe('attributify', () => {
   class="absolute fixed"
   bg="blue-400 hover:blue-500 dark:!blue-500 dark:hover:blue-600"
   text="sm white"
-  flex="~ col"
-  flex="!~"
+  !leading-4
+  flex="!~ col"
   p="t-2"
   pt="2"
   border="rounded-xl"


### PR DESCRIPTION
Modified based on #746  PR

Can identify `!attributify`

eg `!flex`