### PR TITLE
fix(preset-icons): support deno std node polyfill

### DIFF
--- a/packages/preset-icons/src/utils.ts
+++ b/packages/preset-icons/src/utils.ts
@@ -1,2 +1,2 @@
-export const isNode = typeof process < 'u' && typeof process.stdout < 'u'
+export const isNode = typeof process < 'u' && typeof process.stdout < 'u' && !process.versions.deno
 export const isVSCode = isNode && !!process.env.VSCODE_CWD


### PR DESCRIPTION
Since deno std node polyfill added `stdout` support in https://deno.land/std@0.131.0/node/process.ts#L480, the `isNode` will be `true` when import this preset from esm.sh. But the polyfill also added deno version in `process.versions` in https://deno.land/std@0.131.0/node/_process/process.ts#L99, so we can hack it with `!process.versions.deno`