### PR TITLE
chore(core): export toEscapedSelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ When you really need some advanced rules that can't be covered by the combinatio
 By returning a `string` from the dynamic rule's body function, it will be directly passed to the generated CSS. That also means you would need to take care of things like CSS escaping, variants applying, CSS constructing, and so on.
 
 ```ts
-import Unocss, { escapeSelector as e } from 'unocss'
+import Unocss, { toEscapedSelector as e } from 'unocss'
 
 Unocss({
   rules: [
@@ -264,22 +264,22 @@ Unocss({
       // if you want, you can disable the variants for this rule
       if (variantHandlers.length)
         return
-
+      const selector = e(rawSelector)
       // return a string instead of an object
       return `
-.${e(rawSelector)} {
+${selector} {
   font-size: ${theme.fontSize.sm};
 }
 /* you can have multiple rules */
-.${e(rawSelector)}::after {
+${selector}::after {
   content: 'after';
 }
-.foo > .${e(rawSelector)} {
+.foo > ${selector} {
   color: red;
 }
 /* or media queries */
 @media (min-width: ${theme.breakpoints.sm}) {
-  .${e(rawSelector)} {
+  ${selector} {
     font-size: ${theme.fontSize.sm};
   }
 }

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -517,7 +517,7 @@ function applyScope(css: string, scope?: string) {
 }
 
 const attributifyRe = /^\[(.+?)(~?=)"(.*)"\]$/
-function toEscapedSelector(raw: string) {
+export function toEscapedSelector(raw: string) {
   if (attributifyRe.test(raw))
     return raw.replace(attributifyRe, (_, n, s, i) => `[${e(n)}${s}"${e(i)}"]`)
   return `.${e(raw)}`

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -37,6 +37,46 @@ exports[`attributify > autocomplete extractor 5`] = `
 "
 `;
 
+exports[`attributify > compatible with full controlled rules 1`] = `
+"/* layer: default */
+
+  [custom~=\\"\\\\31 \\"] {
+    font-size: 1px;
+  }
+  /* you can have multiple rules */
+  [custom~=\\"\\\\31 \\"]::after {
+    content: 'after';
+  }
+  .foo > [custom~=\\"\\\\31 \\"] {
+    color: red;
+  }
+  /* or media queries */
+  @media (min-width: 680px) {
+    [custom~=\\"\\\\31 \\"] {
+      font-size: 16px;
+    }
+  }
+  
+
+  .custom-2 {
+    font-size: 2px;
+  }
+  /* you can have multiple rules */
+  .custom-2::after {
+    content: 'after';
+  }
+  .foo > .custom-2 {
+    color: red;
+  }
+  /* or media queries */
+  @media (min-width: 680px) {
+    .custom-2 {
+      font-size: 16px;
+    }
+  }
+  "
+`;
+
 exports[`attributify > extractor1 1`] = `
 Set {
   "[layer-base~=\\"c-white/10\\"]",


### PR DESCRIPTION
we can use `toEscapedSelector` directly  to ensure that [Full Controlled Rules](https://github.com/userquin/unocss#full-controlled-rules) is compatible with [Attributify Mode](https://github.com/antfu/unocss/tree/main/packages/preset-attributify/), avoiding others to implement the toEscapedSelector function again