### PR TITLE
fix(spacing): fix DEFAULT spacing mismatch

### DIFF
--- a/packages/preset-mini/src/rules/spacing.ts
+++ b/packages/preset-mini/src/rules/spacing.ts
@@ -3,6 +3,7 @@ import { directionSize } from '../utils'
 
 export const paddings: Rule[] = [
   [/^pa?()-?(-?.*)$/, directionSize('padding'), { autocomplete: ['(m|p)<num>', '(m|p)-<num>'] }],
+  [/^p?()-?(-?.+)$/, utilities.directionSize("padding")],
   [/^p-?([xy])-?(-?.*)$/, directionSize('padding')],
   [/^p-?([rltbse])-?(-?.*)$/, directionSize('padding'), { autocomplete: '(m|p)<directions>-<num>' }],
   [/^p-(block|inline)-(-?.*)$/, directionSize('padding'), { autocomplete: '(m|p)-(block|inline)-<num>' }],
@@ -11,6 +12,7 @@ export const paddings: Rule[] = [
 
 export const margins: Rule[] = [
   [/^ma?()-?(-?.*)$/, directionSize('margin')],
+  [/^m()-?(-?.+)$/, directionSize('margin')],
   [/^m-?([xy])-?(-?.*)$/, directionSize('margin')],
   [/^m-?([rltbse])-?(-?.*)$/, directionSize('margin')],
   [/^m-(block|inline)-(-?.*)$/, directionSize('margin')],

--- a/packages/preset-mini/src/rules/spacing.ts
+++ b/packages/preset-mini/src/rules/spacing.ts
@@ -2,17 +2,17 @@ import type { Rule } from '@unocss/core'
 import { directionSize } from '../utils'
 
 export const paddings: Rule[] = [
-  [/^pa?()-?(-?.+)$/, directionSize('padding'), { autocomplete: ['(m|p)<num>', '(m|p)-<num>'] }],
-  [/^p-?([xy])-?(-?.+)$/, directionSize('padding')],
-  [/^p-?([rltbse])-?(-?.+)$/, directionSize('padding'), { autocomplete: '(m|p)<directions>-<num>' }],
-  [/^p-(block|inline)-(-?.+)$/, directionSize('padding'), { autocomplete: '(m|p)-(block|inline)-<num>' }],
-  [/^p-?([bi][se])-?(-?.+)$/, directionSize('padding'), { autocomplete: '(m|p)-(bs|be|is|ie)-<num>' }],
+  [/^pa?()-?(-?.*)$/, directionSize('padding'), { autocomplete: ['(m|p)<num>', '(m|p)-<num>'] }],
+  [/^p-?([xy])-?(-?.*)$/, directionSize('padding')],
+  [/^p-?([rltbse])-?(-?.*)$/, directionSize('padding'), { autocomplete: '(m|p)<directions>-<num>' }],
+  [/^p-(block|inline)-(-?.*)$/, directionSize('padding'), { autocomplete: '(m|p)-(block|inline)-<num>' }],
+  [/^p-?([bi][se])-?(-?.*)$/, directionSize('padding'), { autocomplete: '(m|p)-(bs|be|is|ie)-<num>' }],
 ]
 
 export const margins: Rule[] = [
-  [/^ma?()-?(-?.+)$/, directionSize('margin')],
-  [/^m-?([xy])-?(-?.+)$/, directionSize('margin')],
-  [/^m-?([rltbse])-?(-?.+)$/, directionSize('margin')],
-  [/^m-(block|inline)-(-?.+)$/, directionSize('margin')],
-  [/^m-?([bi][se])-?(-?.+)$/, directionSize('margin')],
+  [/^ma?()-?(-?.*)$/, directionSize('margin')],
+  [/^m-?([xy])-?(-?.*)$/, directionSize('margin')],
+  [/^m-?([rltbse])-?(-?.*)$/, directionSize('margin')],
+  [/^m-(block|inline)-(-?.*)$/, directionSize('margin')],
+  [/^m-?([bi][se])-?(-?.*)$/, directionSize('margin')],
 ]


### PR DESCRIPTION
The padding and margin spacing are [written here](), but  the `+` is used in the second capture group of the rule,it can never be empty

This means that [the DEFAULT in spacing](https://github.com/unocss/unocss/blob/4981da7d9df42900a38db1fd18cf52ef4a17ad32/packages/preset-mini/src/theme/misc.ts#L18) cannot be matched

I've replaced the `+` with the `*`

before:

![image](https://user-images.githubusercontent.com/26431026/160229278-787c6c1b-c888-4e9a-bf48-01259bb4e8ba.png)

after:

![image](https://user-images.githubusercontent.com/26431026/160229380-5c09a871-d12e-45d4-a3c6-37a33dac296b.png)

