### PR TITLE
fix(spacing): fix DEFAULT spacing mismatch

### DIFF
--- a/packages/preset-mini/src/rules/spacing.ts
+++ b/packages/preset-mini/src/rules/spacing.ts
@@ -4,25 +4,17 @@ import { directionSize } from '../utils'
 export const paddings: Rule[] = [
   [/^pa?()-?(-?.+)$/, directionSize('padding'), { autocomplete: ['(m|p)<num>', '(m|p)-<num>'] }],
   [/^p-?xy()()$/, directionSize('padding'), { autocomplete: '(m|p)-(xy)' }],
-  [/^p-?([xy])-?(-?.+)$/, directionSize('padding')],
-  [/^p-?([xy])()$/, directionSize('padding')],
-  [/^p-?([rltbse])-?(-?.+)$/, directionSize('padding'), { autocomplete: '(m|p)<directions>-<num>' }],
-  [/^p-?([rltbse])()$/, directionSize('padding')],
-  [/^p-(block|inline)-(-?.+)$/, directionSize('padding'), { autocomplete: '(m|p)-(block|inline)-<num>' }],
-  [/^p-(block|inline)()$/, directionSize('padding')],
-  [/^p-?([bi][se])-?(-?.+)$/, directionSize('padding'), { autocomplete: '(m|p)-(bs|be|is|ie)-<num>' }],
-  [/^p-?([bi][se])()$/, directionSize('padding')],
+  [/^p-?([xy])(?:-?(-?.+))?$/, directionSize('padding')],
+  [/^p-?([rltbse])(?:-?(-?.+))?$/, directionSize('padding'), { autocomplete: '(m|p)<directions>-<num>' }],
+  [/^p-(block|inline)(?:-(-?.+))?$/, directionSize('padding'), { autocomplete: '(m|p)-(block|inline)-<num>' }],
+  [/^p-?([bi][se])(?:-?(-?.+))?$/, directionSize('padding'), { autocomplete: '(m|p)-(bs|be|is|ie)-<num>' }],
 ]
 
 export const margins: Rule[] = [
   [/^ma?()-?(-?.+)$/, directionSize('margin')],
   [/^m-?xy()()$/, directionSize('margin')],
-  [/^m-?([xy])-?(-?.+)$/, directionSize('margin')],
-  [/^m-?([xy])()$/, directionSize('margin')],
-  [/^m-?([rltbse])-?(-?.+)$/, directionSize('margin')],
-  [/^m-?([rltbse])()$/, directionSize('margin')],
-  [/^m-(block|inline)-(-?.+)$/, directionSize('margin')],
-  [/^m-(block|inline)()$/, directionSize('margin')],
-  [/^m-?([bi][se])-?(-?.+)$/, directionSize('margin')],
-  [/^m-?([bi][se])()$/, directionSize('margin')],
+  [/^m-?([xy])(?:-?(-?.+))?$/, directionSize('margin')],
+  [/^m-?([rltbse])(?:-?(-?.+))?$/, directionSize('margin')],
+  [/^m-(block|inline)(?:-(-?.+))?$/, directionSize('margin')],
+  [/^m-?([bi][se])(?:-?(-?.+))?$/, directionSize('margin')],
 ]

--- a/packages/preset-mini/src/rules/spacing.ts
+++ b/packages/preset-mini/src/rules/spacing.ts
@@ -3,16 +3,26 @@ import { directionSize } from '../utils'
 
 export const paddings: Rule[] = [
   [/^pa?()-?(-?.+)$/, directionSize('padding'), { autocomplete: ['(m|p)<num>', '(m|p)-<num>'] }],
+  [/^p-?xy()()$/, directionSize('padding'), { autocomplete: '(m|p)-(xy)' }],
   [/^p-?([xy])-?(-?.+)$/, directionSize('padding')],
+  [/^p-?([xy])()$/, directionSize('padding')],
   [/^p-?([rltbse])-?(-?.+)$/, directionSize('padding'), { autocomplete: '(m|p)<directions>-<num>' }],
+  [/^p-?([rltbse])()$/, directionSize('padding')],
   [/^p-(block|inline)-(-?.+)$/, directionSize('padding'), { autocomplete: '(m|p)-(block|inline)-<num>' }],
+  [/^p-(block|inline)()$/, directionSize('padding')],
   [/^p-?([bi][se])-?(-?.+)$/, directionSize('padding'), { autocomplete: '(m|p)-(bs|be|is|ie)-<num>' }],
+  [/^p-?([bi][se])()$/, directionSize('padding')],
 ]
 
 export const margins: Rule[] = [
   [/^ma?()-?(-?.+)$/, directionSize('margin')],
+  [/^m-?xy()()$/, directionSize('margin')],
   [/^m-?([xy])-?(-?.+)$/, directionSize('margin')],
+  [/^m-?([xy])()$/, directionSize('margin')],
   [/^m-?([rltbse])-?(-?.+)$/, directionSize('margin')],
+  [/^m-?([rltbse])()$/, directionSize('margin')],
   [/^m-(block|inline)-(-?.+)$/, directionSize('margin')],
+  [/^m-(block|inline)()$/, directionSize('margin')],
   [/^m-?([bi][se])-?(-?.+)$/, directionSize('margin')],
+  [/^m-?([bi][se])()$/, directionSize('margin')],
 ]

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -53,17 +53,17 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .p-t-2,
 .pt-2,
 .pt2{padding-top:0.5rem;}
+.pb{padding-bottom:1rem;}
 .pl-10px{padding-left:10px;}
 .pt-\\\\$title2{padding-top:var(--title2);}
-.pb{padding-bottom:1rem;}
 .p-bs-2,
 .pbs-2,
 .pbs2{padding-block-start:0.5rem;}
 .p-ie-none{padding-inline-end:0rem;}
-.pbs-\\\\$title2{padding-block-start:var(--title2);}
-.pis-10px{padding-inline-start:10px;}
 .p-is,
 .pis{padding-inline-start:1rem;}
+.pbs-\\\\$title2{padding-block-start:var(--title2);}
+.pis-10px{padding-inline-start:10px;}
 .-m-auto,
 .all\\\\:m-auto *,
 .children\\\\:m-auto>*,
@@ -80,12 +80,12 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .mt-\\\\[-10\\\\.2\\\\%\\\\]{margin-top:-10.2%;}
 .mt-\\\\$height{margin-top:var(--height);}
 .next\\\\:mt-0+*{margin-top:0rem;}
+.m-block{margin-block-start:1rem;margin-block-end:1rem;}
 .m-block-auto{margin-block-start:auto;margin-block-end:auto;}
 .m-inline-none{margin-inline-start:0rem;margin-inline-end:0rem;}
-.m-block{margin-block-start:1rem;margin-block-end:1rem;}
+.mbs{margin-block-start:1rem;}
 .mbs-\\\\[-10\\\\.2\\\\%\\\\]{margin-block-start:-10.2%;}
 .mbs-\\\\$height{margin-block-start:var(--height);}
-.mbs{margin-block-start:1rem;}
 .unocss .scope-unocss\\\\:block{display:block;}
 .contents{display:contents;}
 .disabled\\\\:op50:disabled{opacity:0.5;}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -37,25 +37,33 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .p-2,
 .p2,
 .where-hover\\\\:p-2:where(:hover){padding:0.5rem;}
-.group:focus .group-focus\\\\:p-4{padding:1rem;}
+.group:focus .group-focus\\\\:p-4,
+.p-xy,
+.pxy{padding:1rem;}
 .hover\\\\:\\\\!p-1:hover{padding:0.25rem !important;}
 .hover\\\\:p-5:hover{padding:1.25rem;}
 .is-hover\\\\:p-4px:is(:hover),
 .not-hover\\\\:p-4px:not(:hover){padding:4px;}
 .not-hover\\\\:p-3:not(:hover){padding:0.75rem;}
 .p-none{padding:0rem;}
+.pa{padding:auto;}
 .\\\\!hover\\\\:px-10:hover{padding-left:2.5rem !important;padding-right:2.5rem !important;}
+.p-x,
+.px{padding-left:1rem;padding-right:1rem;}
 .p-t-2,
 .pt-2,
 .pt2{padding-top:0.5rem;}
 .pl-10px{padding-left:10px;}
 .pt-\\\\$title2{padding-top:var(--title2);}
+.pb{padding-bottom:1rem;}
 .p-bs-2,
 .pbs-2,
 .pbs2{padding-block-start:0.5rem;}
 .p-ie-none{padding-inline-end:0rem;}
 .pbs-\\\\$title2{padding-block-start:var(--title2);}
 .pis-10px{padding-inline-start:10px;}
+.p-is,
+.pis{padding-inline-start:1rem;}
 .-m-auto,
 .all\\\\:m-auto *,
 .children\\\\:m-auto>*,
@@ -65,6 +73,8 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .m-0,
 .m-none{margin:0rem;}
 .m-1\\\\/2{margin:50%;}
+.m-xy,
+.mxy{margin:1rem;}
 .my-auto{margin-top:auto;margin-bottom:auto;}
 .-mb-px{margin-bottom:-1px;}
 .mt-\\\\[-10\\\\.2\\\\%\\\\]{margin-top:-10.2%;}
@@ -72,8 +82,10 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .next\\\\:mt-0+*{margin-top:0rem;}
 .m-block-auto{margin-block-start:auto;margin-block-end:auto;}
 .m-inline-none{margin-inline-start:0rem;margin-inline-end:0rem;}
+.m-block{margin-block-start:1rem;margin-block-end:1rem;}
 .mbs-\\\\[-10\\\\.2\\\\%\\\\]{margin-block-start:-10.2%;}
 .mbs-\\\\$height{margin-block-start:var(--height);}
+.mbs{margin-block-start:1rem;}
 .unocss .scope-unocss\\\\:block{display:block;}
 .contents{display:contents;}
 .disabled\\\\:op50:disabled{opacity:0.5;}

--- a/test/autocomplete.test.ts
+++ b/test/autocomplete.test.ts
@@ -158,6 +158,7 @@ describe('autocomplete', () => {
           "dark:md:m-12",
           "dark:md:m-24",
           "dark:md:m-36",
+          "dark:md:m-xy",
         ]
       `)
   })

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -436,6 +436,7 @@ export const presetMiniTargets: string[] = [
   'pt-2',
   'pt2',
   'pt-$title2',
+  'pa',
   'm-[3em]',
   'm-0',
   'm-1/2',
@@ -457,6 +458,20 @@ export const presetMiniTargets: string[] = [
   'm-block-auto',
   'm-inline-none',
 
+  // spacing - default
+  'p',
+  'pb',
+  'px',
+  'p-x',
+  'pxy',
+  'p-xy',
+  'pis',
+  'p-is',
+  'm-block',
+  'mbs',
+  'mxy',
+  'm-xy',
+  
   // static
   'contents',
   'backface-hidden',

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -471,7 +471,7 @@ export const presetMiniTargets: string[] = [
   'mbs',
   'mxy',
   'm-xy',
-  
+
   // static
   'contents',
   'backface-hidden',


### PR DESCRIPTION
The padding and margin spacing are [written here](https://github.com/unocss/unocss/blob/main/packages/preset-mini/src/rules/spacing.ts), but  the `+` is used in the second capture group of the rule,it can never be empty

This means that [the DEFAULT in spacing](https://github.com/unocss/unocss/blob/main/packages/preset-mini/src/theme/misc.ts#L18) cannot be matched

I replaced the `+` with the `*`

before:

![image](https://user-images.githubusercontent.com/26431026/160229278-787c6c1b-c888-4e9a-bf48-01259bb4e8ba.png)

after:

![image](https://user-images.githubusercontent.com/26431026/160231547-b40369c9-5ef2-4562-aec4-86126c54547b.png)


