### PR TITLE
feat(runtime): un-cloak to prevent FOUC

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -83,6 +83,24 @@ import initUnocssRuntime from '@unocss/runtime'
 initUnocssRuntime({ /* options */ })
 ```
 
+## Preventing flash of unstyled content
+
+Since UnoCSS runs after the DOM is present, there can be a "flash of unstyled content" which may leads the user to see the page as unstyled.
+
+Use `un-cloak` attribute with CSS rules such as `[un-cloak] { display: none }` to hide the unstyled element until UnoCSS applies the styles for it.
+
+```css
+[un-cloak] {
+  display: none;
+}
+```
+
+```html
+<div class="text-blue-500" un-cloak>
+  This text will only be visible in blue color.
+</div>
+```
+
 ## License
 
 MIT License © 2021 [Anthony Fu](https://github.com/antfu)

--- a/packages/runtime/play/index.html
+++ b/packages/runtime/play/index.html
@@ -1,8 +1,13 @@
 <head>
 <script src="../attributify.global.js"></script>
+<style>
+[un-cloak] {
+  display: none;
+}
+</style>
 </head>
 
-<body p10 font-sans>
+<body p10 font-sans un-cloak>
   <div id="hi" class="text-red" font="bold" text="xl" animate-bounce>Hello</div>
   <button id="btn">Change Color</button>
 </body>


### PR DESCRIPTION
Add a `un-cloak` attribute to hide an element until it's styles are ready.

Note: dynamic injected elements will still suffer from FOUC, haven't figured out a way to prevent this.