### PR TITLE
fix(shortcuts): full-controlled-rules works with shortcuts

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -379,7 +379,6 @@ export class UnoGenerator {
   stringifyUtil(parsed?: ParsedUtil | RawUtil): StringifiedUtil | undefined {
     if (!parsed)
       return
-
     if (isRawUtil(parsed))
       return [parsed[0], undefined, parsed[1], undefined, parsed[2]]
 
@@ -444,7 +443,6 @@ export class UnoGenerator {
     meta: RuleMeta = { layer: this.config.shortcutsLayer },
   ): Promise<StringifiedUtil[] | undefined> {
     const selectorMap = new TwoKeyMap<string, string | undefined, [[CSSEntries, boolean, number][], number]>()
-
     const parsed = (
       await Promise.all(uniq(expanded)
         .map(async(i) => {
@@ -458,10 +456,12 @@ export class UnoGenerator {
       .sort((a, b) => a[0] - b[0])
 
     const [raw, , parentVariants] = parent
-
+    const rawStringfieldUtil: StringifiedUtil[] = []
     for (const item of parsed) {
-      if (isRawUtil(item))
+      if (isRawUtil(item)) {
+        rawStringfieldUtil.push([item[0], undefined, item[1], undefined, item[2]])
         continue
+      }
       const { selector, entries, parent, sort } = this.applyVariants(item, [...item[4], ...parentVariants], raw)
 
       // find existing selector/mediaQuery pair and merge
@@ -469,8 +469,7 @@ export class UnoGenerator {
       // add entries
       mapItem[0].push([entries, !!item[3]?.noMerge, sort ?? 0])
     }
-
-    return selectorMap
+    return rawStringfieldUtil.concat(selectorMap
       .map(([e, index], selector, mediaQuery) => {
         const stringify = (flatten: boolean, noMerge: boolean, entrySortPair: [CSSEntries, number][]): (StringifiedUtil | undefined)[] => {
           const maxSort = Math.max(...entrySortPair.map(e => e[1]))
@@ -494,7 +493,7 @@ export class UnoGenerator {
         ])
       })
       .flat(2)
-      .filter(Boolean) as StringifiedUtil[]
+      .filter(Boolean) as StringifiedUtil[])
   }
 
   isBlocked(raw: string) {

--- a/test/__snapshots__/layer.test.ts.snap
+++ b/test/__snapshots__/layer.test.ts.snap
@@ -11,6 +11,7 @@ exports[`layers > static 1`] = `
 .c5{name:5;}
 /* layer: d */
 /* RAW 4 */
+/* RAW 3 */
 /* layer: s */
 .abcd{name:bar1;name:bar2;name:2;}"
 `;

--- a/test/__snapshots__/shortcuts.test.ts.snap
+++ b/test/__snapshots__/shortcuts.test.ts.snap
@@ -1,5 +1,13 @@
 // Vitest Snapshot v1
 
+exports[`shortcuts > animate 1`] = `
+"/* layer: shortcuts */
+.loading{transition-duration:1000ms;}
+/* layer: default */
+@keyframes spin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+.loading{animation:spin 1s linear infinite;}"
+`;
+
 exports[`shortcuts > dynamic 1`] = `
 "/* layer: shortcuts */
 .button-1{padding-left:0.75rem;padding-right:0.75rem;padding-top:0.5rem;padding-bottom:0.5rem;}

--- a/test/shortcuts.test.ts
+++ b/test/shortcuts.test.ts
@@ -22,6 +22,7 @@ describe('shortcuts', () => {
       ['transform-duplicated', 'translate-x-1 translate-y-2 scale-4 hover:scale-2 active:scale-x-4'],
       ['shortcut-hover-active-1', 'focus:bg-green-300 hover:bg-green-300 active:bg-green-300'],
       ['shortcut-hover-active-2', 'focus:bg-red-300 hover:bg-yellow-300 active:bg-blue-300'],
+      ['loading', 'animate-spin duration-1000'],
     ],
     presets: [
       presetUno(),
@@ -91,6 +92,11 @@ describe('shortcuts', () => {
 
   test('variant order', async() => {
     const { css } = await uno.generate('shortcut-hover-active-2 layer-shortcuts:bg-blue-300')
+    expect(css).toMatchSnapshot()
+  })
+
+  test('animate', async() => {
+    const { css } = await uno.generate('loading')
     expect(css).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
fix [full-controlled-rules](https://github.com/unocss/unocss#full-controlled-rules) works with shortcut, like animate

but i failed in https://github.com/unocss/unocss/blob/main/test/__snapshots__/layer.test.ts.snap

```diff
// Vitest Snapshot v1

exports[`layers > static 1`] = `
"/* layer: shortcuts */
.abc{name:bar1;name:bar2;name:4;}
/* layer: a */
.a{name:bar1;}
/* layer: b */
.b{name:bar2;}
/* layer: c */
.c5{name:5;}
/* layer: d */
/* RAW 4 */
+ /* RAW 3 */
/* layer: s */
.abcd{name:bar1;name:bar2;name:2;}"
`;
```

I am not sure if this comment(/* RAW 3 */) has to be removed,  