### PR TITLE
fix: user config theme breakpoints order

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -17,6 +17,28 @@ export class UnoGenerator {
     this.config = resolveConfig(userConfig, defaults)
   }
 
+  resolveBreakpoints() {
+    let breakpoints: Record<string, string> | undefined
+    if (this.userConfig && this.userConfig.theme)
+      breakpoints = (this.userConfig.theme as any).breakpoints
+
+    if (!breakpoints && this.config.theme)
+      breakpoints = (this.config.theme as any).breakpoints
+
+    return breakpoints
+  }
+
+  resolveVerticalBreakpoints() {
+    let verticalBreakpoints: Record<string, string> | undefined
+    if (this.userConfig && this.userConfig.theme)
+      verticalBreakpoints = (this.userConfig.theme as any).verticalBreakpoints
+
+    if (!verticalBreakpoints && this.config.theme)
+      verticalBreakpoints = (this.config.theme as any).verticalBreakpoints
+
+    return verticalBreakpoints
+  }
+
   setConfig(userConfig?: UserConfig, defaults?: UserConfigDefaults) {
     if (!userConfig)
       return

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -17,28 +17,6 @@ export class UnoGenerator {
     this.config = resolveConfig(userConfig, defaults)
   }
 
-  resolveBreakpoints() {
-    let breakpoints: Record<string, string> | undefined
-    if (this.userConfig && this.userConfig.theme)
-      breakpoints = (this.userConfig.theme as any).breakpoints
-
-    if (!breakpoints && this.config.theme)
-      breakpoints = (this.config.theme as any).breakpoints
-
-    return breakpoints
-  }
-
-  resolveVerticalBreakpoints() {
-    let verticalBreakpoints: Record<string, string> | undefined
-    if (this.userConfig && this.userConfig.theme)
-      verticalBreakpoints = (this.userConfig.theme as any).verticalBreakpoints
-
-    if (!verticalBreakpoints && this.config.theme)
-      verticalBreakpoints = (this.config.theme as any).verticalBreakpoints
-
-    return verticalBreakpoints
-  }
-
   setConfig(userConfig?: UserConfig, defaults?: UserConfigDefaults) {
     if (!userConfig)
       return

--- a/packages/preset-mini/src/rules/size.ts
+++ b/packages/preset-mini/src/rules/size.ts
@@ -47,8 +47,8 @@ export const sizes: Rule<Theme>[] = [
       ],
     },
   ],
-  [/^(min-|max-)?(h)-screen-(.+)$/, ([, m, w, s], { theme }) => ({ [getPropName(m, w)]: theme.verticalBreakpoints?.[s] }), { autocomplete: ['h-screen-$verticalBreakpoints', '(min|max)-h-screen-$verticalBreakpoints'] }],
-  [/^(min-|max-)?(w)-screen-(.+)$/, ([, m, w, s], { theme }) => ({ [getPropName(m, w)]: theme.breakpoints?.[s] }), { autocomplete: ['w-screen-$breakpoints', '(min|max)-w-screen-$breakpoints'] }],
+  [/^(min-|max-)?(h)-screen-(.+)$/, ([, m, w, s], { generator }) => ({ [getPropName(m, w)]: generator.resolveVerticalBreakpoints()?.[s] }), { autocomplete: ['h-screen-$verticalBreakpoints', '(min|max)-h-screen-$verticalBreakpoints'] }],
+  [/^(min-|max-)?(w)-screen-(.+)$/, ([, m, w, s], { generator }) => ({ [getPropName(m, w)]: generator.resolveBreakpoints()?.[s] }), { autocomplete: ['w-screen-$breakpoints', '(min|max)-w-screen-$breakpoints'] }],
 ]
 
 function getAspectRatio(prop: string) {

--- a/packages/preset-mini/src/rules/size.ts
+++ b/packages/preset-mini/src/rules/size.ts
@@ -1,6 +1,6 @@
 import type { Rule } from '@unocss/core'
 import type { Theme } from '../theme'
-import { handler as h } from '../utils'
+import { handler as h, resolveBreakpoints, resolveVerticalBreakpoints } from '../utils'
 
 const sizeMapping: Record<string, string> = {
   h: 'height',
@@ -47,8 +47,8 @@ export const sizes: Rule<Theme>[] = [
       ],
     },
   ],
-  [/^(min-|max-)?(h)-screen-(.+)$/, ([, m, w, s], { generator }) => ({ [getPropName(m, w)]: generator.resolveVerticalBreakpoints()?.[s] }), { autocomplete: ['h-screen-$verticalBreakpoints', '(min|max)-h-screen-$verticalBreakpoints'] }],
-  [/^(min-|max-)?(w)-screen-(.+)$/, ([, m, w, s], { generator }) => ({ [getPropName(m, w)]: generator.resolveBreakpoints()?.[s] }), { autocomplete: ['w-screen-$breakpoints', '(min|max)-w-screen-$breakpoints'] }],
+  [/^(min-|max-)?(h)-screen-(.+)$/, ([, m, w, s], context) => ({ [getPropName(m, w)]: resolveVerticalBreakpoints(context)?.[s] }), { autocomplete: ['h-screen-$verticalBreakpoints', '(min|max)-h-screen-$verticalBreakpoints'] }],
+  [/^(min-|max-)?(w)-screen-(.+)$/, ([, m, w, s], context) => ({ [getPropName(m, w)]: resolveBreakpoints(context)?.[s] }), { autocomplete: ['w-screen-$breakpoints', '(min|max)-w-screen-$breakpoints'] }],
 ]
 
 function getAspectRatio(prop: string) {

--- a/packages/preset-mini/src/utils/utilities.ts
+++ b/packages/preset-mini/src/utils/utilities.ts
@@ -1,4 +1,4 @@
-import type { CSSEntries, CSSObject, ParsedColorValue, RuleContext } from '@unocss/core'
+import type { CSSEntries, CSSObject, ParsedColorValue, RuleContext, VariantContext } from '@unocss/core'
 import { toArray } from '@unocss/core'
 import type { Theme } from '../theme'
 import { colorToString, getComponents, parseCssColor } from './colors'
@@ -175,4 +175,26 @@ export const colorableShadows = (shadows: string | string[], colorVar: string) =
 
 export const hasParseableColor = (color: string | undefined, theme: Theme) => {
   return color != null && !!parseColor(color, theme)?.color
+}
+
+export const resolveBreakpoints = ({ theme, generator }: Readonly<VariantContext<Theme>>) => {
+  let breakpoints: Record<string, string> | undefined
+  if (generator.userConfig && generator.userConfig.theme)
+    breakpoints = (generator.userConfig.theme as any).breakpoints
+
+  if (!breakpoints)
+    breakpoints = theme.breakpoints
+
+  return breakpoints
+}
+
+export const resolveVerticalBreakpoints = ({ theme, generator }: Readonly<VariantContext<Theme>>) => {
+  let verticalBreakpoints: Record<string, string> | undefined
+  if (generator.userConfig && generator.userConfig.theme)
+    verticalBreakpoints = (generator.userConfig.theme as any).verticalBreakpoints
+
+  if (!verticalBreakpoints)
+    verticalBreakpoints = theme.verticalBreakpoints
+
+  return verticalBreakpoints
 }

--- a/packages/preset-mini/src/variants/breakpoints.ts
+++ b/packages/preset-mini/src/variants/breakpoints.ts
@@ -1,4 +1,5 @@
 import type { Variant } from '@unocss/core'
+import { resolveBreakpoints } from '../utils'
 import type { Theme } from '../theme'
 
 const regexCache: Record<string, RegExp> = {}
@@ -11,10 +12,9 @@ const calcMaxWidthBySize = (size: string) => {
 }
 
 export const variantBreakpoints: Variant<Theme> = {
-  match(matcher, { generator }) {
-    const bp = generator.resolveBreakpoints() ?? {}
+  match(matcher, context) {
     const variantEntries: Array<[string, string, number]>
-    = Object.entries(bp).map(([point, size], idx) => [point, size, idx])
+    = Object.entries(resolveBreakpoints(context) ?? {}).map(([point, size], idx) => [point, size, idx])
     for (const [point, size, idx] of variantEntries) {
       if (!regexCache[point])
         regexCache[point] = new RegExp(`^((?:[al]t-)?${point}[:-])`)

--- a/packages/preset-mini/src/variants/breakpoints.ts
+++ b/packages/preset-mini/src/variants/breakpoints.ts
@@ -11,9 +11,10 @@ const calcMaxWidthBySize = (size: string) => {
 }
 
 export const variantBreakpoints: Variant<Theme> = {
-  match(matcher, { theme }) {
+  match(matcher, { generator }) {
+    const bp = generator.resolveBreakpoints() ?? {}
     const variantEntries: Array<[string, string, number]>
-    = Object.entries(theme.breakpoints || {}).map(([point, size], idx) => [point, size, idx])
+    = Object.entries(bp).map(([point, size], idx) => [point, size, idx])
     for (const [point, size, idx] of variantEntries) {
       if (!regexCache[point])
         regexCache[point] = new RegExp(`^((?:[al]t-)?${point}[:-])`)

--- a/packages/preset-wind/src/rules/container.ts
+++ b/packages/preset-wind/src/rules/container.ts
@@ -1,6 +1,7 @@
 import type { Rule, Shortcut } from '@unocss/core'
 import { toArray } from '@unocss/core'
 import type { Theme } from '@unocss/preset-mini'
+import { resolveBreakpoints } from '@unocss/preset-mini/utils'
 
 const queryMatcher = /@media \(min-width: (.+)\)/
 
@@ -24,8 +25,8 @@ export const container: Rule<Theme>[] = [
 ]
 
 export const containerShortcuts: Shortcut<Theme>[] = [
-  [/^(?:(\w+)[:-])?container$/, ([, bp], { generator }) => {
-    let points = Object.keys(generator.resolveBreakpoints() ?? {})
+  [/^(?:(\w+)[:-])?container$/, ([, bp], context) => {
+    let points = Object.keys(resolveBreakpoints(context) ?? {})
     if (bp) {
       if (!points.includes(bp))
         return

--- a/packages/preset-wind/src/rules/container.ts
+++ b/packages/preset-wind/src/rules/container.ts
@@ -24,8 +24,8 @@ export const container: Rule<Theme>[] = [
 ]
 
 export const containerShortcuts: Shortcut<Theme>[] = [
-  [/^(?:(\w+)[:-])?container$/, ([, bp], { theme }) => {
-    let points = Object.keys(theme.breakpoints || {})
+  [/^(?:(\w+)[:-])?container$/, ([, bp], { generator }) => {
+    let points = Object.keys(generator.resolveBreakpoints() ?? {})
     if (bp) {
       if (!points.includes(bp))
         return

--- a/test/transformer-directives.test.ts
+++ b/test/transformer-directives.test.ts
@@ -294,4 +294,65 @@ describe('transformer-directives', () => {
 
     expect(result).toMatchSnapshot()
   })
+
+  test('custom breakpoints', async() => {
+    const customUno = createGenerator({
+      presets: [
+        presetUno(),
+      ],
+      theme: {
+        breakpoints: {
+          'xs': '320px',
+          'sm': '640px',
+          'md': '768px',
+          'lg': '1024px',
+          'xl': '1280px',
+          '2xl': '1536px',
+          'xxl': '1536px',
+        },
+      },
+    })
+    const result = await transform(
+      '.grid { @apply grid grid-cols-2 xs:grid-cols-1 xxl:grid-cols-15 xl:grid-cols-10 sm:grid-cols-7 md:grid-cols-3 lg:grid-cols-4 }',
+      customUno,
+    )
+    expect(result)
+      .toMatchInlineSnapshot(`
+        ".grid {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+        @media (min-width: 320px) {
+          .grid {
+            grid-template-columns: repeat(1, minmax(0, 1fr));
+          }
+        }
+        @media (min-width: 640px) {
+          .grid {
+            grid-template-columns: repeat(7, minmax(0, 1fr));
+          }
+        }
+        @media (min-width: 768px) {
+          .grid {
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+          }
+        }
+        @media (min-width: 1024px) {
+          .grid {
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+          }
+        }
+        @media (min-width: 1280px) {
+          .grid {
+            grid-template-columns: repeat(10, minmax(0, 1fr));
+          }
+        }
+        @media (min-width: 1536px) {
+          .grid {
+            grid-template-columns: repeat(15, minmax(0, 1fr));
+          }
+        }
+        "
+      `)
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
       "@unocss/preset-uno": ["./packages/preset-uno/src/index.ts"],
       "@unocss/preset-icons": ["./packages/preset-icons/src/index.ts"],
       "@unocss/preset-attributify": ["./packages/preset-attributify/src/index.ts"],
+      "@unocss/preset-typography": ["./packages/preset-typography/src/index.ts"],
       "@unocss/transformer-variant-group": ["./packages/transformer-variant-group/src/index.ts"],
       "@unocss/transformer-directives": ["./packages/transformer-directives/src/index.ts"],
     }


### PR DESCRIPTION
This PR fix the breakpoints from user config theme:
- ~~`generator`: add resolve breakpoints utilities~~ => moved to `src/utils/utilities` on `preset-mini` 
- `preset-mini`: size and breakpoints
- `preset-wind`: container
- test: transformer-directive.test.ts (check last test `custom breakpoints` with custom generator)
- add `@unocss/preset-typography` to root `tsconfig.json`

**This PR doesn't solve the order problem, maybe we should document it or try to fix it later.**

closes #778 