### PR TITLE
fix(playground):adjust matched time interval

### DIFF
--- a/packages/inspector/client/components/CodeMirror.vue
+++ b/packages/inspector/client/components/CodeMirror.vue
@@ -79,7 +79,7 @@ onMounted(async() => {
   watch(() => [props.modelValue, props.matched], async() => {
     clearTimeout(timer)
     if (props.matched)
-      timer = setTimeout(highlight, 100)
+      timer = setTimeout(highlight, 200)
   }, { immediate: true })
 })
 </script>


### PR DESCRIPTION
Before:
Occasionally, some matched rules not highlight
![image](https://user-images.githubusercontent.com/42139754/161376415-e5facded-6459-4980-ae11-b916427df8a9.png)
