### PR TITLE
feat(variantGroup): support tilde syntax

### DIFF
--- a/packages/core/src/utils/variantGroup.ts
+++ b/packages/core/src/utils/variantGroup.ts
@@ -1,6 +1,6 @@
 import type MagicString from 'magic-string'
 
-export const regexClassGroup = /([!\w+:_/-]+?)([:-])\(((?:[!\w\s:/\\,%#.$-]|\[.*?\])*?)\)/gm
+export const regexClassGroup = /([!\w+:_/-]+?)([:-])\(((?:[~!\w\s:/\\,%#.$-]|\[.*?\])*?)\)/gm
 
 export function expandVariantGroup(str: string): string
 export function expandVariantGroup(str: MagicString): MagicString
@@ -9,7 +9,10 @@ export function expandVariantGroup(str: string | MagicString) {
   return str.replace(
     regexClassGroup,
     (_, pre, sep, body: string) => {
-      return body.split(/\s/g).map(i => i.replace(/^(!?)(.*)/, `$1${pre}${sep}$2`)).join(' ')
+      return body
+        .split(/\s/g)
+        .map(i => i === '~' ? pre : i.replace(/^(!?)(.*)/, `$1${pre}${sep}$2`))
+        .join(' ')
     },
   )
 }

--- a/packages/inspector/client/composables/codemirror.ts
+++ b/packages/inspector/client/composables/codemirror.ts
@@ -11,18 +11,26 @@ import 'codemirror/addon/hint/show-hint'
 import 'codemirror/lib/codemirror.css'
 import 'codemirror-theme-vars/base.css'
 import 'codemirror/addon/hint/show-hint.css'
+import type { MaybeRef } from '@vueuse/core'
 
 export function useCodeMirror(
   textarea: Ref<HTMLTextAreaElement | null | undefined>,
   input: Ref<string> | WritableComputedRef<string>,
-  options: CodeMirror.EditorConfiguration = {},
+  options: MaybeRef<CodeMirror.EditorConfiguration> = {},
 ) {
   const cm = CodeMirror.fromTextArea(
     textarea.value!,
     {
       theme: 'vars',
-      ...options,
+      ...unref(options),
     },
+  )
+
+  watch(
+    options,
+    options => Object
+      .entries(options)
+      .forEach(([key, option]) => cm.setOption(key as keyof CodeMirror.EditorConfiguration, option)),
   )
 
   let skip = false

--- a/playground/src/components/Editor.vue
+++ b/playground/src/components/Editor.vue
@@ -4,7 +4,7 @@ import parserCSS from 'prettier/parser-postcss'
 // @ts-expect-error missing types
 import { Pane, Splitpanes } from 'splitpanes'
 import { isDark } from '../logics/dark'
-import { customConfigError, customConfigRaw, getHint, inputHTML, output } from '../logics/uno'
+import { customConfigError, customConfigRaw, getHint, inputHTML, output, transformedHTML } from '../logics/uno'
 import { defaultConfigRaw, defaultHTML } from '../defaults'
 import { options } from '../logics/url'
 import { version } from '../../../package.json'
@@ -104,6 +104,10 @@ onMounted(() => {
           <input v-model="options.strict" type="checkbox">
           Strict
         </label>
+        <label>
+          <input v-model="options.transform" type="checkbox">
+          Transform
+        </label>
         <div flex-auto />
         <div text-sm op50>
           v{{ version }}
@@ -122,12 +126,14 @@ onMounted(() => {
         />
       </TitleBar>
       <CodeMirror
-        v-model="inputHTML"
         flex-auto
         mode="htmlmixed"
         class="scrolls border-(l gray-400/20)"
         :matched="output?.matched || new Set()"
         :get-hint="getHint"
+        :read-only="options.transform"
+        :model-value="options.transform ? transformedHTML : inputHTML"
+        @update:model-value="inputHTML = $event"
       />
     </Pane>
     <Pane :min-size="titleHeightPercent" :size="panelSizes[1]" flex flex-col>

--- a/playground/src/logics/url.ts
+++ b/playground/src/logics/url.ts
@@ -7,7 +7,7 @@ const params = new URLSearchParams(window.location.search || localStorage.getIte
 
 export const customConfigRaw = ref(decode(params.get('config') || '') || defaultConfigRaw)
 export const inputHTML = ref(decode(params.get('html') || '') || defaultHTML)
-export const options = ref<{ strict?: boolean }>(JSON.parse(decode(params.get('options') || '') || defaultOptions))
+export const options = ref<{ strict?: boolean; transform?: boolean }>(JSON.parse(decode(params.get('options') || '') || defaultOptions))
 
 throttledWatch(
   [customConfigRaw, inputHTML, options],

--- a/test/variant-group.test.ts
+++ b/test/variant-group.test.ts
@@ -13,7 +13,11 @@ describe('variant-group', () => {
     expect(expandVariantGroup('b:c:d:(!a z)')).toEqual('!b:c:d:a b:c:d:z')
   })
 
-  test('dash seperator', async() => {
+  test('dash separator', async() => {
     expect(expandVariantGroup('a-(b c) c-(a:b d)')).toEqual('a-b a-c c-a:b c-d')
+  })
+
+  test('tilde symbol', () => {
+    expect(expandVariantGroup('a-(~ b c)')).toEqual('a a-b a-c')
   })
 })


### PR DESCRIPTION
- added support for the tilde syntax in attributify mode to variant groups 
before: 
<img width="625" alt="image" src="https://user-images.githubusercontent.com/52692296/162117085-e692a5e1-8784-4b97-8ff0-ed801bb70a9d.png">
after:
<img width="612" alt="image" src="https://user-images.githubusercontent.com/52692296/162117119-31ccb069-bb86-4d91-98bf-e89771a18137.png">
- playground: show transformed code
<img width="940" alt="image" src="https://user-images.githubusercontent.com/52692296/162117224-d8811a7d-3f9a-47d1-b716-ce58ae52c7ae.png">
- reactified CodeMirror options to allow toggling read-only mode
