### PR TITLE
feat(variantGroup): transform index.html

### DIFF
--- a/packages/vite/src/transformers.ts
+++ b/packages/vite/src/transformers.ts
@@ -34,6 +34,10 @@ export function initTransformerPlugins(ctx: UnocssPluginContext): Plugin[] {
       transform(code, id) {
         return applyTransformers(code, id)
       },
+      transformIndexHtml(code) {
+        return applyTransformers(code, 'index.html')
+          .then(t => t?.code)
+      },
     },
     {
       name: 'unocss:transformers:pre',
@@ -41,12 +45,20 @@ export function initTransformerPlugins(ctx: UnocssPluginContext): Plugin[] {
       transform(code, id) {
         return applyTransformers(code, id, 'pre')
       },
+      transformIndexHtml(code) {
+        return applyTransformers(code, 'index.html', 'pre')
+          .then(t => t?.code)
+      },
     },
     {
       name: 'unocss:transformers:post',
       enforce: 'post',
       transform(code, id) {
         return applyTransformers(code, id, 'post')
+      },
+      transformIndexHtml(code) {
+        applyTransformers(code, 'index.html', 'post')
+          .then(t => t?.code)
       },
     },
   ]


### PR DESCRIPTION
With this PR, you should be able to use variant groups in index.html. But apparently, you would still have to explicitly include `.html` files in your unocss config. perhaps `.html` files should be included by default?