### PR TITLE
fix(docs): Renamed escape to escapeSelector in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ When you really need some advanced rules that can't be covered by the combinatio
 By returning a `string` from the dynamic rule's body function, it will be directly passed to the generated CSS. That also means you would need to take care of things like CSS escaping, variants applying, CSS constructing, and so on.
 
 ```ts
-import Unocss, { escape as e } from 'unocss'
+import Unocss, { escapeSelector as e } from 'unocss'
 
 Unocss({
   rules: [


### PR DESCRIPTION
I am not sure if this PR fixes the error or not. I am playing around with the Playground and I got an error (see console):
[Playground with error](https://unocss.antfu.me/?html=DwEwlgbgBAFgtAMwK4BsVQC4FMAeG4DGWAdtgE5QIq5QDOW1B%2BxA9sVlAIZoBcGZnYrTAYwbOABYADFIB8AKChRQkKAFtOCpUpXRseOAFYc6BAHcAjDK7EwG7IRZJScMMQRuRHQXc4OLtFraSs4sBLS0itrAAPTgEEE68VAsAA4AzFKYuPgoAOaUZplZahaJ2gAqMBxutBiCGCnEcCBYGsQgUACCGCxqYARQAMIAyiNQJHluWAB0UTpxkOW66gBMlNQ4UABWSHVgCACehCTk2QarJikZWTAsEFhkALwARGkAHFIv5Tqc88FQMCEThkABG4hQLDyLDgUwwMCQoP%2BwX0%2BDc1TIImR2hgZCwCFeMAwGFStB4MRicIRoJmBD6MVC4VoDNYTJe2KU9TIeSwGFeAH1QShBABrdkAqCyWKaf6xeJBOVLeSKhLKljoUjwdJ8HJwIVIDiauDa0F5PUoA1cWggOAWKB44WiB5QOC9VJwVZZKg0Xb7I4nUiPKB5TjunCSBUoMCyACS2DUUAssSjkejcbaUFWyejUWAKfTCfS2YUsXVsiAA&config=JYWwDg9gTgLgBAbzgEwKYDNgDtUGEJaYDmANHKgM4DGAhmKnAL5zpQQhwDkArlhFRQqcAUMNQAPSLBQYa3ADbw0mHPkLAiACgTC4cKAsoAuOAG1deswHoAelhgALADoBaTU%2BQBqAJROjmgDoAKm8AEisyGgoATywqOE1TMmQyKABdMgQoGgB3AGVUeVQqGGgyKgIKGAMS3Dy8siJUHGzSqEZvOABeAD5EOAtLOCsrUwAibPzC4raxkjGqbigoZpgCopLoObHHVBBUbaaWmln5gDcaKGAaewAJG%2BQiqAptiqwqmpg6vO2Lq5uYABZE5UBxjNKDSxvKr6QzdOC5GjAeCaI6oVrQAJgS4UVAAFQgAGtmpooN5vJC9CsYEssHAAAYBUIISi0eik3LrGbQbzMPpBIz2BwuUHAeTITTM5AdExIZkGIqmAAMaVMACY0sxGPTIYwMhYIR0gA&options=N4IgzgLgTglgxhEAuaBXApgXyA)

which is the code in the [`README.md#full-controlled-rules`](https://github.com/unocss/unocss#full-controlled-rules)

If I change:

```js
import { defineConfig, escape } from 'unocss'
```

to

```js
import { defineConfig, escapeSelector } from 'unocss'
```

I don't see the error anymore. See [correct Playground](https://unocss.antfu.me/?html=DwEwlgbgBAFgtAMwK4BsVQC4FMAeG4DGWAdtgE5QIq5QDOW1B%2BxA9sVlAIZoBcGZnYrTAYwbOABYADFIB8AKChRQkKAFtOCpUpXRseOAFYc6BAHcAjDK7EwG7IRZJScMMQRuRHQXc4OLtFraSs4sBLS0itrAAPTgEEE68VAsAA4AzFKYuPgoAOaUZplZahaJ2gAqMBxutBiCGCnEcCBYGsQgUACCGCxqYARQAMIAyiNQJHluWAB0UTpxkOW66gBMlNQ4UABWSHVgCACehCTk2QarJikZWTAsEFhkALwARGkAHFIv5Tqc88FQMCEThkABG4hQLDyLDgUwwMCQoP%2BwX0%2BDc1TIImR2hgZCwCFeMAwGFStB4MRicIRoJmBD6MVC4VoDNYTJe2KU9TIeSwGFeAH1QShBABrdkAqCyWKaf6xeJBOVLeSKhLKljoUjwdJ8HJwIVIDiauDa0F5PUoA1cWggOAWKB44WiB5QOC9VJwVZZKg0Xb7I4nUiPKB5TjunCSBUoMCyACS2DUUAssSjkejcbaUFWyejUWAKfTCfS2YUsXVsiAA&config=JYWwDg9gTgLgBAbzgEwKYDNgDtUGEJaYDmANHKgM4DGAhmKgMqoA2qVM0cAvnOlBCDgByAK5YIVChSEAoGagAekWCgw0RzeGkw58hYEQAUCGXDhQNlAFxwA2qbN2A9AD0sMABYAdALSGvyADUAJReVoYAdABUwQAkTmQ0FACeWFRwhrZkyGRQALpkCFA0AO5MrOzQZFQEFDAW7LgMDGREqDjFHFBcwXAAvAB8iHAOjnBOTrYARMVlLGxdUyRTVCJQUO0w5QvQS1OeqCCoe20dNIvLAG40UMA07gAS98isUBR7NVh1DTBNDHvXW73GAAWXOVA8Uzyo0cnzq5ks-TgpRowHghlOqE60AiYBuFFQABUIABrdqGKDBYIwswbGBrLBwAAGEViCEotHo20qUAppW5XWCPCGUSs7g8PghwGYyEMbOQPRsSDZFlYtgADHlbAAmPI8LhMmFcAoOaE9IA&options=N4IgzgLgTglgxhEAuaBXApgXyA)

