### PR TITLE
refactor(cli): migrate bin to ESM

### DIFF
--- a/packages/cli/bin/unocss.cjs
+++ b/packages/cli/bin/unocss.cjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('../dist/cli.cjs')

--- a/packages/cli/bin/unocss.mjs
+++ b/packages/cli/bin/unocss.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+'use strict'
+import('../dist/index.mjs')

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,15 +19,21 @@
     "directory": "packages/cli"
   },
   "funding": "https://github.com/sponsors/antfu",
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "exports": "./dist/index.cjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "bin",
     "dist"
   ],
   "bin": {
-    "unocss": "./bin/unocss.cjs"
+    "unocss": "./bin/unocss.mjs"
   },
   "scripts": {
     "build": "unbuild",


### PR DESCRIPTION
This is a proposal. I think by now it's safe to use ESM, since the latest LTS version is 16+ anyway.