### PR TITLE
refactor(cli): no need to emit CJS dist files

### DIFF
--- a/packages/cli/build.config.ts
+++ b/packages/cli/build.config.ts
@@ -7,7 +7,4 @@ export default defineBuildConfig({
   ],
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-  },
 })


### PR DESCRIPTION
Forgot to remove the now unneeded `unbuild` config lines.