### PR TITLE
fix(attributify): add support for boolean attributes

### DIFF
--- a/packages/preset-attributify/src/jsx.ts
+++ b/packages/preset-attributify/src/jsx.ts
@@ -66,4 +66,4 @@ export type AttributifyNames<Prefix extends string = ''> =
   | `${Prefix}${VariantNames}`
   | `${Prefix}${VariantNames}:${UtilityNames}`
 
-export interface AttributifyAttributes extends Partial<Record<AttributifyNames, string>> {}
+export interface AttributifyAttributes extends Partial<Record<AttributifyNames, string | boolean>> {}


### PR DESCRIPTION
Solves #867.

Although it works perfectly with SolidJS, it might not work with other frameworks (the change doesn't seem to be breaking though). Definitely needs a review.