### PR TITLE
fix(preset-mini): fix first-line-x and first-letter-x pseudo

### DIFF
--- a/packages/preset-mini/src/variants/default.ts
+++ b/packages/preset-mini/src/variants/default.ts
@@ -7,7 +7,7 @@ import { variantColorsMediaOrClass } from './dark'
 import { variantLanguageDirections } from './directions'
 import { variantImportant, variantLayer, variantNegative, variantScope, variantSelector } from './misc'
 import { variantCustomMedia, variantPrint } from './media'
-import { partClasses, variantPseudoClassFunctions, variantPseudoClasses, variantPseudoElements, variantTaggedPseudoClasses } from './pseudo'
+import { partClasses, variantPseudoClassFunctions, variantPseudoClassesAndElements, variantTaggedPseudoClasses } from './pseudo'
 
 export const variants = (options: PresetMiniOptions): Variant<Theme>[] => [
   variantSelector,
@@ -18,10 +18,11 @@ export const variants = (options: PresetMiniOptions): Variant<Theme>[] => [
   variantCustomMedia,
   variantBreakpoints,
   ...variantCombinators,
-  variantPseudoClasses,
+
+  variantPseudoClassesAndElements,
   variantPseudoClassFunctions,
   ...variantTaggedPseudoClasses(options),
-  variantPseudoElements,
+
   partClasses,
   ...variantColorsMediaOrClass(options),
   ...variantLanguageDirections,

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -107,6 +107,8 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .bg-teal-400\\\\/\\\\[\\\\.55\\\\]{background-color:rgba(45,212,191,.55);}
 .bg-teal-500\\\\/\\\\[55\\\\%\\\\]{background-color:rgba(20,184,166,55%);}
 .file\\\\:bg-violet-50::file-selector-button{--un-bg-opacity:1;background-color:rgba(245,243,255,var(--un-bg-opacity));}
+.first-letter\\\\:bg-green-400::first,
+.first-line\\\\:bg-green-400::first{--un-bg-opacity:1;background-color:rgba(74,222,128,var(--un-bg-opacity));}
 .focus-within\\\\:has-first\\\\:checked\\\\:bg-gray\\\\/20:focus-within:has(:first-child):checked,
 .focus-within\\\\:where-first\\\\:checked\\\\:bg-gray\\\\/20:focus-within:where(:first-child):checked{background-color:rgba(156,163,175,0.2);}
 .hover\\\\:file\\\\:bg-violet-100:hover::file-selector-button{--un-bg-opacity:1;background-color:rgba(237,233,254,var(--un-bg-opacity));}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -743,6 +743,8 @@ export const presetMiniTargets: string[] = [
   'at-sm:m1',
   'disabled:op50',
   'first:p-2',
+  'first-line:bg-green-400',
+  'first-letter:bg-green-400',
   'group-hover:group-focus:text-center',
   'hover:!p-1',
   'hover:not-first:checked:bg-red/10',

--- a/test/autocomplete.test.ts
+++ b/test/autocomplete.test.ts
@@ -112,7 +112,7 @@ describe('autocomplete', () => {
         "origin-": "origin-b origin-bc origin-bl origin-bottom origin-bottom-center origin-bottom-left origin-bottom-right origin-br origin-c origin-cb",
         "outline-": "outline-amber outline-auto outline-black outline-blue outline-bluegray outline-blueGray outline-coolgray outline-coolGray outline-current outline-cyan",
         "outline-offset-": "outline-offset-0 outline-offset-1 outline-offset-2 outline-offset-3 outline-offset-4 outline-offset-5 outline-offset-6 outline-offset-8 outline-offset-10 outline-offset-12",
-        "placeholder-": "placeholder-.dark: placeholder-.light: placeholder-@dark: placeholder-@light: placeholder-active: placeholder-animate-delay placeholder-animate-direction placeholder-animate-duration placeholder-animate-none placeholder-antialiased",
+        "placeholder-": "placeholder-.dark: placeholder-.light: placeholder-@dark: placeholder-@light: placeholder-active: placeholder-after: placeholder-animate-delay placeholder-animate-direction placeholder-animate-duration placeholder-animate-none",
         "scroll-": "scroll-auto scroll-block scroll-inline scroll-m scroll-ma scroll-p scroll-pa scroll-smooth",
         "scroll-m-": "scroll-m-2xl scroll-m-3xl scroll-m-4xl scroll-m-5xl scroll-m-6xl scroll-m-7xl scroll-m-8xl scroll-m-9xl scroll-m-b scroll-m-be",
         "shadow-": "shadow-2xl shadow-amber shadow-black shadow-blue shadow-bluegray shadow-blueGray shadow-coolgray shadow-coolGray shadow-current shadow-cyan",

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -44,7 +44,6 @@ const targets2 = [
 
 const nonTargets = [
   '--p-2',
-  'before:before:m2',
   'hi',
   'row-{row.id}',
   'tabs',


### PR DESCRIPTION
Fix `first-line-x` and `first-letter-x` pseudo elements shadowed by `first-x` pseudo class utility, 

Note that combining pseudo class & pseudo elements now allows multiple pseudo elements. Using `before:before:m2` thus generate `.m2::before::before`

Closes #885