### PR TITLE
docs: fix display width

### DIFF
--- a/interactive/app.vue
+++ b/interactive/app.vue
@@ -13,7 +13,7 @@ useHead({
 </script>
 
 <template>
-  <main class="pt2 text-center font-sans" w-100% h-screen of-hidden relative>
+  <main class="pt2 text-center font-sans" w-full h-screen of-hidden relative>
     <NuxtPage />
   </main>
 </template>

--- a/interactive/app.vue
+++ b/interactive/app.vue
@@ -13,7 +13,7 @@ useHead({
 </script>
 
 <template>
-  <main class="pt2 text-center font-sans" w-screen h-screen of-hidden relative>
+  <main class="pt2 text-center font-sans" w-100% h-screen of-hidden relative>
     <NuxtPage />
   </main>
 </template>


### PR DESCRIPTION
###  The documentation was incredible, but I found a small bug .when there is an scroll-y, using a width of 100vw will produce an scroll-x 

![image](https://user-images.githubusercontent.com/73213399/165962042-5a5075d7-0ba2-49fe-b8fd-e4fe2de6d528.png)

### old:
![image](https://user-images.githubusercontent.com/73213399/165962586-5c48916d-b994-4e05-a8ef-c9ce8b715787.png)

### now:
![image](https://user-images.githubusercontent.com/73213399/165962452-759a7bac-d64b-414b-b957-366e9611d53e.png)
