### PR TITLE
feat(interactive): add a11y and SEO improvements

### DIFF
--- a/interactive/app.vue
+++ b/interactive/app.vue
@@ -3,6 +3,13 @@ import './markdown.css'
 
 useHead({
   title: 'UnoCSS Interactive Docs',
+  htmlAttrs: [
+    { lang: 'en-US' },
+  ],
+  meta: [{
+    name: 'description',
+    content: 'Interactive documentation for UnoCSS',
+  }],
   link: [
     { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
     { rel: 'search', type: 'application/opensearchdescription+xml', href: '/search.xml', title: 'UnoCSS' },

--- a/interactive/app.vue
+++ b/interactive/app.vue
@@ -8,7 +8,7 @@ useHead({
   ],
   meta: [{
     name: 'description',
-    content: 'Interactive documentation for UnoCSS',
+    content: 'UnoCSS Interactive Docs',
   }],
   link: [
     { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },

--- a/interactive/components/DarkToggle.vue
+++ b/interactive/components/DarkToggle.vue
@@ -5,7 +5,7 @@ function toggleDark() {
 </script>
 
 <template>
-  <button class="!outline-none" @click="toggleDark">
-    <div class="dark:i-carbon-moon i-carbon-sun" />
+  <button class="!outline-none" :aria-label="isDark ? 'Switch to light theme' : 'Switch to dark theme'" @click="toggleDark">
+    <span class="dark:i-carbon-moon i-carbon-sun block" aria-hidden="true" />
   </button>
 </template>

--- a/interactive/components/Search.vue
+++ b/interactive/components/Search.vue
@@ -36,6 +36,7 @@ useEventListener('keydown', (e) => {
 
 function clear() {
   router.push({ query: { s: '' } })
+  nextTick().then(() => inputEl?.focus())
 }
 
 function openItem(item: ResultItem) {
@@ -58,6 +59,9 @@ function selectItem(item: ResultItem) {
     openItem(item)
   }
 }
+const vFocus = {
+  mounted: (el: HTMLElement) => el.focus(),
+}
 </script>
 
 <template>
@@ -67,20 +71,23 @@ function selectItem(item: ResultItem) {
       <input
         ref="inputEl"
         v-model="input"
+        v-focus
+        aria-label="Type to explore"
         placeholder="Type to explore..."
         type="text"
-        autocomplete="off"
-        w="full" p="x6 y4"
-        border-none bg-transparent
-        text-2xl font-200
+        autocomplete="off" w="full"
+        p="x6 y4" border-none
+        bg-transparent text-2xl
+        font-200
         outline="none active:none"
       >
       <button
         v-if="input"
         absolute flex right-2 w-10 top-2 bottom-2 text-xl op30 hover:op90
+        aria-label="Clear search"
         @click="clear()"
       >
-        <div i-carbon-close ma />
+        <span i-carbon-close ma block aria-hidden="true" />
       </button>
     </div>
     <div v-if="searchResult.length || isSearching" border="l b r base" mx2 of-auto>
@@ -95,7 +102,7 @@ function selectItem(item: ResultItem) {
         </ItemBase>
         <div divider />
       </template>
-      <template v-for="i, idx of searchResult" :key="idx">
+      <template v-for="(i, idx) of searchResult" :key="idx">
         <ResultItem
           :item="i"
           :active="selectIndex === idx"
@@ -110,8 +117,8 @@ function selectItem(item: ResultItem) {
         No result found
       </div>
       <div row justify-center>
-        <button btn @click="input = ''">
-          Clear
+        <button btn @click="clear()">
+          Clear search
         </button>
       </div>
     </div>

--- a/interactive/components/TheNav.vue
+++ b/interactive/components/TheNav.vue
@@ -6,12 +6,12 @@ import { isCompact, toggleCompact, uno } from '~/composables/state'
   <div row text-left py4 pr1 items-center>
     <RouterLink to="/">
       <h1>
-        <div op50 font-200 leading-1em>
+        <span op50 font-200 leading-1em block>
           UnoCSS
-        </div>
-        <div font-400 text-lg leading-1em>
+        </span>
+        <span font-400 text-lg leading-1em block>
           Interactive
-        </div>
+        </span>
       </h1>
     </RouterLink>
     <div text-xs op-30 ml-2 self-end leading-12px>
@@ -19,8 +19,12 @@ import { isCompact, toggleCompact, uno } from '~/composables/state'
     </div>
     <div flex-auto />
     <div row gap4 text="lg gray4" items-center>
-      <button :class="isCompact ? 'i-carbon-list': 'i-carbon-list-boxes'" @click="toggleCompact()" />
-      <a i-carbon-logo-github href="https://github.com/unocss/unocss" target="_blank" />
+      <button
+        :class="isCompact ? 'i-carbon-list': 'i-carbon-list-boxes'"
+        :aria-label="isCompact ? 'Show results entries dense' : 'Show results entries normal'"
+        @click="toggleCompact()"
+      />
+      <a i-carbon-logo-github href="https://github.com/unocss/unocss" target="_blank" aria-label="GitHub" />
       <DarkToggle />
     </div>
   </div>

--- a/interactive/public/robots.txt
+++ b/interactive/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/interactive/scripts/prepare.ts
+++ b/interactive/scripts/prepare.ts
@@ -5,15 +5,18 @@ import YAML from 'js-yaml'
 import { genArrayFromRaw, genObjectFromRaw } from 'knitwork'
 import { objectMap } from '@antfu/utils'
 
+const dereference = process.platform === 'win32' ? true : undefined
+
 const { copyFile, copy, writeFileSync } = fs
 
 await fs.ensureDir('guides/vendor/')
 
 await copy('node_modules/shiki/', 'public/shiki/', {
+  dereference,
   filter: src => src === 'node_modules/shiki/' || src.includes('languages') || src.includes('dist'),
 })
-await copy('node_modules/theme-vitesse/themes', 'public/shiki/themes')
-await copy('node_modules/theme-vitesse/themes', 'node_modules/shiki/themes', { overwrite: true })
+await copy('node_modules/theme-vitesse/themes', 'public/shiki/themes', { dereference })
+await copy('node_modules/theme-vitesse/themes', 'node_modules/shiki/themes', { overwrite: true, dereference })
 
 await Promise.all([
   copyFile('../README.md', 'guides/vendor/intro.md'),


### PR DESCRIPTION
This PR fixes some a11y and SEO problems:
- added `robots.txt`
- fix buttons without text
- fix links without description
- fix wrong nested html elements
- added lang and description to html
- focus search input on load: also focus it once clear buttons clicked

Before merging this PR, please check the following change to `prepare.ts` module: we cannot copy symliks on Windows, so I've added `dereference: true` to all `fs.copy` options but only for Windows, I've configured this option as `undefined` for non Windows environments.

Before applying this PR:

![Captura de pantalla 2022-04-29 170510](https://user-images.githubusercontent.com/6311119/165973404-a0dff67f-8503-4880-8878-da98c00bb8dc.png)

and on local with changes applied:

![Captura de pantalla 2022-04-29 170530](https://user-images.githubusercontent.com/6311119/165973440-0c36af95-fc0a-4441-ad63-97e39a1a3e7c.png)

