### PR TITLE
docs: update all readme licenses and licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Anthony Fu <https://github.com/antfu>
+Copyright (c) 2021-PRESENT Anthony Fu <https://github.com/antfu>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -635,4 +635,4 @@ See [@unocss/runtime](https://github.com/unocss/unocss/tree/main/packages/runtim
 
 ## License
 
-[MIT](./LICENSE) License © 2021 [Anthony Fu](https://github.com/antfu)
+[MIT](./LICENSE) License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/autocomplete/README.md
+++ b/packages/autocomplete/README.md
@@ -70,4 +70,4 @@ For multiple templates
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2021 Anthony Fu <https://github.com/antfu>
-Copyright (c) 2021 Johann Schopplich <https://github.com/johannschopplich>
+Copyright (c) 2021-PRESENT Anthony Fu <https://github.com/antfu>
+Copyright (c) 2021-PRESENT Johann Schopplich <https://github.com/johannschopplich>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -98,6 +98,6 @@ Indicates if the files found by the glob pattern should be watched.
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)
 
-MIT License © 2021-PRESENT [Johann Schopplich](https://github.com/johannschopplich)
+MIT License &copy; 2021-PRESENT [Johann Schopplich](https://github.com/johannschopplich)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -14,5 +14,5 @@ const { css } = await generator.generate(code)
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)
 

--- a/packages/extractor-pug/README.md
+++ b/packages/extractor-pug/README.md
@@ -22,4 +22,4 @@ Unocss({
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/inspector/README.md
+++ b/packages/inspector/README.md
@@ -24,4 +24,4 @@ Visit `http://localhost:3000/__unocss` in your Vite dev server to see the inspec
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -53,4 +53,4 @@ export default {
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/preset-attributify/README.md
+++ b/packages/preset-attributify/README.md
@@ -117,4 +117,4 @@ Initial idea by [@Tahul](https://github.com/Tahul) and [@antfu](https://github.c
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/preset-icons/README.md
+++ b/packages/preset-icons/README.md
@@ -290,4 +290,4 @@ This preset is inspired from [this issue](https://github.com/antfu/unplugin-icon
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/preset-mini/README.md
+++ b/packages/preset-mini/README.md
@@ -20,4 +20,4 @@ Unocss({
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/preset-typography/LICENSE
+++ b/packages/preset-typography/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Jeff Yang
+Copyright (c) 2021-PRESENT Jeff Yang
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/preset-uno/README.md
+++ b/packages/preset-uno/README.md
@@ -37,4 +37,4 @@ For more details about the default preset, you can check out our [playground](ht
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/preset-web-fonts/README.md
+++ b/packages/preset-web-fonts/README.md
@@ -79,4 +79,4 @@ Refer to the [type definition](https://github.com/unocss/unocss/blob/main/packag
 
 ## License
 
-MIT License © 2022-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2022-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/preset-wind/README.md
+++ b/packages/preset-wind/README.md
@@ -20,4 +20,4 @@ Unocss({
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -103,4 +103,4 @@ Use `un-cloak` attribute with CSS rules such as `[un-cloak] { display: none }` t
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/transformer-directives/LICENSE
+++ b/packages/transformer-directives/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 hannoeru
+Copyright (c) 2022-PRESENT hannoeru
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/transformer-variant-group/README.md
+++ b/packages/transformer-variant-group/README.md
@@ -33,4 +33,4 @@ Will be transformed to:
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -423,4 +423,4 @@ You have a `Vite + Elm` example project on [examples/vite-elm](https://github.co
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -32,6 +32,6 @@ By default the extension will search for the config files under project root. Wh
 
 ## License
 
-MIT License © 2021-PRESENT [Anthony Fu](https://github.com/antfu)
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)
 
 

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -24,3 +24,7 @@ module.exports = {
 ```
 
 Or you can have the config file in `unocss.config.js` or `unocss.config.ts`.
+
+## License
+
+MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)


### PR DESCRIPTION
This PR includes: 
- updates all licences to use a common layout:
```txt
MIT License &copy; 20XY-PRESENT [name/gh_username](https://github.com/gh_username)
```
- updates all `LICENSE` files to include `-PRESENT` as the year suffix
- added webpack license on package README