### PR TITLE
chore(webpack): convert to left slash

### DIFF
--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -104,7 +104,7 @@ export default function WebpackPlugin(
       const result = await uno.generate(tokens)
       Array.from(plugin.__vfsModules)
         .forEach((id) => {
-          const path = id.slice(plugin.__virtualModulePrefix.length)
+          const path = id.slice(plugin.__virtualModulePrefix.length).replace(/\\/g, '/')
           const layer = entries.get(path)
           if (!layer)
             return


### PR DESCRIPTION
Used in webpack, the slash seems alwas **to right**, but **entries**'s slash key alway **to left**, so **layer**'s value always null here

![image](https://user-images.githubusercontent.com/11707934/167219402-e63d91df-8566-4f86-bff5-ca615c261e53.png)


https://github.com/unocss/unocss/blob/0f24d04eca3e45aac75f8a2c5d4ac980824a7803/packages/webpack/src/index.ts#L104-L116