### PR TITLE
feat(reset): update from tailwind reset

### DIFF
--- a/packages/reset/tailwind.css
+++ b/packages/reset/tailwind.css
@@ -155,6 +155,7 @@ select,
 textarea {
   font-family: inherit; /* 1 */
   font-size: 100%; /* 1 */
+  font-weight: inherit; /* 1 */
   line-height: inherit; /* 1 */
   color: inherit; /* 1 */
   margin: 0; /* 2 */

--- a/packages/reset/tailwind.css
+++ b/packages/reset/tailwind.css
@@ -353,7 +353,3 @@ video {
   max-width: 100%;
   height: auto;
 }
-
-.dark {
-  color-scheme: dark;
-}

--- a/packages/reset/tailwind.css
+++ b/packages/reset/tailwind.css
@@ -354,14 +354,6 @@ video {
   height: auto;
 }
 
-/*
-Ensure the default browser behavior of the `hidden` attribute.
-*/
-
-[hidden] {
-  display: none;
-}
-
 .dark {
   color-scheme: dark;
 }


### PR DESCRIPTION
I just noticed there's new flex reset here. Should the `.dark` block be removed in the tailwind reset?