### PR TITLE
feat: support webpack hmr

### DIFF
--- a/examples/vue-cli/vue.config.js
+++ b/examples/vue-cli/vue.config.js
@@ -9,5 +9,8 @@ module.exports = {
   chainWebpack(config) {
     config.module.rule('vue').uses.delete('cache-loader')
     config.module.rule('tsx').uses.delete('cache-loader')
+    config.merge({
+      cache: false,
+    })
   },
 }

--- a/packages/shared-integration/src/layers.ts
+++ b/packages/shared-integration/src/layers.ts
@@ -27,7 +27,7 @@ export function getLayerPlaceholder(layer: string) {
   return `#--unocss--{layer:${layer}}`
 }
 
-export const HASH_PLACEHOLDER_RE = /#--unocss-hash--\s*{\s*content\s*:\s*"(.+?)";?\s*}/g
+export const HASH_PLACEHOLDER_RE = /#--unocss-hash--\s*{\s*content\s*:\s*\\*"(.+?)\\*";?\s*}/g
 export function getHashPlaceholder(hash: string) {
   return `#--unocss-hash--{content:"${hash}"}`
 }


### PR DESCRIPTION
webpack hmr not works because of the css placeholder text is not changed, this pr added the content hash value to prepend the layer placeholder.

because the webpack source code string escapes the double quotes, hash content regx needs add `\\` to match the code

In webpack v5, need set `cache: false`, I don't know if there is any other better way, a small problem is that sometimes you need to typing `Ctrl + S` twice


