### PR TITLE
feat(vscode): support loading from iles.config file

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -17,7 +17,7 @@
 ## Features
 
 - Decoration and tooltip for matched utilities
-- Loading configs from `uno.config.js`, `vite.config.js` or `nuxt.config.js`
+- Loading configs from `uno.config.js`, `vite.config.js`, `svelte.config.js`, `astro.config.js`, `iles.config.js` or `nuxt.config.js`
 - Count of matched utilities
 
 ## Config

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -28,6 +28,7 @@ export async function activate(ext: ExtensionContext) {
           'vite.config',
           'svelte.config',
           'astro.config',
+          'iles.config',
         ],
         targetModule: 'unocss/vite',
         parameters: [{ command: 'serve', mode: 'development' }],


### PR DESCRIPTION
Since I'm using the wonderful [iles](https://iles.pages.dev/) static site generator and unocss vscode extension did not support loading from the `iles.config.ts` (or js) file, this PR solves it since the format for the vite configuration is the same as other config files (a `vite` property).

For the extension to work correctly, I did have to explicitly defines the presets to use, without it, it did not find utilities, maybe the default preset is not applied 🤔