### PR TITLE
fix(vite): emit better warning in build

### DIFF
--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -119,8 +119,11 @@ export function GlobalModeBuildPlugin({ uno, ready, extract, tokens, modules, fi
       enforce: 'post',
       // rewrite the css placeholders
       async generateBundle(_, bundle) {
-        if (!vfsLayerMap.size)
+        if (!vfsLayerMap.size) {
+          const msg = '[unocss] entry module not found, have you add `import \'uno.css\'` in your main entry?'
+          this.warn(msg)
           return
+        }
 
         const files = Object.keys(bundle)
         const cssFiles = files

--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -119,6 +119,9 @@ export function GlobalModeBuildPlugin({ uno, ready, extract, tokens, modules, fi
       enforce: 'post',
       // rewrite the css placeholders
       async generateBundle(_, bundle) {
+        if (!vfsLayerMap.size)
+          return
+
         const files = Object.keys(bundle)
         const cssFiles = files
           .filter(i => i.endsWith('.css'))


### PR DESCRIPTION
[unocss:global:build:generate] [unocss] does not found CSS placeholder in the generated chunks,
this is likely an internal bug of unocss vite plugin

If I don't import uno.css, I get this error during the build phase.