### PR TITLE
docs(playground): missing icon preset

### DIFF
--- a/playground/src/logics/config.ts
+++ b/playground/src/logics/config.ts
@@ -1,5 +1,5 @@
 import type { UserConfig } from 'unocss'
-import { createConfig } from '../../unocss.config'
+import { createConfig } from '../../unocss.config.client'
 import { options } from './url'
 
 export const defaultConfig = computed(() =>

--- a/playground/unocss.config.client.ts
+++ b/playground/unocss.config.client.ts
@@ -1,0 +1,25 @@
+import {
+  defineConfig,
+  presetAttributify,
+  presetUno,
+  transformerCompileClass,
+  transformerDirectives,
+  transformerVariantGroup,
+} from 'unocss'
+
+export function createConfig({ strict = true, dev = true } = {}) {
+  return defineConfig({
+    envMode: dev ? 'dev' : 'build',
+    presets: [
+      presetAttributify({ strict }),
+      presetUno(),
+    ],
+    transformers: [
+      transformerVariantGroup(),
+      transformerDirectives(),
+      transformerCompileClass(),
+    ],
+  })
+}
+
+export default createConfig()

--- a/playground/unocss.config.ts
+++ b/playground/unocss.config.ts
@@ -1,6 +1,7 @@
 import {
   defineConfig,
   presetAttributify,
+  presetIcons,
   presetUno,
   transformerCompileClass,
   transformerDirectives,
@@ -19,6 +20,9 @@ export function createConfig({ strict = true, dev = true } = {}) {
     presets: [
       presetAttributify({ strict }),
       presetUno(),
+      presetIcons({
+        scale: 1.2,
+      }),
     ],
     transformers: [
       transformerVariantGroup(),

--- a/playground/unocss.config.ts
+++ b/playground/unocss.config.ts
@@ -8,28 +8,21 @@ import {
   transformerVariantGroup,
 } from 'unocss'
 
-export function createConfig({ strict = true, dev = true } = {}) {
-  return defineConfig({
-    envMode: dev ? 'dev' : 'build',
-    theme: {
-      fontFamily: {
-        sans: '\'Inter\', sans-serif',
-        mono: '\'Fira Code\', monospace',
-      },
+export default defineConfig({
+  theme: {
+    fontFamily: {
+      sans: '\'Inter\', sans-serif',
+      mono: '\'Fira Code\', monospace',
     },
-    presets: [
-      presetAttributify({ strict }),
-      presetUno(),
-      presetIcons({
-        scale: 1.2,
-      }),
-    ],
-    transformers: [
-      transformerVariantGroup(),
-      transformerDirectives(),
-      transformerCompileClass(),
-    ],
-  })
-}
-
-export default createConfig()
+  },
+  presets: [
+    presetAttributify(),
+    presetUno(),
+    presetIcons(),
+  ],
+  transformers: [
+    transformerVariantGroup(),
+    transformerDirectives(),
+    transformerCompileClass(),
+  ],
+})


### PR DESCRIPTION
<img width="381" alt="image" src="https://user-images.githubusercontent.com/42139754/168116705-8d2f716e-b86d-4c3d-a53e-70419e06d450.png">
I thought it was intentional, but found that the `presetIcons` was missing

-----------------------

And: 
<img width="1703" alt="image" src="https://user-images.githubusercontent.com/42139754/168117497-5a2b84cb-09ba-4b0d-8e21-5e25fa20f595.png">

In my local, i don't understand why some properties are missing in the browser, although they are correct when I debug
