### PR TITLE
feat(core): merge safelist presets from config

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -30,7 +30,7 @@ export function resolveConfig(
 
   const layers = Object.assign(defaultLayers, ...rawPresets.map(i => i.layers), userConfig.layers)
 
-  function mergePresets<T extends 'rules' | 'variants' | 'extractors' | 'shortcuts' | 'preflights' | 'preprocess' | 'postprocess' | 'extendTheme'>(key: T): Required<UserConfig>[T] {
+  function mergePresets<T extends 'rules' | 'variants' | 'extractors' | 'shortcuts' | 'preflights' | 'preprocess' | 'postprocess' | 'extendTheme' | 'safelist'>(key: T): Required<UserConfig>[T] {
     return uniq([
       ...sortedPresets.flatMap(p => toArray(p[key] || []) as any[]),
       ...toArray(config[key] || []) as any[],
@@ -73,7 +73,7 @@ export function resolveConfig(
     mergeSelectors: true,
     warn: true,
     blocklist: [],
-    safelist: [],
+    safelist: mergePresets('safelist'),
     sortLayers: layers => layers,
     ...config,
     presets: sortedPresets,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -73,7 +73,6 @@ export function resolveConfig(
     mergeSelectors: true,
     warn: true,
     blocklist: [],
-    safelist: mergePresets('safelist'),
     sortLayers: layers => layers,
     ...config,
     presets: sortedPresets,
@@ -91,5 +90,6 @@ export function resolveConfig(
     variants: mergePresets('variants').map(normalizeVariant),
     shortcuts: resolveShortcuts(mergePresets('shortcuts')),
     extractors,
+    safelist: mergePresets('safelist'),
   }
 }


### PR DESCRIPTION
The main reason is if someone wants to build a UI library / presets on top of unocss we can define the classes that will always be generated

Close #968 