### PR TITLE
fix(vite): infer Theme type from plugin config

### DIFF
--- a/packages/unocss/src/vite.ts
+++ b/packages/unocss/src/vite.ts
@@ -5,7 +5,9 @@ import type { Plugin } from 'vite'
 
 export * from '@unocss/vite'
 
-export default function UnocssVitePlugin(configOrPath?: VitePluginConfig | string): Plugin[] {
+export default function UnocssVitePlugin<Theme extends {}>(
+  configOrPath?: VitePluginConfig<Theme> | string,
+): Plugin[] {
   return VitePlugin(
     configOrPath,
     {


### PR DESCRIPTION
This provides proper typing of the `extendTheme` option while using a preset, for example.