### PR TITLE
perf(preset-attributify): skip extracting if there is no any valid element

### DIFF
--- a/packages/preset-attributify/src/extractor.ts
+++ b/packages/preset-attributify/src/extractor.ts
@@ -19,6 +19,8 @@ export const extractorAttributify = (options?: AttributifyOptions): Extractor =>
   return {
     name: 'attributify',
     extract({ code }) {
+      if (!code.includes('>'))
+        return
       const result = Array.from(code.matchAll(elementRE))
         .flatMap(match => Array.from((match[1] || '').matchAll(valuedAttributeRE)))
         .flatMap(([, name, _, content]) => {

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -192,4 +192,11 @@ describe('attributify', () => {
     `)
     expect(css).toMatchSnapshot()
   })
+
+  test('with incomplete element', async () => {
+    const start = Date.now()
+    await uno.generate('<div class="w-fullllllllllllll"')
+    const end = Date.now()
+    expect(end - start).toBeLessThan(100)
+  })
 })


### PR DESCRIPTION
Fixes #804 

I tried using Vitest's timeout feature (passing timeout as the third argument), but it didn't work for some reason.