### PR TITLE
refactor(preset-attributify): simplify element regex

### DIFF
--- a/packages/preset-attributify/src/extractor.ts
+++ b/packages/preset-attributify/src/extractor.ts
@@ -8,7 +8,7 @@ const strippedPrefixes = [
 ]
 
 const splitterRE = /[\s'"`;]+/g
-const elementRE = /<\w[\w:\.$-]*\s((?:'[\s\S]*?'|"[\s\S]*?"|`[\s\S]*?`|\{[\s\S]*?\}|[\s\S]*?)*?)>/g
+const elementRE = /<\w(?=.*>)[\w:\.$-]*\s((?:['"`\{\}].*?['"`\}]|.*?)*?)>/gs
 const valuedAttributeRE = /([?]|(?!\d|-{2}|-\d)[a-zA-Z0-9\u00A0-\uFFFF-_:!%-]+)(?:=(["'])([^\2]*?)\2)?/g
 
 export const extractorAttributify = (options?: AttributifyOptions): Extractor => {
@@ -19,8 +19,6 @@ export const extractorAttributify = (options?: AttributifyOptions): Extractor =>
   return {
     name: 'attributify',
     extract({ code }) {
-      if (!code.includes('>'))
-        return
       const result = Array.from(code.matchAll(elementRE))
         .flatMap(match => Array.from((match[1] || '').matchAll(valuedAttributeRE)))
         .flatMap(([, name, _, content]) => {

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -197,6 +197,6 @@ describe('attributify', () => {
     const start = Date.now()
     await uno.generate('<div class="w-fullllllllllllll"')
     const end = Date.now()
-    expect(end - start).toBeLessThan(100)
+    expect(end - start).toBeLessThan(5)
   })
 })


### PR DESCRIPTION
1. Enabled `/s` flag to reduce usage of `\s\S`
2. #981 moved into regex `(?=.*>)`