### PR TITLE
feat(preset-mini): add `backdrop:x` variant for `::backdrop` pseudo element

### DIFF
--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -408,6 +408,7 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .shadow{--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 var(--un-shadow-color, rgba(0,0,0,0.1)),var(--un-shadow-inset) 0 1px 2px -1px var(--un-shadow-color, rgba(0,0,0,0.1));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-none{--un-shadow:0 0 var(--un-shadow-color, rgba(0,0,0,0));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-xl{--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px var(--un-shadow-color, rgba(0,0,0,0.1)),var(--un-shadow-inset) 0 8px 10px -6px var(--un-shadow-color, rgba(0,0,0,0.1));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.backdrop\\\\:shadow-green::backdrop{--un-shadow-opacity:1;--un-shadow-color:rgba(74,222,128,var(--un-shadow-opacity));}
 .shadow-current{--un-shadow-color:currentColor;}
 .shadow-green-500{--un-shadow-opacity:1;--un-shadow-color:rgba(34,197,94,var(--un-shadow-opacity));}
 .shadow-green-900\\\\/50{--un-shadow-color:rgba(20,83,45,0.5);}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -824,6 +824,7 @@ export const presetMiniTargets: string[] = [
   'marker:bg-violet-200',
   'file:bg-violet-50',
   'hover:file:bg-violet-100',
+  'backdrop:shadow-green',
 
   // variants - pseudo classes
   'rtl:text-right',

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -97,6 +97,9 @@ const nonTargets = [
   'tab-$',
   'ws-$',
 
+  // mini - pseudo colon only
+  'backdrop-shadow-green',
+
   // wind - placeholder
   '$-placeholder-red-200',
 


### PR DESCRIPTION
This variant is only available with colon `:` since using dash `-` conflict with the existing backdrop-filter rules.

Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop
