### PR TITLE
feat(core,presets)!: add slack around layers order value

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -12,7 +12,7 @@ export function resolveShortcuts(shortcuts: UserShortcuts): Shortcut[] {
 
 const defaultLayers = {
   preflights: -100,
-  shortcuts: -1,
+  shortcuts: -10,
   default: 0,
 }
 

--- a/packages/preset-icons/src/index.ts
+++ b/packages/preset-icons/src/index.ts
@@ -74,9 +74,7 @@ export const preset = (options: IconsOptions = {}): Preset => {
     name: '@unocss/preset-icons',
     enforce: 'pre',
     options,
-    layers: {
-      icons: -10,
-    },
+    layers: { icons: -30 },
     rules: [[
       new RegExp(`^${prefix}([a-z0-9:-]+)(?:\\?(mask|bg|auto))?$`),
       async ([full, body, _mode = mode]) => {

--- a/packages/preset-typography/src/index.ts
+++ b/packages/preset-typography/src/index.ts
@@ -65,7 +65,7 @@ export function presetTypography(options?: TypographyOptions): Preset {
   return {
     name: '@unocss/preset-typography',
     enforce: 'post',
-    layers: { typography: -1 },
+    layers: { typography: -20 },
     rules: [
       [
         selectorNameRE,

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -66,9 +66,7 @@ const preset = (options: WebFontsOptions = {}): Preset<any> => {
 
   const preset: Preset<any> = {
     name: '@unocss/preset-web-fonts',
-    layers: {
-      [layerName]: -20,
-    },
+    layers: { [layerName]: -40 },
     preflights: [
       {
         async getCSS() {


### PR DESCRIPTION
Sometimes, some css have to be spliced between the internal layers. Having some space between layers may make it easier to insert another.

Alternatively it becomes ~layer naming creativity~ either carefully naming layer or overriding the order in `layers` option.

Another breaking change which is for users expecting the old layer order.