### PR TITLE
feat(preset-tagify): add excludeTags option

### DIFF
--- a/packages/preset-tagify/src/extractor.ts
+++ b/packages/preset-tagify/src/extractor.ts
@@ -7,6 +7,7 @@ export const htmlTagRE = /<([\w\d-:]+)/g
 export const extractorTagify = (options: TagifyOptions): Extractor => {
   const {
     prefix = '',
+    excludedTags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
   } = options
 
   return {
@@ -14,7 +15,7 @@ export const extractorTagify = (options: TagifyOptions): Extractor => {
     extract({ code }) {
       return new Set(
         Array.from(code.matchAll(htmlTagRE))
-          .filter(({ 1: match }) => match.startsWith(prefix))
+          .filter(({ 1: match }) => match.startsWith(prefix) && !excludedTags.includes(match))
           .map(([, matched]) => `${MARKER}${matched}`),
       )
     },

--- a/packages/preset-tagify/src/types.ts
+++ b/packages/preset-tagify/src/types.ts
@@ -5,6 +5,12 @@ export interface TagifyOptions {
   prefix?: string
 
   /**
+   * Tags excluded from processing.
+   * @default ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+   */
+  excludedTags: string[]
+
+   /**
    * Extra CSS properties to apply to matched rules
    */
   extraProperties?:

--- a/test/preset-tagify.test.ts
+++ b/test/preset-tagify.test.ts
@@ -40,6 +40,7 @@ describe('tagify', () => {
 
     const code = `
       <flex>
+        <h1 class="h2"> excluded heading </h1>
         <text-red> red text </text-red>
         <text-green5:10 />
         <m-1> margin </m-1>
@@ -61,6 +62,7 @@ describe('tagify', () => {
       text-red{--un-text-opacity:1;color:rgba(248,113,113,var(--un-text-opacity));}
       text-green5\\\\:10{color:rgba(34,197,94,0.1);}
       flex{display:flex;}
+      .h2{height:0.5rem;}
       custom-rule{background-color:pink;}"
     `)
   })


### PR DESCRIPTION
This PR adds option to ignore specified tags from being processed. Primarily used for h1-h6.

/cc @zojize If the default values are not ok on the main plugin maybe we'll try them only on runtime.