### PR TITLE
feat: show generated info in watch mode

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,13 +26,11 @@ export async function generate(options: ResolvedCliOptions) {
     await fs.mkdir(dir, { recursive: true })
   await fs.writeFile(outFile, css, 'utf-8')
 
-  if (!options.watch) {
-    consola.success(
-      `${[...matched].length} utilities generated to ${cyan(
-        relative(process.cwd(), outFile),
-      )}\n`,
-    )
-  }
+  consola.success(
+    `${[...matched].length} utilities generated to ${cyan(
+      relative(process.cwd(), outFile),
+    )}\n`,
+  )
 }
 
 export async function resolveOptions(options: CliOptions) {


### PR DESCRIPTION
Seems cleaner than the current output

after changing
<img width="553" alt="2" src="https://user-images.githubusercontent.com/33021497/171417430-9674e556-534f-4f52-a9ff-67f0117c0e09.png">

before changing
<img width="553" alt="1" src="https://user-images.githubusercontent.com/33021497/171417447-efb81e68-6b09-4caf-9b4c-5e93047ff495.png">