### PR TITLE
feat: add defaultUnocssConfig to webpack plugin and unocss vscode extension

### DIFF
--- a/packages/shared-integration/package.json
+++ b/packages/shared-integration/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@unocss/core": "workspace:*",
+    "@unocss/preset-uno": "workspace:*",
     "@unocss/scope": "workspace:*"
   }
 }

--- a/packages/shared-integration/src/defaults.ts
+++ b/packages/shared-integration/src/defaults.ts
@@ -1,4 +1,10 @@
+import type { UserConfigDefaults } from '@unocss/core'
 import { cssIdRE } from '@unocss/core'
+import presetUno from '@unocss/preset-uno'
 
 export const defaultExclude = [cssIdRE]
 export const defaultInclude = [/\.vue$/, /\.vue\?vue/, /\.svelte$/, /\.[jt]sx$/, /\.mdx?$/, /\.astro$/, /\.elm$/]
+
+export const defaultUnocssConfig: UserConfigDefaults = {
+  presets: [presetUno()],
+}

--- a/packages/unocss/src/vite.ts
+++ b/packages/unocss/src/vite.ts
@@ -1,7 +1,7 @@
 import type { VitePluginConfig } from '@unocss/vite'
 import VitePlugin from '@unocss/vite'
-import presetUno from '@unocss/preset-uno'
 import type { Plugin } from 'vite'
+import { defaultUnocssConfig } from '../../shared-integration/src'
 
 export * from '@unocss/vite'
 
@@ -10,10 +10,6 @@ export default function UnocssVitePlugin<Theme extends {}>(
 ): Plugin[] {
   return VitePlugin(
     configOrPath,
-    {
-      presets: [
-        presetUno(),
-      ],
-    },
+    defaultUnocssConfig,
   )
 }

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -4,7 +4,7 @@ import { StatusBarAlignment, window, workspace } from 'vscode'
 import { sourceObjectFields, sourcePluginFactory } from 'unconfig/presets'
 import { version } from '../package.json'
 import { resolveOptions as resolveNuxtOptions } from '../../nuxt/src/options'
-import { createContext } from './integration'
+import { createContext, defaultUnocssConfig } from './integration'
 import { log } from './log'
 import { registerAnnonations } from './annonation'
 import { registerAutoComplete } from './autocomplete'
@@ -21,7 +21,7 @@ export async function activate(ext: ExtensionContext) {
   log.appendLine(`UnoCSS for VS Code  v${version} ${process.cwd()}`)
 
   const context = createContext(
-    cwd, {},
+    cwd, defaultUnocssConfig,
     [
       sourcePluginFactory({
         files: [
@@ -71,4 +71,4 @@ export async function activate(ext: ExtensionContext) {
   registerAnnonations(cwd, context, status, ext)
 }
 
-export function deactivate() {}
+export function deactivate() { }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -43,6 +43,7 @@
     "@rollup/pluginutils": "^4.2.1",
     "@unocss/config": "workspace:*",
     "@unocss/core": "workspace:*",
+    "@unocss/preset-uno": "workspace:*",
     "unplugin": "^0.6.3",
     "webpack-sources": "^3.2.3"
   },

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -7,6 +7,7 @@ import {
   LAYER_MARK_ALL,
   LAYER_PLACEHOLDER_RE,
   createContext,
+  defaultUnocssConfig,
   getHash,
   getHashPlaceholder,
   getLayerPlaceholder,
@@ -14,7 +15,7 @@ import {
   resolveId,
 } from '../../shared-integration/src'
 
-export interface WebpackPluginOptions<Theme extends {} = {}> extends UserConfig<Theme> {}
+export interface WebpackPluginOptions<Theme extends {} = {}> extends UserConfig<Theme> { }
 
 const PLUGIN_NAME = 'unocss:webpack'
 const UPDATE_DEBOUNCE = 10
@@ -25,7 +26,7 @@ export function defineConfig<Theme extends {}>(config: WebpackPluginOptions<Them
 
 export default function WebpackPlugin(
   configOrPath?: WebpackPluginOptions | string,
-  defaults?: UserConfigDefaults,
+  defaults: UserConfigDefaults = defaultUnocssConfig,
 ) {
   return createUnplugin(() => {
     const context = createContext(configOrPath, defaults)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,9 +455,11 @@ importers:
   packages/shared-integration:
     specifiers:
       '@unocss/core': workspace:*
+      '@unocss/preset-uno': workspace:*
       '@unocss/scope': workspace:*
     dependencies:
       '@unocss/core': link:../core
+      '@unocss/preset-uno': link:../preset-uno
       '@unocss/scope': link:../scope
 
   packages/transformer-compile-class:
@@ -571,6 +573,7 @@ importers:
       '@types/webpack-sources': ^3.2.0
       '@unocss/config': workspace:*
       '@unocss/core': workspace:*
+      '@unocss/preset-uno': workspace:*
       unplugin: ^0.6.3
       webpack: ^5.72.1
       webpack-sources: ^3.2.3
@@ -578,6 +581,7 @@ importers:
       '@rollup/pluginutils': 4.2.1
       '@unocss/config': link:../config
       '@unocss/core': link:../core
+      '@unocss/preset-uno': link:../preset-uno
       unplugin: 0.6.3_webpack@5.72.1
       webpack-sources: 3.2.3
     devDependencies:


### PR DESCRIPTION
close #1032 

also make webpack plugin use [@unocss/preset-uno](https://github.com/unocss/unocss/tree/main/packages/preset-uno) as default preset.