### PR TITLE
feat(preset-wind): support bracket values for `object-x`

### DIFF
--- a/packages/preset-wind/src/rules/static.ts
+++ b/packages/preset-wind/src/rules/static.ts
@@ -1,5 +1,5 @@
 import type { Rule } from '@unocss/core'
-import { positionMap } from '@unocss/preset-mini/utils'
+import { handler as h, positionMap } from '@unocss/preset-mini/utils'
 
 export const textTransforms: Rule[] = [
   // tailwind compat
@@ -83,7 +83,13 @@ export const objectPositions: Rule[] = [
   ['object-none', { 'object-fit': 'none' }],
 
   // object position
-  [/^object-([-\w]+)$/, ([, s]) => ({ 'object-position': positionMap[s] }), { autocomplete: `object-(${Object.keys(positionMap).join('|')})` }],
+  [/^object-(.+)$/, ([, d]) => {
+    if (positionMap[d])
+      return { 'object-position': positionMap[d] }
+    if (h.bracketOfPosition(d) != null)
+      return { 'object-position': h.bracketOfPosition(d)!.split(' ').map(e => h.position.fraction.auto.px.cssvar(e)).join(' ') }
+  }, { autocomplete: `object-(${Object.keys(positionMap).join('|')})` }],
+
 ]
 
 export const backgroundBlendModes: Rule[] = [

--- a/test/__snapshots__/preset-wind.test.ts.snap
+++ b/test/__snapshots__/preset-wind.test.ts.snap
@@ -261,6 +261,7 @@ exports[`preset-wind > targets 1`] = `
 .bg-origin-border{background-origin:border-box;}
 .svg\\\\:fill-red svg{--un-fill-opacity:1;fill:rgba(248,113,113,var(--un-fill-opacity));}
 .object-none{object-fit:none;}
+.object-\\\\[center_25\\\\%\\\\]{object-position:center 25%;}
 .object-cb,
 .object-center-bottom{object-position:center bottom;}
 .object-center{object-position:center;}

--- a/test/assets/preset-wind-targets.ts
+++ b/test/assets/preset-wind-targets.ts
@@ -280,6 +280,7 @@ export const presetWindTargets: string[] = [
   'object-cb',
   'object-center-top',
   'object-center-bottom',
+  'object-[center_25%]',
 
   // tables
   'border-collapse',


### PR DESCRIPTION
Closes #1086

Based on [`bg-x` code](https://github.com/unocss/unocss/blob/c8cd80596987bddc660e907a08ef87ee0f5c97a1/packages/preset-wind/src/rules/background.ts#L65-L66)