### PR TITLE
chore(vscode): specify `height` for the banner icon

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,7 +1,7 @@
 <br>
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/unocss/unocss/main/packages/vscode/res/logo.png" style="width:100px;" />
+<img src="https://raw.githubusercontent.com/unocss/unocss/main/packages/vscode/res/logo.png" style="width:100px;" height="128" />
 </p>
 
 <h1 align="center">UnoCSS for VS Code</h1>


### PR DESCRIPTION
VS Code doesn't respect the `style` attribute of the icon, making it (horribly) huge. Let's set a height for it.