### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ You can inject raw css as preflights from the configuration. The resolved `theme
 ```ts
 preflights: [
   {
-    getCss: ({ theme }) => `
+    getCSS: ({ theme }) => `
       * {
         color: ${theme.colors.gray?.[700] ?? '#333'}
         padding: 0;


### PR DESCRIPTION
[source](https://github.com/unocss/unocss/blob/main/packages/core/src/types.ts#L184-L187)

```typescript
export interface Preflight<Theme extends {} = {}> {
  getCSS: (context: PreflightContext<Theme>) => Promise<string | undefined> | string | undefined
  layer?: string
}
```