### PR TITLE
feat(vscode): resolve config by file path

### DIFF
--- a/packages/autocomplete/src/create.ts
+++ b/packages/autocomplete/src/create.ts
@@ -2,10 +2,10 @@ import type { AutoCompleteExtractorResult, AutoCompleteFunction, AutoCompleteTem
 import { escapeRegExp, toArray, uniq } from '@unocss/core'
 import LRU from 'lru-cache'
 import { parseAutocomplete } from './parse'
-import type { ParsedAutocompleteTemplate } from './types'
+import type { ParsedAutocompleteTemplate, UnocssAutocomplete } from './types'
 import { searchUsageBoundary } from './utils'
 
-export function createAutocomplete(uno: UnoGenerator) {
+export function createAutocomplete(uno: UnoGenerator): UnocssAutocomplete {
   const templateCache = new Map<string, ParsedAutocompleteTemplate>()
   const cache = new LRU<string, string[]>({ max: 5000 })
 

--- a/packages/autocomplete/src/types.ts
+++ b/packages/autocomplete/src/types.ts
@@ -1,3 +1,6 @@
+import type { AutoCompleteFunction, SuggestResult } from '@unocss/core'
+import type LRU from 'lru-cache'
+
 export type AutocompleteTemplatePart = AutocompleteTemplateStatic | AutocompleteTemplateGroup | AutocompleteTemplateTheme
 
 export interface AutocompleteTemplateStatic {
@@ -18,4 +21,13 @@ export interface AutocompleteTemplateTheme {
 export interface ParsedAutocompleteTemplate {
   parts: AutocompleteTemplatePart[]
   suggest(input: string): string[] | undefined
+}
+
+export interface UnocssAutocomplete {
+  suggest: (input: string) => Promise<string[]>
+  suggestInFile: (content: string, cursor: number) => Promise<SuggestResult>
+  templates: (string | AutoCompleteFunction)[]
+  cache: LRU<string, string[]>
+  reset: () => void
+  enumerate: () => Promise<Set<string>>
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -462,10 +462,12 @@ export interface UnocssPluginContext<Config extends UserConfig = UserConfig> {
   /** Map for all module's raw content */
   modules: BetterMap<string, string>
   filter: (code: string, id: string) => boolean
+  rollupFilter: (id: unknown) => boolean
   extract: (code: string, id?: string) => Promise<void>
 
   reloadConfig: () => Promise<LoadConfigResult<Config>>
   getConfig: () => Promise<Config>
+  onReload: (fn: () => void) => void
 
   invalidate: () => void
   onInvalidate: (fn: () => void) => void

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -462,7 +462,6 @@ export interface UnocssPluginContext<Config extends UserConfig = UserConfig> {
   /** Map for all module's raw content */
   modules: BetterMap<string, string>
   filter: (code: string, id: string) => boolean
-  rollupFilter: (id: unknown) => boolean
   extract: (code: string, id?: string) => Promise<void>
 
   reloadConfig: () => Promise<LoadConfigResult<Config>>

--- a/packages/shared-integration/src/context.ts
+++ b/packages/shared-integration/src/context.ts
@@ -102,7 +102,6 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
       invalidations.push(fn)
     },
     filter,
-    rollupFilter,
     reloadConfig,
     onReload(fn: () => void) {
       reloadListeners.push(fn)

--- a/packages/shared-integration/src/context.ts
+++ b/packages/shared-integration/src/context.ts
@@ -18,6 +18,7 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
   let rollupFilter = createFilter(defaultInclude, defaultExclude)
 
   const invalidations: Array<() => void> = []
+  const reloadListeners: Array<() => void> = []
 
   const modules = new BetterMap<string, string>()
   const tokens = new Set<string>()
@@ -38,6 +39,7 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
     tokens.clear()
     await Promise.all(modules.map((code, id) => uno.applyExtractors(code, id, tokens)))
     invalidate()
+    dispatchReload()
 
     // check preset duplication
     const presets = new Set<string>()
@@ -63,6 +65,10 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
 
   function invalidate() {
     invalidations.forEach(cb => cb())
+  }
+
+  function dispatchReload() {
+    reloadListeners.forEach(cb => cb())
   }
 
   async function extract(code: string, id?: string) {
@@ -96,7 +102,11 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
       invalidations.push(fn)
     },
     filter,
+    rollupFilter,
     reloadConfig,
+    onReload(fn: () => void) {
+      reloadListeners.push(fn)
+    },
     uno,
     extract,
     getConfig,

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -28,7 +28,13 @@
     "workspaceContains:**/package.json"
   ],
   "contributes": {
-    "commands": [],
+    "commands": [
+      {
+        "command": "unocss.reload",
+        "title": "Reload UnoCSS",
+        "category": "UnoCSS"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "UnoCSS",

--- a/packages/vscode/src/annonation.ts
+++ b/packages/vscode/src/annonation.ts
@@ -1,19 +1,17 @@
-import { relative } from 'path'
+import path from 'path'
 import type { DecorationOptions, ExtensionContext, StatusBarItem } from 'vscode'
 import { DecorationRangeBehavior, MarkdownString, Range, window, workspace } from 'vscode'
-import type { UnocssPluginContext } from '@unocss/core'
 import { INCLUDE_COMMENT_IDE, getMatchedPositions } from './integration'
 import { log } from './log'
 import { getPrettiedMarkdown, isCssId, throttle } from './utils'
+import type { ContextLoader } from './contextLoader'
 
 export async function registerAnnonations(
   cwd: string,
-  context: UnocssPluginContext,
+  contextLoader: ContextLoader,
   status: StatusBarItem,
   ext: ExtensionContext,
 ) {
-  const { sources } = await context.ready
-  const { uno, filter } = context
   let underline: boolean = workspace.getConfiguration().get('unocss.underline') ?? true
   ext.subscriptions.push(workspace.onDidChangeConfiguration((event) => {
     if (event.affectsConfiguration('unocss.underline')) {
@@ -23,10 +21,14 @@ export async function registerAnnonations(
   }))
 
   workspace.onDidSaveTextDocument(async (doc) => {
-    if (sources.includes(doc.uri.fsPath)) {
+    const id = doc.uri.fsPath
+    const dir = path.dirname(id)
+
+    if (contextLoader.contexts.has(dir)) {
+      const ctx = contextLoader.contexts.get(dir)!
       try {
-        await context.reloadConfig()
-        log.appendLine(`Config reloaded by ${relative(cwd, doc.uri.fsPath)}`)
+        await ctx.reloadConfig()
+        log.appendLine(`Config reloaded by ${path.relative(cwd, doc.uri.fsPath)}`)
       }
       catch (e) {
         log.appendLine('Error on loading config')
@@ -54,17 +56,23 @@ export async function registerAnnonations(
       const code = doc.getText()
       const id = doc.uri.fsPath
 
-      if (!code || (!code.includes(INCLUDE_COMMENT_IDE) && !isCssId(id) && !filter(code, id)))
+      if (!code)
         return reset()
 
-      const result = await uno.generate(code, { id, preflights: false, minify: true })
+      let ctx = await contextLoader.resolveContext(id)
+      if (!ctx && (code.includes(INCLUDE_COMMENT_IDE) || isCssId(id)))
+        ctx = contextLoader.defaultContext
+      else if (!ctx?.filter(code, id))
+        return null
+
+      const result = await ctx.uno.generate(code, { id, preflights: false, minify: true })
 
       const ranges: DecorationOptions[] = (
         await Promise.all(
           getMatchedPositions(code, Array.from(result.matched))
             .map(async (i): Promise<DecorationOptions> => {
               try {
-                const md = await getPrettiedMarkdown(uno, i[2])
+                const md = await getPrettiedMarkdown(ctx!.uno, i[2])
                 return {
                   range: new Range(doc.positionAt(i[0]), doc.positionAt(i[1])),
                   get hoverMessage() {

--- a/packages/vscode/src/annonation.ts
+++ b/packages/vscode/src/annonation.ts
@@ -121,6 +121,9 @@ export async function registerAnnonations(
     if (e.document === window.activeTextEditor?.document)
       throttledUpdateAnnotation()
   })
+  contextLoader.events.on('reload', async () => {
+    await updateAnnotation()
+  })
 
   await updateAnnotation()
 }

--- a/packages/vscode/src/annonation.ts
+++ b/packages/vscode/src/annonation.ts
@@ -59,9 +59,9 @@ export async function registerAnnonations(
       if (!code)
         return reset()
 
-      let ctx = await contextLoader.resolveContext(id)
+      let ctx = await contextLoader.resolveContext(code, id)
       if (!ctx && (code.includes(INCLUDE_COMMENT_IDE) || isCssId(id)))
-        ctx = await contextLoader.resolveCloestContext(id)
+        ctx = await contextLoader.resolveCloestContext(code, id)
       else if (!ctx?.filter(code, id))
         return null
 

--- a/packages/vscode/src/annonation.ts
+++ b/packages/vscode/src/annonation.ts
@@ -61,7 +61,7 @@ export async function registerAnnonations(
 
       let ctx = await contextLoader.resolveContext(id)
       if (!ctx && (code.includes(INCLUDE_COMMENT_IDE) || isCssId(id)))
-        ctx = contextLoader.defaultContext
+        ctx = await contextLoader.resolveCloestContext(id)
       else if (!ctx?.filter(code, id))
         return null
 

--- a/packages/vscode/src/autocomplete.ts
+++ b/packages/vscode/src/autocomplete.ts
@@ -1,9 +1,11 @@
-import type { UnocssPluginContext } from '@unocss/core'
+import type { UnocssAutocomplete } from '@unocss/autocomplete'
 import { createAutocomplete } from '@unocss/autocomplete'
-import type { CompletionItemProvider, ExtensionContext, Position, TextDocument } from 'vscode'
+import type { CompletionItemProvider, ExtensionContext } from 'vscode'
 import { CompletionItem, CompletionItemKind, CompletionList, MarkdownString, Range, languages } from 'vscode'
+import type { UnoGenerator, UnocssPluginContext } from '@unocss/core'
 import { getPrettiedMarkdown, isCssId } from './utils'
 import { log } from './log'
+import type { ContextLoader } from './contextLoader'
 
 const languageIds = [
   'erb',
@@ -24,27 +26,59 @@ const languageIds = [
 ]
 const delimiters = ['-', ':']
 
+class UnoCompletionItem extends CompletionItem {
+  uno: UnoGenerator
+
+  constructor(label: string, kind: CompletionItemKind, uno: UnoGenerator) {
+    super(label, kind)
+    this.uno = uno
+  }
+}
+
 export async function registerAutoComplete(
-  context: UnocssPluginContext,
+  contextLoader: ContextLoader,
   ext: ExtensionContext,
 ) {
-  const { uno, filter } = context
+  const autoCompletes = new Map<UnocssPluginContext, UnocssAutocomplete>()
+  contextLoader.events.on('contextReload', (ctx) => {
+    autoCompletes.delete(ctx)
+  })
+  contextLoader.events.on('contextUnload', (ctx) => {
+    autoCompletes.delete(ctx)
+  })
 
-  const autoComplete = createAutocomplete(uno)
+  function getAutocomplete(ctx: UnocssPluginContext) {
+    const cached = autoCompletes.get(ctx)
+    if (cached)
+      return cached
 
-  async function getMarkdown(util: string) {
+    const autocomplete = createAutocomplete(ctx.uno)
+
+    autoCompletes.set(ctx, autocomplete)
+    return autocomplete
+  }
+
+  async function getMarkdown(uno: UnoGenerator, util: string) {
     return new MarkdownString(await getPrettiedMarkdown(uno, util))
   }
 
-  const provider: CompletionItemProvider = {
-    async provideCompletionItems(doc: TextDocument, position: Position) {
+  const provider: CompletionItemProvider<UnoCompletionItem> = {
+    async provideCompletionItems(doc, position) {
       const code = doc.getText()
       const id = doc.uri.fsPath
 
-      if (!code || (!isCssId(id) && !filter(code, id)))
+      if (!code)
+        return null
+
+      let ctx = await contextLoader.resolveContext(id)
+      if (!ctx && isCssId(id))
+        ctx = contextLoader.defaultContext
+      else if (!ctx?.filter(code, id))
         return null
 
       try {
+        const autoComplete = getAutocomplete(ctx)
+
         const result = await autoComplete.suggestInFile(code, doc.offsetAt(position))
 
         log.appendLine(`[autocomplete] ${id} | ${result.suggestions.slice(0, 10).map(v => `[${v[0]}, ${v[1]}]`).join(', ')}`)
@@ -54,7 +88,7 @@ export async function registerAutoComplete(
 
         return new CompletionList(result.suggestions.map(([value, label]) => {
           const resolved = result.resolveReplacement(value)
-          const item = new CompletionItem(label, CompletionItemKind.EnumMember)
+          const item = new UnoCompletionItem(label, CompletionItemKind.EnumMember, ctx!.uno)
           item.insertText = resolved.replacement
           item.range = new Range(doc.positionAt(resolved.start), doc.positionAt(resolved.end))
           return item
@@ -66,10 +100,10 @@ export async function registerAutoComplete(
       }
     },
 
-    async resolveCompletionItem(item: CompletionItem) {
+    async resolveCompletionItem(item) {
       return {
         ...item,
-        documentation: await getMarkdown(item.label as string),
+        documentation: await getMarkdown(item.uno, item.label as string),
       }
     },
   }

--- a/packages/vscode/src/autocomplete.ts
+++ b/packages/vscode/src/autocomplete.ts
@@ -70,9 +70,9 @@ export async function registerAutoComplete(
       if (!code)
         return null
 
-      let ctx = await contextLoader.resolveContext(id)
+      let ctx = await contextLoader.resolveContext(code, id)
       if (!ctx && isCssId(id))
-        ctx = await contextLoader.resolveCloestContext(id)
+        ctx = await contextLoader.resolveCloestContext(code, id)
       else if (!ctx?.filter(code, id))
         return null
 

--- a/packages/vscode/src/autocomplete.ts
+++ b/packages/vscode/src/autocomplete.ts
@@ -72,7 +72,7 @@ export async function registerAutoComplete(
 
       let ctx = await contextLoader.resolveContext(id)
       if (!ctx && isCssId(id))
-        ctx = contextLoader.defaultContext
+        ctx = await contextLoader.resolveCloestContext(id)
       else if (!ctx?.filter(code, id))
         return null
 

--- a/packages/vscode/src/contextLoader.ts
+++ b/packages/vscode/src/contextLoader.ts
@@ -103,9 +103,7 @@ export class ContextLoader {
 
     context.onReload(() => {
       for (const [path, ctx] of this.fileContextCache) {
-        if (ctx === context && !context.rollupFilter(path))
-          this.fileContextCache.delete(path)
-        if (!ctx)
+        if (ctx === context || !ctx)
           this.fileContextCache.delete(path)
       }
 
@@ -127,7 +125,7 @@ export class ContextLoader {
     return context
   }
 
-  async resolveContext(file: string) {
+  async resolveContext(code: string, file: string) {
     const cached = this.fileContextCache.get(file)
     if (cached !== undefined)
       return cached
@@ -139,7 +137,7 @@ export class ContextLoader {
       if (!isSubdir(configDir, file))
         continue
 
-      if (!context.rollupFilter(file))
+      if (!context.filter(code, file))
         continue
 
       this.fileContextCache.set(file, context)
@@ -160,7 +158,7 @@ export class ContextLoader {
       const context = await this.loadConfigInDirectory(dir)
       this.configExistsCache.set(dir, !!context)
 
-      if (context?.rollupFilter(file)) {
+      if (context?.filter(code, file)) {
         this.fileContextCache.set(file, context)
         return context
       }
@@ -172,7 +170,7 @@ export class ContextLoader {
     return null
   }
 
-  async resolveCloestContext(file: string) {
+  async resolveCloestContext(code: string, file: string) {
     const cached = this.fileContextCache.get(file)
     if (cached)
       return cached
@@ -181,7 +179,7 @@ export class ContextLoader {
       if (!isSubdir(configDir, file))
         continue
 
-      if (!context.rollupFilter(file))
+      if (!context.filter(code, file))
         continue
 
       this.fileContextCache.set(file, context)

--- a/packages/vscode/src/contextLoader.ts
+++ b/packages/vscode/src/contextLoader.ts
@@ -170,4 +170,30 @@ export class ContextLoader {
     this.fileContextCache.set(file, null)
     return null
   }
+
+  async resolveCloestContext(file: string) {
+    const cached = this.fileContextCache.get(file)
+    if (cached)
+      return cached
+
+    for (const [configDir, context] of this.contexts) {
+      if (!isSubdir(configDir, file))
+        continue
+
+      if (!context.rollupFilter(file))
+        continue
+
+      this.fileContextCache.set(file, context)
+      return context
+    }
+
+    for (const [configDir, context] of this.contexts) {
+      if (isSubdir(configDir, file)) {
+        this.fileContextCache.set(file, context)
+        return context
+      }
+    }
+
+    return this.defaultContext
+  }
 }

--- a/packages/vscode/src/contextLoader.ts
+++ b/packages/vscode/src/contextLoader.ts
@@ -32,6 +32,9 @@ export class ContextLoader {
     })
 
     this.ready = this.reload()
+      .then(async () => {
+        await this.defaultContext.ready
+      })
   }
 
   async reload() {

--- a/packages/vscode/src/contextLoader.ts
+++ b/packages/vscode/src/contextLoader.ts
@@ -109,6 +109,7 @@ export class ContextLoader {
           this.fileContextCache.delete(path)
       }
 
+      this.configExistsCache.clear()
       this.events.emit('contextReload', context)
     })
 

--- a/packages/vscode/src/contextLoader.ts
+++ b/packages/vscode/src/contextLoader.ts
@@ -1,0 +1,139 @@
+import path from 'path'
+import type { UnocssPluginContext, UserConfig } from '@unocss/core'
+import { sourceObjectFields, sourcePluginFactory } from 'unconfig/presets'
+import presetUno from '@unocss/preset-uno'
+import { resolveOptions as resolveNuxtOptions } from '../../nuxt/src/options'
+import { createNanoEvents } from '../../core/src/utils/events'
+import { createContext } from './integration'
+import { isSubdir } from './utils'
+import { log } from './log'
+
+export class ContextLoader {
+  public cwd: string
+  public defaultContext: UnocssPluginContext<UserConfig<any>>
+  public contexts = new Map<string, UnocssPluginContext<UserConfig<any>>>()
+  private fileToContextCache = new Map<string, UnocssPluginContext<UserConfig<any>>>()
+  public events = createNanoEvents<{
+    contextLoaded: (context: UnocssPluginContext<UserConfig<any>>) => void
+    contextReload: (context: UnocssPluginContext<UserConfig<any>>) => void
+    contextUnload: (context: UnocssPluginContext<UserConfig<any>>) => void
+  }>()
+
+  constructor(cwd: string) {
+    this.cwd = cwd
+    this.defaultContext = createContext({
+      presets: [
+        presetUno(),
+      ],
+    })
+  }
+
+  async unloadContext(configDir: string) {
+    const context = this.contexts.get(configDir)
+    if (!context)
+      return
+
+    this.contexts.delete(configDir)
+
+    for (const [path, ctx] of this.fileToContextCache) {
+      if (ctx === context)
+        this.fileToContextCache.delete(path)
+    }
+
+    this.events.emit('contextUnload', context)
+  }
+
+  async loadConfigInDirectory(dir: string) {
+    const cached = this.contexts.get(dir)
+    if (cached)
+      return cached
+
+    const context = createContext(
+      dir,
+      undefined,
+      [
+        sourcePluginFactory({
+          files: [
+            'vite.config',
+            'svelte.config',
+            'astro.config',
+            'iles.config',
+          ],
+          targetModule: 'unocss/vite',
+          parameters: [{ command: 'serve', mode: 'development' }],
+        }),
+        sourceObjectFields({
+          files: 'nuxt.config',
+          fields: 'unocss',
+        }),
+      ],
+      (result) => {
+        if (result.sources.some(s => s.includes('nuxt.config')))
+          resolveNuxtOptions(result.config)
+      },
+    )
+
+    context.updateRoot(dir)
+
+    let sources = []
+    try {
+      sources = (await context.ready).sources
+    }
+    catch (e) {
+      log.appendLine(`[error] ${String(e)}`)
+      log.appendLine(`[error] Error occurred while loading config. Config directory: ${dir}`)
+      return null
+    }
+
+    if (!sources.length)
+      return null
+
+    const baseDir = path.dirname(sources[0])
+    if (this.contexts.has(baseDir))
+      return this.contexts.get(baseDir)!
+
+    context.onReload(() => {
+      for (const [path, ctx] of this.fileToContextCache) {
+        if (ctx === context && !context.rollupFilter(path))
+          this.fileToContextCache.delete(path)
+      }
+
+      this.events.emit('contextReload', context)
+    })
+
+    this.events.emit('contextLoaded', context)
+
+    log.appendLine(`[info] New configuration loaded from\n  ${sources.map(s => `  - ${s}`).join('\n')}`)
+
+    this.contexts.set(baseDir, context)
+
+    return context
+  }
+
+  async resolveContext(file: string) {
+    const cached = this.fileToContextCache.get(file)
+    if (cached)
+      return cached
+
+    // try finding an existing context that includes the file
+    for (const [configDir, context] of this.contexts) {
+      if (!isSubdir(configDir, file))
+        continue
+
+      if (!context.rollupFilter(file))
+        continue
+
+      this.fileToContextCache.set(file, context)
+      return context
+    }
+
+    // try finding a config from disk
+    const dir = path.dirname(file)
+    const context = await this.loadConfigInDirectory(dir)
+
+    if (context?.rollupFilter(file)) {
+      this.fileToContextCache.set(file, context)
+      return context
+    }
+  }
+}

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -1,14 +1,11 @@
-import { relative, resolve } from 'path'
+import path from 'path'
 import type { ExtensionContext } from 'vscode'
 import { StatusBarAlignment, window, workspace } from 'vscode'
-import { sourceObjectFields, sourcePluginFactory } from 'unconfig/presets'
-import presetUno from '@unocss/preset-uno'
 import { version } from '../package.json'
-import { resolveOptions as resolveNuxtOptions } from '../../nuxt/src/options'
-import { createContext } from './integration'
 import { log } from './log'
 import { registerAnnonations } from './annonation'
 import { registerAutoComplete } from './autocomplete'
+import { ContextLoader } from './contextLoader'
 
 export async function activate(ext: ExtensionContext) {
   const projectPath = workspace.workspaceFolders?.[0].uri.fsPath
@@ -17,64 +14,18 @@ export async function activate(ext: ExtensionContext) {
 
   const config = workspace.getConfiguration('unocss')
   const root = config.get<string>('root')
-  const cwd = root ? resolve(projectPath, root) : projectPath
+  const cwd = root ? path.resolve(projectPath, root) : projectPath
 
   log.appendLine(`UnoCSS for VS Code  v${version} ${process.cwd()}`)
 
-  const context = createContext(
-    cwd,
-    {
-      presets: [
-        presetUno(),
-      ],
-    },
-    [
-      sourcePluginFactory({
-        files: [
-          'vite.config',
-          'svelte.config',
-          'astro.config',
-          'iles.config',
-        ],
-        targetModule: 'unocss/vite',
-        parameters: [{ command: 'serve', mode: 'development' }],
-      }),
-      sourceObjectFields({
-        files: 'nuxt.config',
-        fields: 'unocss',
-      }),
-    ],
-    (result) => {
-      if (result.sources.some(s => s.includes('nuxt.config')))
-        resolveNuxtOptions(result.config)
-    },
-  )
-
-  context.updateRoot(cwd)
-
-  let sources: string[] = []
-  try {
-    sources = (await context.ready).sources
-  }
-  catch (e) {
-    log.appendLine(`[error] ${String(e)}`)
-    log.appendLine('[error] Failed to start extension, exiting')
-    return
-  }
-
-  if (!sources.length) {
-    log.appendLine('[warn] No config files found, disabled')
-    log.appendLine('[warn] Make sure you have `unocss.config.js` in your workspace root, or change `unocss.root` in your workspace settings')
-    return
-  }
-
-  log.appendLine(`Configuration loaded from\n${sources.map(s => ` - ${relative(cwd, s)}`).join('\n')}`)
+  const contextLoader = new ContextLoader(cwd)
+  await contextLoader.loadConfigInDirectory(cwd)
 
   const status = window.createStatusBarItem(StatusBarAlignment.Right, 200)
   status.text = 'UnoCSS'
 
-  registerAutoComplete(context, ext)
-  registerAnnonations(cwd, context, status, ext)
+  registerAutoComplete(contextLoader, ext)
+  registerAnnonations(cwd, contextLoader, status, ext)
 }
 
 export function deactivate() {}

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import type { ExtensionContext } from 'vscode'
-import { StatusBarAlignment, window, workspace } from 'vscode'
+import { StatusBarAlignment, commands, window, workspace } from 'vscode'
 import { version } from '../package.json'
 import { log } from './log'
 import { registerAnnonations } from './annonation'
@@ -19,13 +19,18 @@ export async function activate(ext: ExtensionContext) {
   log.appendLine(`UnoCSS for VS Code  v${version} ${process.cwd()}`)
 
   const contextLoader = new ContextLoader(cwd)
-  await contextLoader.loadConfigInDirectory(cwd)
+  await contextLoader.ready
 
   const status = window.createStatusBarItem(StatusBarAlignment.Right, 200)
   status.text = 'UnoCSS'
 
   registerAutoComplete(contextLoader, ext)
   registerAnnonations(cwd, contextLoader, status, ext)
+
+  ext.subscriptions.push(commands.registerCommand('unocss.reload', async () => {
+    await contextLoader.reload()
+    log.appendLine('[info] UnoCSS reloaded.')
+  }))
 }
 
 export function deactivate() {}

--- a/packages/vscode/src/utils.ts
+++ b/packages/vscode/src/utils.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import type { UnoGenerator } from '@unocss/core'
 import { cssIdRE } from '@unocss/core'
 import prettier from 'prettier/standalone'
@@ -38,4 +39,9 @@ export async function getPrettiedMarkdown(uno: UnoGenerator, util: string) {
 
 export function isCssId(id: string) {
   return cssIdRE.test(id)
+}
+
+export function isSubdir(parent: string, child: string) {
+  const relative = path.relative(parent, child)
+  return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
 }


### PR DESCRIPTION
### What have changed

- The VSCode extension now can load multiple config files according to file's path.
  - Config files will be searched from file's directory to the workspace directory or what's being specified in `unocss.root`.
  - Every config file will only be loaded once, every file will be searched against loaded configs first.
  - The config file living in CWD will be loaded upon extension start.

### Unsolved problems

- ~~Files meeting `code.includes(INCLUDE_COMMENT_IDE) || isCssId(id)` will now be resolved to default config. Should it use the "closest" config or the default one?~~
- ~~Should the config file search all the way to the root of the drive? Should it be CWD instead?~~
- ~~Should there be a command to unload all loaded contexts(aka. reload)? It definitely helps with potential loading issues (eg. when a new config file is added), but I'm not sure if it's necessary.~~
- ~~Reduce the number of `createContext` calls. Currently it's being called every time a resolve from cache fails, and it does lot's of disk reads which is slow. I think it could be reduced by a better cache algorithm, haven't came up with one yet.~~