### PR TITLE
feat(core): use recursive callback to resolve variant

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -344,8 +344,22 @@ export class UnoGenerator {
       .reverse()
       .reduce(
         (previous, v) =>
-          (input: VariantHandlerContext) =>
-            (v.handler ?? defaultHandler)(input, previous),
+          // (input: VariantHandlerContext) =>
+          //   (v.handler ?? defaultHandler)(input, previous),
+          (input: VariantHandlerContext) => {
+            const entries = v.body?.(input.entries) || input.entries
+            const parents: [string | undefined, number | undefined] = v.parent
+              ? (Array.isArray(v.parent) ? v.parent : [v.parent ?? '', undefined])
+              : [input.parent, input.parentOrder]
+            return (v.handler ?? defaultHandler)({
+              entries,
+              selector: v.selector?.(input.selector, entries) || input.selector,
+              parent: parents[0],
+              parentOrder: parents[1],
+              layer: v.layer || input.layer,
+              sort: v.sort || input.sort,
+            }, previous)
+          },
         (input: VariantHandlerContext) => input,
       )
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -211,36 +211,36 @@ export interface VariantHandler {
    * Order in which the variant is applied to selector.
    */
   order?: number
-  // /**
-  //  * @deprecated use `handler` instead. It will be removed in 1.0.
-  //  *
-  //  * Rewrite the output selector. Often be used to append pesudo classes or parents.
-  //  */
-  // selector?: (input: string, body: CSSEntries) => string | undefined
-  // /**
-  //  * @deprecated use `handler` instead. It will be removed in 1.0.
-  //  *
-  //  * Rewrite the output css body. The input come in [key,value][] pairs.
-  //  */
-  // body?: (body: CSSEntries) => CSSEntries | undefined
-  // /**
-  //  * @deprecated use `handler` instead. It will be removed in 1.0.
-  //  *
-  //  * Provide a parent selector(e.g. media query) to the output css.
-  //  */
-  // parent?: string | [string, number] | undefined
-  // /**
-  //  * @deprecated use `handler` instead. It will be removed in 1.0.
-  //  *
-  //  * Order in which the variant is sorted within single rule.
-  //  */
-  // sort?: number
-  // /**
-  //  * @deprecated use `handler` instead. It will be removed in 1.0.
-  //  *
-  //  * Override layer to the output css.
-  //  */
-  // layer?: string | undefined
+  /**
+   * @deprecated use `handler` instead. It will be removed in 1.0.
+   *
+   * Rewrite the output selector. Often be used to append pesudo classes or parents.
+   */
+  selector?: (input: string, body: CSSEntries) => string | undefined
+  /**
+   * @deprecated use `handler` instead. It will be removed in 1.0.
+   *
+   * Rewrite the output css body. The input come in [key,value][] pairs.
+   */
+  body?: (body: CSSEntries) => CSSEntries | undefined
+  /**
+   * @deprecated use `handler` instead. It will be removed in 1.0.
+   *
+   * Provide a parent selector(e.g. media query) to the output css.
+   */
+  parent?: string | [string, number] | undefined
+  /**
+   * @deprecated use `handler` instead. It will be removed in 1.0.
+   *
+   * Order in which the variant is sorted within single rule.
+   */
+  sort?: number
+  /**
+   * @deprecated use `handler` instead. It will be removed in 1.0.
+   *
+   * Override layer to the output css.
+   */
+  layer?: string | undefined
 }
 
 export type VariantFunction<Theme extends {} = {}> = (matcher: string, context: Readonly<VariantContext<Theme>>) => string | VariantHandler | undefined

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -191,30 +191,44 @@ export type BlocklistRule = string | RegExp
 
 export interface VariantHandler {
   /**
+   * Callback to process the handler.
+   */
+  handler?: (input: UtilObject, next: (input: UtilObject) => UtilObject) => UtilObject
+  /**
    * The result rewritten selector for the next round of matching
    */
   matcher: string
-  /**
-   * Rewrite the output selector. Often be used to append pesudo classes or parents.
-   */
-  selector?: (input: string, body: CSSEntries) => string | undefined
-  /**
-   * Rewrite the output css body. The input come in [key,value][] pairs.
-   */
-  body?: (body: CSSEntries) => CSSEntries | undefined
-  /**
-   * Provide a parent selector(e.g. media query) to the output css.
-   */
-  parent?: string | [string, number] | undefined
   /**
    * Order in which the variant is applied to selector.
    */
   order?: number
   /**
+   * @deprecated use `handler` instead. It will be removed in 1.0.
+   *
+   * Rewrite the output selector. Often be used to append pesudo classes or parents.
+   */
+  selector?: (input: string, body: CSSEntries) => string | undefined
+  /**
+   * @deprecated use `handler` instead. It will be removed in 1.0.
+   *
+   * Rewrite the output css body. The input come in [key,value][] pairs.
+   */
+  body?: (body: CSSEntries) => CSSEntries | undefined
+  /**
+   * @deprecated use `handler` instead. It will be removed in 1.0.
+   *
+   * Provide a parent selector(e.g. media query) to the output css.
+   */
+  parent?: string | [string, number] | undefined
+  /**
+   * @deprecated use `handler` instead. It will be removed in 1.0.
+   *
    * Order in which the variant is sorted within single rule.
    */
   sort?: number
   /**
+   * @deprecated use `handler` instead. It will be removed in 1.0.
+   *
    * Override layer to the output css.
    */
   layer?: string | undefined

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -189,11 +189,20 @@ export interface Preflight<Theme extends {} = {}> {
 
 export type BlocklistRule = string | RegExp
 
+export interface VariantHandlerContext {
+  selector: string
+  entries: CSSEntries
+  parent?: string
+  parentOrder?: number
+  layer?: string
+  sort?: number
+}
+
 export interface VariantHandler {
   /**
    * Callback to process the handler.
    */
-  handler?: (input: UtilObject, next: (input: UtilObject) => UtilObject) => UtilObject
+  handler?: (input: VariantHandlerContext, next: (input: VariantHandlerContext) => VariantHandlerContext) => VariantHandlerContext
   /**
    * The result rewritten selector for the next round of matching
    */
@@ -202,36 +211,36 @@ export interface VariantHandler {
    * Order in which the variant is applied to selector.
    */
   order?: number
-  /**
-   * @deprecated use `handler` instead. It will be removed in 1.0.
-   *
-   * Rewrite the output selector. Often be used to append pesudo classes or parents.
-   */
-  selector?: (input: string, body: CSSEntries) => string | undefined
-  /**
-   * @deprecated use `handler` instead. It will be removed in 1.0.
-   *
-   * Rewrite the output css body. The input come in [key,value][] pairs.
-   */
-  body?: (body: CSSEntries) => CSSEntries | undefined
-  /**
-   * @deprecated use `handler` instead. It will be removed in 1.0.
-   *
-   * Provide a parent selector(e.g. media query) to the output css.
-   */
-  parent?: string | [string, number] | undefined
-  /**
-   * @deprecated use `handler` instead. It will be removed in 1.0.
-   *
-   * Order in which the variant is sorted within single rule.
-   */
-  sort?: number
-  /**
-   * @deprecated use `handler` instead. It will be removed in 1.0.
-   *
-   * Override layer to the output css.
-   */
-  layer?: string | undefined
+  // /**
+  //  * @deprecated use `handler` instead. It will be removed in 1.0.
+  //  *
+  //  * Rewrite the output selector. Often be used to append pesudo classes or parents.
+  //  */
+  // selector?: (input: string, body: CSSEntries) => string | undefined
+  // /**
+  //  * @deprecated use `handler` instead. It will be removed in 1.0.
+  //  *
+  //  * Rewrite the output css body. The input come in [key,value][] pairs.
+  //  */
+  // body?: (body: CSSEntries) => CSSEntries | undefined
+  // /**
+  //  * @deprecated use `handler` instead. It will be removed in 1.0.
+  //  *
+  //  * Provide a parent selector(e.g. media query) to the output css.
+  //  */
+  // parent?: string | [string, number] | undefined
+  // /**
+  //  * @deprecated use `handler` instead. It will be removed in 1.0.
+  //  *
+  //  * Order in which the variant is sorted within single rule.
+  //  */
+  // sort?: number
+  // /**
+  //  * @deprecated use `handler` instead. It will be removed in 1.0.
+  //  *
+  //  * Override layer to the output css.
+  //  */
+  // layer?: string | undefined
 }
 
 export type VariantFunction<Theme extends {} = {}> = (matcher: string, context: Readonly<VariantContext<Theme>>) => string | VariantHandler | undefined

--- a/packages/preset-mini/src/utils/variants.ts
+++ b/packages/preset-mini/src/utils/variants.ts
@@ -1,7 +1,7 @@
 import type { VariantHandler, VariantObject } from '@unocss/core'
 import { escapeRegExp } from '@unocss/core'
 
-export const variantMatcher = (name: string, selector?: (input: string) => string | undefined): VariantObject => {
+export const variantMatcher = (name: string, selector?: (input: string) => string): VariantObject => {
   const re = new RegExp(`^${escapeRegExp(name)}[:-]`)
   return {
     name,
@@ -10,7 +10,10 @@ export const variantMatcher = (name: string, selector?: (input: string) => strin
       if (match) {
         return {
           matcher: input.slice(match[0].length),
-          selector,
+          handler: (input, next) => next({
+            ...input,
+            selector: selector ? selector(input.selector) : input.selector,
+          }),
         }
       }
     },
@@ -27,7 +30,10 @@ export const variantParentMatcher = (name: string, parent: string): VariantObjec
       if (match) {
         return {
           matcher: input.slice(match[0].length),
-          parent,
+          handler: (input, next) => next({
+            ...input,
+            parent,
+          }),
         }
       }
     },

--- a/packages/preset-mini/src/variants/breakpoints.ts
+++ b/packages/preset-mini/src/variants/breakpoints.ts
@@ -42,7 +42,11 @@ export const variantBreakpoints: Variant<Theme> = {
         order -= (idx + 1)
         return {
           matcher: m,
-          parent: [`@media (max-width: ${calcMaxWidthBySize(size)})`, order],
+          handler: (input, next) => next({
+            ...input,
+            parent: `@media (max-width: ${calcMaxWidthBySize(size)})`,
+            parentOrder: order,
+          }),
         }
       }
 
@@ -52,13 +56,21 @@ export const variantBreakpoints: Variant<Theme> = {
       if (isAtPrefix && idx < variantEntries.length - 1) {
         return {
           matcher: m,
-          parent: [`@media (min-width: ${size}) and (max-width: ${calcMaxWidthBySize(variantEntries[idx + 1][1])})`, order],
+          handler: (input, next) => next({
+            ...input,
+            parent: `@media (min-width: ${size}) and (max-width: ${calcMaxWidthBySize(variantEntries[idx + 1][1])})`,
+            parentOrder: order,
+          }),
         }
       }
 
       return {
         matcher: m,
-        parent: [`@media (min-width: ${size})`, order],
+        handler: (input, next) => next({
+          ...input,
+          parent: `@media (min-width: ${size})`,
+          parentOrder: order,
+        }),
       }
     }
   },

--- a/packages/preset-mini/src/variants/combinators.ts
+++ b/packages/preset-mini/src/variants/combinators.ts
@@ -11,7 +11,10 @@ const scopeMatcher = (strict: boolean, name: string, template: string): VariantO
       if (match) {
         return {
           matcher: matcher.slice(match[0].length),
-          selector: s => template.replace('&&-s', s).replace('&&-c', match[1] ?? '*'),
+          handler: (input, next) => next({
+            ...input,
+            selector: template.replace('&&-s', input.selector).replace('&&-c', match[1] ?? '*'),
+          }),
         }
       }
     },

--- a/packages/preset-mini/src/variants/important.ts
+++ b/packages/preset-mini/src/variants/important.ts
@@ -14,12 +14,12 @@ export const variantImportant: Variant = {
     if (base) {
       return {
         matcher: base,
-        body: (body) => {
-          body.forEach((v) => {
+        handler: (input, next) => {
+          input.entries.forEach((v) => {
             if (v[1])
               v[1] += ' !important'
           })
-          return body
+          return next(input)
         },
       }
     }

--- a/packages/preset-mini/src/variants/media.ts
+++ b/packages/preset-mini/src/variants/media.ts
@@ -12,7 +12,10 @@ export const variantCustomMedia: VariantObject = {
       const media = theme.media?.[match[1]] ?? `(--${match[1]})`
       return {
         matcher: matcher.slice(match[0].length),
-        parent: `@media ${media}`,
+        handler: (input, next) => next({
+          ...input,
+          parent: `@media ${media}`,
+        }),
       }
     }
   },

--- a/packages/preset-mini/src/variants/misc.ts
+++ b/packages/preset-mini/src/variants/misc.ts
@@ -7,7 +7,10 @@ export const variantSelector: Variant = {
     if (match) {
       return {
         matcher: matcher.slice(match[0].length),
-        selector: () => match[1],
+        handler: (input, next) => next({
+          ...input,
+          selector: match[1],
+        }),
       }
     }
   },
@@ -20,7 +23,10 @@ export const variantCssLayer: Variant = {
     if (match) {
       return {
         matcher: matcher.slice(match[0].length),
-        parent: `@layer ${match[1]}`,
+        handler: (input, next) => next({
+          ...input,
+          parent: `@layer ${match[1]}`,
+        }),
       }
     }
   },
@@ -33,7 +39,10 @@ export const variantInternalLayer: Variant = {
     if (match) {
       return {
         matcher: matcher.slice(match[0].length),
-        layer: match[1],
+        handler: (input, next) => next({
+          ...input,
+          layer: match[1],
+        }),
       }
     }
   },
@@ -46,7 +55,10 @@ export const variantScope: Variant = {
     if (match) {
       return {
         matcher: matcher.slice(match[0].length),
-        selector: s => `.${match[1]} $$ ${s}`,
+        handler: (input, next) => next({
+          ...input,
+          selector: `.${match[1]} $$ ${input.selector}`,
+        }),
       }
     }
   },

--- a/packages/preset-mini/src/variants/negative.ts
+++ b/packages/preset-mini/src/variants/negative.ts
@@ -15,24 +15,31 @@ export const variantNegative: Variant = {
 
     return {
       matcher: matcher.slice(1),
-      body: (body) => {
-        if (body.find(v => v[0] === CONTROL_MINI_NO_NEGATIVE))
-          return
-        let changed = false
-        body.forEach((v) => {
-          const value = v[1]?.toString()
-          if (!value || value === '0')
+      handler: (input, next) => {
+        const body = ((body) => {
+          if (body.find(v => v[0] === CONTROL_MINI_NO_NEGATIVE))
             return
-          if (ignoreProps.some(i => v[0].match(i)))
-            return
-          if (numberRE.test(value)) {
-            v[1] = value.replace(numberRE, i => `-${i}`)
-            changed = true
-          }
+          let changed = false
+          body.forEach((v) => {
+            const value = v[1]?.toString()
+            if (!value || value === '0')
+              return
+            if (ignoreProps.some(i => v[0].match(i)))
+              return
+            if (numberRE.test(value)) {
+              v[1] = value.replace(numberRE, i => `-${i}`)
+              changed = true
+            }
+          })
+          if (changed)
+            return body
+          return []
+        })(input.entries)
+
+        return next({
+          ...input,
+          entries: body ?? input.entries,
         })
-        if (changed)
-          return body
-        return []
       },
     }
   },

--- a/packages/preset-mini/src/variants/pseudo.ts
+++ b/packages/preset-mini/src/variants/pseudo.ts
@@ -95,10 +95,13 @@ const taggedPseudoClassMatcher = (tag: string, parent: string, combinator: strin
           pseudo = `:${match[2]}(${pseudo})`
         return {
           matcher: input.slice(match[0].length),
-          selector: s => rawRe.test(s)
-            ? s.replace(rawRe, `${parent}${pseudo}:`)
-            : `${parent}${pseudo}${combinator}${s}`,
-          sort: sortValue(match[3]),
+          handler: (input, next) => next({
+            ...input,
+            selector: rawRe.test(input.selector)
+              ? input.selector.replace(rawRe, `${parent}${pseudo}:`)
+              : `${parent}${pseudo}${combinator}${input.selector}`,
+            sort: sortValue(match[3]),
+          }),
         }
       }
     },
@@ -117,8 +120,11 @@ export const variantPseudoClassesAndElements: VariantObject = {
       const pseudo = PseudoClasses[match[1]] || PseudoClassesColon[match[1]] || `:${match[1]}`
       return {
         matcher: input.slice(match[0].length),
-        selector: s => `${s}${pseudo}`,
-        sort: sortValue(match[1]),
+        handler: (input, next) => next({
+          ...input,
+          selector: `${input.selector}${pseudo}`,
+          sort: sortValue(match[1]),
+        }),
       }
     }
   },
@@ -136,7 +142,10 @@ export const variantPseudoClassFunctions: VariantObject = {
       const pseudo = PseudoClasses[match[2]] || PseudoClassesColon[match[2]] || `:${match[2]}`
       return {
         matcher: input.slice(match[0].length),
-        selector: s => `${s}:${fn}(${pseudo})`,
+        handler: (input, next) => next({
+          ...input,
+          selector: `${input.selector}:${fn}(${pseudo})`,
+        }),
       }
     }
   },
@@ -175,7 +184,10 @@ export const partClasses: VariantObject = {
       const part = `part(${match[2]})`
       return {
         matcher: input.slice(match[1].length),
-        selector: s => `${s}::${part}`,
+        handler: (input, next) => next({
+          ...input,
+          selector: `${input.selector}::${part}`,
+        }),
       }
     }
   },

--- a/packages/preset-tagify/src/variant.ts
+++ b/packages/preset-tagify/src/variant.ts
@@ -1,4 +1,4 @@
-import type { VariantHandler, VariantObject } from '@unocss/core'
+import type { VariantObject } from '@unocss/core'
 import type { TagifyOptions } from './types'
 import { MARKER } from './extractor'
 
@@ -13,19 +13,23 @@ export const variantTagify = (options: TagifyOptions): VariantObject => {
         return
 
       const matcher = input.slice(prefix.length)
-      const handler: VariantHandler = {
+
+      return {
         matcher,
-        selector: i => i.slice(MARKER.length + 1),
-      }
+        handler: (input, next) => {
+          if (extraProperties) {
+            if (typeof extraProperties === 'function')
+              input.entries.push(...Object.entries(extraProperties(matcher) ?? {}))
+            else
+              input.entries.push(...Object.entries(extraProperties))
+          }
 
-      if (extraProperties) {
-        if (typeof extraProperties === 'function')
-          handler.body = entries => [...entries, ...Object.entries(extraProperties(matcher) ?? {})]
-        else
-          handler.body = entries => [...entries, ...Object.entries(extraProperties)]
+          return next({
+            ...input,
+            selector: input.selector.slice(MARKER.length + 1),
+          })
+        },
       }
-
-      return handler
     },
   }
 }

--- a/packages/preset-uno/src/variants/mix.ts
+++ b/packages/preset-uno/src/variants/mix.ts
@@ -64,8 +64,8 @@ export const variantColorMix: Variant = (matcher) => {
   if (m) {
     return {
       matcher: matcher.slice(m[0].length),
-      body: (body) => {
-        body.forEach((v) => {
+      handler: (input, next) => {
+        input.entries.forEach((v) => {
           if (v[1]) {
             const color = parseCssColor(`${v[1]}`)
             if (color) {
@@ -75,7 +75,7 @@ export const variantColorMix: Variant = (matcher) => {
             }
           }
         })
-        return body
+        return next(input)
       },
     }
   }

--- a/packages/preset-wind/src/rules/container.ts
+++ b/packages/preset-wind/src/rules/container.ts
@@ -1,5 +1,4 @@
-import type { Rule, Shortcut } from '@unocss/core'
-import { toArray } from '@unocss/core'
+import type { Rule, Shortcut, VariantHandlerContext } from '@unocss/core'
 import type { Theme } from '@unocss/preset-mini'
 import { resolveBreakpoints } from '@unocss/preset-mini/utils'
 
@@ -11,7 +10,7 @@ export const container: Rule<Theme>[] = [
     (m, { variantHandlers }) => {
       let width = '100%'
       for (const v of variantHandlers) {
-        const query = toArray(v.parent || [])[0]
+        const query = v.handler?.({} as VariantHandlerContext, x => x).parent
         if (typeof query === 'string') {
           const match = query.match(queryMatcher)?.[1]
           if (match)

--- a/packages/preset-wind/src/variants/misc.ts
+++ b/packages/preset-wind/src/variants/misc.ts
@@ -4,9 +4,10 @@ export const variantSpaceAndDivide: Variant = (matcher) => {
   if (/^space-?([xy])-?(-?.+)$/.test(matcher) || /^divide-/.test(matcher)) {
     return {
       matcher,
-      selector: (input) => {
-        return `${input}>:not([hidden])~:not([hidden])`
-      },
+      handler: (input, next) => next({
+        ...input,
+        selector: `${input.selector}>:not([hidden])~:not([hidden])`,
+      }),
     }
   }
 }

--- a/test/order.test.ts
+++ b/test/order.test.ts
@@ -92,11 +92,14 @@ describe('order', () => {
           if (m) {
             return {
               matcher: input.slice(m[0].length),
-              selector: s => `${m[1]} ${s}`,
-              sort: {
-                pre: -1,
-                post: 1,
-              }[m[1]],
+              handler: (input, next) => next({
+                ...input,
+                selector: `${m[1]} ${input.selector}`,
+                sort: {
+                  pre: -1,
+                  post: 1,
+                }[m[1]],
+              }),
             }
           }
         },


### PR DESCRIPTION
- update `applyVariants`
- update related presets variant functions
- deprecate most of `VariantHandler` properties, moving them to `handler()`

The main goal for this is to enable usecase of #1104 without plenty of selector replace hack, while also still supports #987

#1104 should be addressed in the following branch if this PR is accepted:
https://github.com/chu121su12/unocss/tree/split-selector

Reference:
https://github.com/chu121su12/unocss/blob/51e0583c0569b12675c3cfe3b2fcfa05a0cac38b/test/__snapshots__/preset-mini.test.ts.snap#L370

https://github.com/chu121su12/unocss/blob/51e0583c0569b12675c3cfe3b2fcfa05a0cac38b/test/__snapshots__/preset-mini.test.ts.snap#L387