### PR TITLE
feat(core,presets)!: update presets to use the recursive callback

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -322,7 +322,7 @@ export class UnoGenerator {
         if (typeof handler === 'string')
           handler = { matcher: handler }
         processed = handler.matcher
-        handlers.unshift(handler)
+        handlers.push(handler)
         variants.add(v)
         applied = true
         break
@@ -347,6 +347,7 @@ export class UnoGenerator {
             const entries = v.body?.(input.entries) || input.entries
             const parents: [string | undefined, number | undefined] = Array.isArray(v.parent) ? v.parent : [v.parent, undefined]
             return (v.handle ?? defaultVariantHandler)({
+              ...input,
               entries,
               selector: v.selector?.(input.selector, entries) || input.selector,
               parent: parents[0] || input.parent,
@@ -359,16 +360,22 @@ export class UnoGenerator {
       )
 
     const variantContextResult = handler({
-      entries: parsed[2],
+      prefix: '',
       selector: toEscapedSelector(raw),
+      pseudo: '',
+      entries: parsed[2],
     })
 
-    const { parent, parentOrder, selector } = variantContextResult
+    const { parent, parentOrder } = variantContextResult
     if (parent != null && parentOrder != null)
       this.parentOrders.set(parent, parentOrder)
 
     const obj: UtilObject = {
-      selector: movePseudoElementsEnd(selector),
+      selector: movePseudoElementsEnd([
+        variantContextResult.prefix,
+        variantContextResult.selector,
+        variantContextResult.pseudo,
+      ].join('')),
       entries: variantContextResult.entries,
       parent,
       layer: variantContextResult.layer,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -191,9 +191,17 @@ export type BlocklistRule = string | RegExp
 
 export interface VariantHandlerContext {
   /**
-   * Rewrite the output selector. Often be used to append pesudo classes or parents.
+   * Rewrite the output selector. Often be used to append parents.
+   */
+  prefix: string
+  /**
+   * Rewrite the output selector. Often be used to append pesudo classes.
    */
   selector: string
+  /**
+   * Rewrite the output selector. Often be used to append pesudo elements.
+   */
+  pseudo: string
   /**
    * Rewrite the output css body. The input come in [key,value][] pairs.
    */

--- a/packages/preset-mini/src/utils/variants.ts
+++ b/packages/preset-mini/src/utils/variants.ts
@@ -1,7 +1,7 @@
-import type { VariantHandler, VariantObject } from '@unocss/core'
+import type { VariantHandler, VariantHandlerContext, VariantObject } from '@unocss/core'
 import { escapeRegExp } from '@unocss/core'
 
-export const variantMatcher = (name: string, selector?: (input: string) => string | undefined): VariantObject => {
+export const variantMatcher = (name: string, handler: (input: VariantHandlerContext) => Record<string, any>): VariantObject => {
   const re = new RegExp(`^${escapeRegExp(name)}[:-]`)
   return {
     name,
@@ -10,7 +10,10 @@ export const variantMatcher = (name: string, selector?: (input: string) => strin
       if (match) {
         return {
           matcher: input.slice(match[0].length),
-          selector,
+          handle: (input, next) => next({
+            ...input,
+            ...handler(input),
+          }),
         }
       }
     },

--- a/packages/preset-mini/src/variants/dark.ts
+++ b/packages/preset-mini/src/variants/dark.ts
@@ -5,8 +5,8 @@ import { variantMatcher, variantParentMatcher } from '../utils'
 export const variantColorsMediaOrClass = (options: PresetMiniOptions = {}): Variant[] => {
   if (options?.dark === 'class') {
     return [
-      variantMatcher('dark', input => `.dark $$ ${input}`),
-      variantMatcher('light', input => `.light $$ ${input}`),
+      variantMatcher('dark', input => ({ prefix: `${input.prefix}.dark $$ ` })),
+      variantMatcher('light', input => ({ prefix: `${input.prefix}.light $$ ` })),
     ]
   }
 

--- a/packages/preset-mini/src/variants/directions.ts
+++ b/packages/preset-mini/src/variants/directions.ts
@@ -2,6 +2,6 @@ import type { Variant } from '@unocss/core'
 import { variantMatcher } from '../utils'
 
 export const variantLanguageDirections: Variant[] = [
-  variantMatcher('rtl', input => `[dir="rtl"] $$ ${input}`),
-  variantMatcher('ltr', input => `[dir="ltr"] $$ ${input}`),
+  variantMatcher('rtl', input => ({ prefix: `${input.prefix}[dir="rtl"] $$ ` })),
+  variantMatcher('ltr', input => ({ prefix: `${input.prefix}[dir="ltr"] $$ ` })),
 ]

--- a/packages/preset-wind/src/variants/combinators.ts
+++ b/packages/preset-wind/src/variants/combinators.ts
@@ -2,5 +2,5 @@ import type { Variant } from '@unocss/core'
 import { variantMatcher } from '@unocss/preset-mini/utils'
 
 export const variantCombinators: Variant[] = [
-  variantMatcher('svg', input => `${input} svg`),
+  variantMatcher('svg', input => ({ selector: `${input.selector} svg` })),
 ]

--- a/packages/preset-wind/src/variants/dark.ts
+++ b/packages/preset-wind/src/variants/dark.ts
@@ -2,8 +2,8 @@ import type { Variant } from '@unocss/core'
 import { variantMatcher, variantParentMatcher } from '@unocss/preset-mini/utils'
 
 export const variantColorsScheme: Variant[] = [
-  variantMatcher('.dark', input => `.dark $$ ${input}`),
-  variantMatcher('.light', input => `.light $$ ${input}`),
+  variantMatcher('.dark', input => ({ prefix: `${input.prefix}.dark $$ ` })),
+  variantMatcher('.light', input => ({ prefix: `${input.prefix}.light $$ ` })),
   variantParentMatcher('@dark', '@media (prefers-color-scheme: dark)'),
   variantParentMatcher('@light', '@media (prefers-color-scheme: light)'),
 ]

--- a/test/__snapshots__/order.test.ts.snap
+++ b/test/__snapshots__/order.test.ts.snap
@@ -14,16 +14,24 @@ exports[`order > movePseudoElementsEnd 1`] = `".marker\\\\:file\\\\:hover\\\\:se
 
 exports[`order > multiple variant sorting 1`] = `
 "/* layer: default */
-.dark .group:hover:focus-within .dark\\\\:group-hover\\\\:group-focus-within\\\\:bg-blue-600{--un-bg-opacity:1;background-color:rgba(37,99,235,var(--un-bg-opacity));}
-.group:hover:focus-within .dark .group-hover\\\\:group-focus-within\\\\:dark\\\\:bg-red-600{--un-bg-opacity:1;background-color:rgba(220,38,38,var(--un-bg-opacity));}"
+.dark .group:focus-within:hover .dark\\\\:group-hover\\\\:group-focus-within\\\\:bg-blue-600{--un-bg-opacity:1;background-color:rgba(37,99,235,var(--un-bg-opacity));}
+.group:focus-within:hover .dark .group-hover\\\\:group-focus-within\\\\:dark\\\\:bg-red-600{--un-bg-opacity:1;background-color:rgba(220,38,38,var(--un-bg-opacity));}"
 `;
 
 exports[`order > variant ordering 1`] = `
 "/* layer: default */
-.dark .group .dark\\\\:group\\\\:foo-3{name:foo-3;}
-.dark .group .group\\\\:dark\\\\:foo-4{name:foo-4;}
+.group .dark .dark\\\\:group\\\\:foo-3{name:foo-3;}
+.group .dark .group\\\\:dark\\\\:foo-4{name:foo-4;}
 .group .light .group\\\\:light\\\\:foo-2{name:foo-2;}
 .light .group .light\\\\:group\\\\:foo-1{name:foo-1;}"
+`;
+
+exports[`order > variant ordering reversed 1`] = `
+"/* layer: default */
+.dark .group .dark\\\\:group\\\\:foo-3{name:foo-3;}
+.dark .group .group\\\\:dark\\\\:foo-4{name:foo-4;}
+.group .light .light\\\\:group\\\\:foo-1{name:foo-1;}
+.light .group .group\\\\:light\\\\:foo-2{name:foo-2;}"
 `;
 
 exports[`order > variant sorting 1`] = `

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -116,12 +116,12 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .file\\\\:bg-violet-50::file-selector-button{--un-bg-opacity:1;background-color:rgba(245,243,255,var(--un-bg-opacity));}
 .first-letter\\\\:bg-green-400::first-letter,
 .first-line\\\\:bg-green-400::first-line{--un-bg-opacity:1;background-color:rgba(74,222,128,var(--un-bg-opacity));}
-.focus-within\\\\:has-first\\\\:checked\\\\:bg-gray\\\\/20:checked:has(:first-child):focus-within,
-.focus-within\\\\:where-first\\\\:checked\\\\:bg-gray\\\\/20:checked:where(:first-child):focus-within{background-color:rgba(156,163,175,0.2);}
+.focus-within\\\\:has-first\\\\:checked\\\\:bg-gray\\\\/20:focus-within:has(:first-child):checked,
+.focus-within\\\\:where-first\\\\:checked\\\\:bg-gray\\\\/20:focus-within:where(:first-child):checked{background-color:rgba(156,163,175,0.2);}
 .hover\\\\:file\\\\:bg-violet-100:hover::file-selector-button{--un-bg-opacity:1;background-color:rgba(237,233,254,var(--un-bg-opacity));}
-.hover\\\\:is-first\\\\:checked\\\\:bg-true-gray\\\\/10:checked:is(:first-child):hover,
-.hover\\\\:not-first\\\\:checked\\\\:bg-true-gray\\\\/10:checked:not(:first-child):hover{background-color:rgba(163,163,163,0.1);}
-.hover\\\\:not-first\\\\:checked\\\\:bg-red\\\\/10:checked:not(:first-child):hover{background-color:rgba(248,113,113,0.1);}
+.hover\\\\:is-first\\\\:checked\\\\:bg-true-gray\\\\/10:hover:is(:first-child):checked,
+.hover\\\\:not-first\\\\:checked\\\\:bg-true-gray\\\\/10:hover:not(:first-child):checked{background-color:rgba(163,163,163,0.1);}
+.hover\\\\:not-first\\\\:checked\\\\:bg-red\\\\/10:hover:not(:first-child):checked{background-color:rgba(248,113,113,0.1);}
 .marker\\\\:bg-violet-200::marker{--un-bg-opacity:1;background-color:rgba(221,214,254,var(--un-bg-opacity));}
 .peer:checked~.peer-checked\\\\:bg-blue-500{--un-bg-opacity:1;background-color:rgba(59,130,246,var(--un-bg-opacity));}
 .previous:checked+.previous-checked\\\\:bg-red-500{--un-bg-opacity:1;background-color:rgba(239,68,68,var(--un-bg-opacity));}
@@ -335,7 +335,7 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .text-shadow-color-op-30{--un-text-shadow-opacity:0.3;}
 .case-upper{text-transform:uppercase;}
 .case-normal{text-transform:none;}
-.group:hover:focus .group-hover\\\\:group-focus\\\\:text-center,
+.group:focus:hover .group-hover\\\\:group-focus\\\\:text-center,
 .parent:hover>.parent-hover\\\\:text-center{text-align:center;}
 .text-left,
 [dir=\\"ltr\\"] .ltr\\\\:text-left{text-align:left;}
@@ -371,6 +371,7 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .c-\\\\$color-variable,
 .c-\\\\$color-variable\\\\/\\\\$opacity-variable,
 .c-\\\\$color-variable\\\\/10{color:var(--color-variable);}
+.checked\\\\:next\\\\:text-slate-100:checked+*{--un-text-opacity:1;color:rgba(241,245,249,var(--un-text-opacity));}
 .color-\\\\$red{color:var(--red);}
 .color-blue,
 .color-blue-400{--un-text-opacity:1;color:rgba(96,165,250,var(--un-text-opacity));}
@@ -387,6 +388,7 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .in-range\\\\:color-pink-100:in-range,
 .open\\\\:color-pink-100[open],
 .out-of-range\\\\:color-pink-100:out-of-range{--un-text-opacity:1;color:rgba(252,231,243,var(--un-text-opacity));}
+.next\\\\:checked\\\\:text-slate-200+*:checked{--un-text-opacity:1;color:rgba(226,232,240,var(--un-text-opacity));}
 .placeholder-color-red-1::placeholder,
 .text-red-100,
 .text-red100{--un-text-opacity:1;color:rgba(254,226,226,var(--un-text-opacity));}

--- a/test/__snapshots__/variant-handler.test.ts.snap
+++ b/test/__snapshots__/variant-handler.test.ts.snap
@@ -1,10 +1,18 @@
 // Vitest Snapshot v1
 
+exports[`variants > selector section is merged in order 1`] = `
+"/* layer: default */
+.prefix .pre\\\\:back\\\\:foo::pseudo,
+.prefix .replaced,
+.prefix .replaced::pseudo,
+.replaced::pseudo{name:bar;}"
+`;
+
 exports[`variants > variant can stack 1`] = `
 "/* layer: default */
-.first\\\\:second\\\\:third\\\\:foo > :third > :second > :first,
-.first\\\\:three\\\\:two\\\\:foo > :first + :three + :two,
-.one\\\\:two\\\\:three\\\\:foo + :one + :two + :three{name:bar;}"
+.append-one\\\\:append-two\\\\:append-three\\\\:foo > :append-one > :append-two > :append-three,
+.append-one\\\\:prepend-three\\\\:prepend-two\\\\:foo > :append-one + :prepend-two + :prepend-three,
+.prepend-one\\\\:prepend-two\\\\:prepend-three\\\\:foo + :prepend-three + :prepend-two + :prepend-one{name:bar;}"
 `;
 
 exports[`variants > variant context is propagated 1`] = `
@@ -12,6 +20,6 @@ exports[`variants > variant context is propagated 1`] = `
 .foo{name:bar;}
 /* layer: variant */
 @supports{
-.selector{name:bar !important;}
+:prefix > .selector::pseudo{name:bar !important;}
 }"
 `;

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -880,6 +880,10 @@ export const presetMiniTargets: string[] = [
   '[&_&]:m-13',
   '[@supports(display:grid)]:bg-red/33',
   '[@supports(display:grid)]:[*+&]:bg-red/34',
+
+  // variants - tagged & pseudo
+  'checked:next:text-slate-100',
+  'next:checked:text-slate-200',
 ]
 
 export const presetMiniNonTargets = [

--- a/test/order.test.ts
+++ b/test/order.test.ts
@@ -35,10 +35,42 @@ describe('order', () => {
       ],
       presets: [],
       variants: [
-        variantMatcher('light', input => `.light $$ ${input}`),
-        variantMatcher('group', input => `.group ${input}`),
+        variantMatcher('light', input => ({ prefix: `${input.prefix}.light $$ ` })),
+        variantMatcher('group', input => ({ prefix: `${input.prefix}.group ` })),
         (v, ctx) => {
-          const match = variantMatcher('dark', input => `.dark $$ ${input}`).match(v, ctx)
+          const match = variantMatcher('dark', input => ({ prefix: `${input.prefix}.dark $$ ` })).match(v, ctx)
+          if (typeof match === 'object') {
+            return {
+              ...match,
+              order: 1,
+            }
+          }
+        },
+      ],
+    })
+    const code = [
+      'light:group:foo-1',
+      'group:light:foo-2',
+      'dark:group:foo-3',
+      'group:dark:foo-4',
+    ].join(' ')
+    const { css } = await uno.generate(code, { preflights: false })
+    const { css: css2 } = await uno.generate(code, { preflights: false })
+    expect(css).toMatchSnapshot()
+    expect(css).toEqual(css2)
+  })
+
+  test('variant ordering reversed', async () => {
+    const uno = createGenerator({
+      rules: [
+        [/^foo-.$/, ([m]) => ({ name: m })],
+      ],
+      presets: [],
+      variants: [
+        variantMatcher('light', input => ({ prefix: `.light $$ ${input.prefix}` })),
+        variantMatcher('group', input => ({ prefix: `.group ${input.prefix}` })),
+        (v, ctx) => {
+          const match = variantMatcher('dark', input => ({ prefix: `.dark $$ ${input.prefix}` })).match(v, ctx)
           if (typeof match === 'object') {
             return {
               ...match,

--- a/test/selector-no-merge.test.ts
+++ b/test/selector-no-merge.test.ts
@@ -25,8 +25,8 @@ describe('variant', () => {
       [/^m3-(.+)$/, ([, s]) => `moz:${s} merge-candidate-early`],
     ],
     variants: [
-      variantMatcher('moz', s => `${s}::non-breaking`),
-      variantMatcher('webkit', s => `${s}::breaking`),
+      variantMatcher('moz', s => ({ pseudo: `${s.pseudo}::non-breaking` })),
+      variantMatcher('webkit', s => ({ pseudo: `${s.pseudo}::breaking` })),
     ],
     rules: [
       [/^no-merge$/, () => ({ merged: 1 }), { noMerge: true }],


### PR DESCRIPTION
Follow up to #1126, this PR update the existing variants to use the introduced variant `handler()`.

Closes #1104 

This PR adds 2 extra properties on the handler. Variants that use selector sectioning (the one that uses `$$`: dark, rtl/ltr and group pseudo) are now moved into `prefix` so it can be modified selectively.
https://github.com/unocss/unocss/blob/91ea249ea583b7403bf3256f1705ae0966ab3360/packages/core/src/types.ts#L193-L204
