### PR TITLE
fix: webpack plugin's resolveId preserve the input query

### DIFF
--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -55,8 +55,13 @@ export default function WebpackPlugin<Theme extends {}>(
       resolveId(id) {
         const entry = resolveId(id)
         if (entry) {
+          let query = ''
+          const queryIndex = id.indexOf('?')
+          if (queryIndex >= 0)
+            query = id.slice(queryIndex)
           entries.add(entry)
-          return entry
+          // preserve the input query
+          return entry + query
         }
       },
       // serve the placeholders in virtual module


### PR DESCRIPTION
Same question and work with https://github.com/unjs/unplugin/pull/129