### PR TITLE
feat(preset-mini)!: add tagged variants' pseudo in order

### DIFF
--- a/packages/preset-mini/src/variants/pseudo.ts
+++ b/packages/preset-mini/src/variants/pseudo.ts
@@ -82,7 +82,7 @@ const sortValue = (pseudo: string) => {
 }
 
 const taggedPseudoClassMatcher = (tag: string, parent: string, combinator: string): VariantObject => {
-  const rawRe = new RegExp(`${escapeRegExp(parent)}:`)
+  const rawRe = new RegExp(`^(${escapeRegExp(parent)}:)(\\S+)${escapeRegExp(combinator)}\\1`)
   const pseudoRE = new RegExp(`^${tag}-((?:(${PseudoClassFunctionsStr})-)?(${PseudoClassesStr}))[:-]`)
   const pseudoColonRE = new RegExp(`^${tag}-((?:(${PseudoClassFunctionsStr})-)?(${PseudoClassesColonStr}))[:]`)
   return {
@@ -97,14 +97,13 @@ const taggedPseudoClassMatcher = (tag: string, parent: string, combinator: strin
           matcher: input.slice(match[0].length),
           handle: (input, next) => next({
             ...input,
-            prefix: rawRe.test(input.prefix)
-              ? input.prefix.replace(rawRe, `${parent}${pseudo}:`)
-              : `${parent}${pseudo}${combinator}${input.prefix}`,
+            prefix: `${parent}${pseudo}${combinator}${input.prefix}`.replace(rawRe, '$1$2:'),
             sort: sortValue(match[3]),
           }),
         }
       }
     },
+    multiPass: true,
   }
 }
 
@@ -164,22 +163,10 @@ export const variantTaggedPseudoClasses = (options: PresetMiniOptions = {}): Var
   const attributify = !!options?.attributifyPseudo
 
   return [
-    {
-      ...taggedPseudoClassMatcher('group', attributify ? '[group=""]' : '.group', ' '),
-      multiPass: true,
-    },
-    {
-      ...taggedPseudoClassMatcher('peer', attributify ? '[peer=""]' : '.peer', '~'),
-      multiPass: true,
-    },
-    {
-      ...taggedPseudoClassMatcher('parent', attributify ? '[parent=""]' : '.parent', '>'),
-      multiPass: true,
-    },
-    {
-      ...taggedPseudoClassMatcher('previous', attributify ? '[previous=""]' : '.previous', '+'),
-      multiPass: true,
-    },
+    taggedPseudoClassMatcher('group', attributify ? '[group=""]' : '.group', ' '),
+    taggedPseudoClassMatcher('peer', attributify ? '[peer=""]' : '.peer', '~'),
+    taggedPseudoClassMatcher('parent', attributify ? '[parent=""]' : '.parent', '>'),
+    taggedPseudoClassMatcher('previous', attributify ? '[previous=""]' : '.previous', '+'),
   ]
 }
 

--- a/test/__snapshots__/order.test.ts.snap
+++ b/test/__snapshots__/order.test.ts.snap
@@ -15,7 +15,9 @@ exports[`order > movePseudoElementsEnd 1`] = `".marker\\\\:file\\\\:hover\\\\:se
 exports[`order > multiple variant sorting 1`] = `
 "/* layer: default */
 .dark .group:hover:focus-within .dark\\\\:group-hover\\\\:group-focus-within\\\\:bg-blue-600{--un-bg-opacity:1;background-color:rgba(37,99,235,var(--un-bg-opacity));}
-.group:hover:focus-within .dark .group-hover\\\\:group-focus-within\\\\:dark\\\\:bg-red-600{--un-bg-opacity:1;background-color:rgba(220,38,38,var(--un-bg-opacity));}"
+.group:hover:focus-within .dark .group-hover\\\\:group-focus-within\\\\:dark\\\\:bg-red-600{--un-bg-opacity:1;background-color:rgba(220,38,38,var(--un-bg-opacity));}
+.parent:hover>.light .group:focus-within .parent-hover\\\\:light\\\\:group-focus-within\\\\:bg-yellow-600{--un-bg-opacity:1;background-color:rgba(202,138,4,var(--un-bg-opacity));}
+.parent:hover>.light .parent:focus-within>.parent-hover\\\\:light\\\\:parent-focus-within\\\\:bg-green-600{--un-bg-opacity:1;background-color:rgba(22,163,74,var(--un-bg-opacity));}"
 `;
 
 exports[`order > variant ordering 1`] = `

--- a/test/order.test.ts
+++ b/test/order.test.ts
@@ -102,6 +102,8 @@ describe('order', () => {
     const { css } = await uno.generate([
       'dark:group-hover:group-focus-within:bg-blue-600',
       'group-hover:group-focus-within:dark:bg-red-600',
+      'parent-hover:light:parent-focus-within:bg-green-600',
+      'parent-hover:light:group-focus-within:bg-yellow-600',
     ].join(' '), { preflights: false })
 
     expect(css).toMatchSnapshot()


### PR DESCRIPTION
Breaking because currently this

```html
<div class="parent-hover:dark:parent-focus:bg-yellow-600">
``` 

bunches the `parent`s together and yields:

```css
.dark .parent:hover:focus>.parent-hover\:dark\:parent-focus\:bg-yellow-600{...}
```

This PR aligns the behavior with the distinct version (ex.: group & parent):

```html
<div class="group-hover:dark:parent-focus:bg-yellow-600">
``` 
```css
.group:hover .dark .parent:focus>.group-hover\:dark\:parent-focus\:bg-yellow-600{...}
```

Edit: update examples