### PR TITLE
feat(core)!: default preflights to `preflights` layer

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -175,12 +175,10 @@ export class UnoGenerator {
         theme: this.config.theme,
       }
 
-      const preflightLayerSet = new Set<string>(['preflights'])
-      this.config.preflights.forEach(({ layer }) => {
-        if (layer) {
-          layerSet.add(layer)
-          preflightLayerSet.add(layer)
-        }
+      const preflightLayerSet = new Set<string>([])
+      this.config.preflights.forEach(({ layer = 'preflights' }) => {
+        layerSet.add(layer)
+        preflightLayerSet.add(layer)
       })
 
       preflightsMap = Object.fromEntries(

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -175,7 +175,7 @@ export class UnoGenerator {
         theme: this.config.theme,
       }
 
-      const preflightLayerSet = new Set<string>(['default'])
+      const preflightLayerSet = new Set<string>(['preflights'])
       this.config.preflights.forEach(({ layer }) => {
         if (layer) {
           layerSet.add(layer)
@@ -188,7 +188,7 @@ export class UnoGenerator {
           async (layer) => {
             const preflights = await Promise.all(
               this.config.preflights
-                .filter(i => (i.layer || 'default') === layer)
+                .filter(i => (i.layer || 'preflights') === layer)
                 .map(async i => await i.getCSS(preflightContext)),
             )
             const css = preflights

--- a/test/__snapshots__/preflights.test.ts.snap
+++ b/test/__snapshots__/preflights.test.ts.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1
 
 exports[`preflights > basic 1`] = `
-"/* layer: default */
+"/* layer: preflights */
 .default-preflight {}
-/* layer: preflight */
+/* layer: custom */
 .hello { text: red }"
 `;

--- a/test/preflights.test.ts
+++ b/test/preflights.test.ts
@@ -9,7 +9,7 @@ describe('preflights', () => {
           getCSS() {
             return '.hello { text: red }'
           },
-          layer: 'preflight',
+          layer: 'custom',
         },
         {
           getCSS() { return undefined },


### PR DESCRIPTION
Trying to address https://github.com/unocss/unocss/issues/1186 though I'm not exactly sure I understand the code enough, so I don't know if those two places are sufficient or if I missed something.

Please let me know if there's more to it.

Quoting myself from https://github.com/unocss/unocss/issues/1186 for a little more inline-context
> I think this is really confusing as I'm specifically defining a preflight here, so I'd expect it to be in preflight and therefore ordered before other styles instead of needing to manually "duplicate" my intend.

Closes https://github.com/unocss/unocss/issues/1186