### PR TITLE
feat(vscode): add color preview

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "publisher": "antfu",
-  "name": "unocss",
+  "name": "@vscode/unocss",
   "displayName": "UnoCSS",
   "version": "0.41.2",
   "private": true,

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -50,7 +50,7 @@
         },
         "unocss.colorPreview": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Enable/disable color preview decorations"
         }
       }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -47,6 +47,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enable/disable underline decoration for class names"
+        },
+        "unocss.colorPreview": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable/disable color preview decorations"
         }
       }
     }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "publisher": "antfu",
-  "name": "@unocss/vscode",
+  "name": "unocss",
   "displayName": "UnoCSS",
   "version": "0.41.2",
   "private": true,

--- a/packages/vscode/src/annotation.ts
+++ b/packages/vscode/src/annotation.ts
@@ -1,6 +1,9 @@
 import path from 'path'
 import type { DecorationOptions, ExtensionContext, StatusBarItem } from 'vscode'
 import { DecorationRangeBehavior, MarkdownString, Range, window, workspace } from 'vscode'
+import { parseColor } from '@unocss/preset-mini'
+import type { Theme } from '@unocss/preset-mini'
+import { hex2rgba } from '@unocss/preset-mini/utils'
 import { INCLUDE_COMMENT_IDE, getMatchedPositions } from './integration'
 import { log } from './log'
 import { getPrettiedMarkdown, isCssId, throttle } from './utils'
@@ -47,6 +50,26 @@ export async function registerAnnotations(
     rangeBehavior: DecorationRangeBehavior.ClosedClosed,
   })
 
+  const colorDecoration = window.createTextEditorDecorationType({
+    before: {
+      width: '0.8em',
+      height: '0.8em',
+      contentText: ' ',
+      border: '0.1em solid',
+      margin: '0.1em 0.2em 0',
+    },
+    dark: {
+      before: {
+        borderColor: '#eeeeee',
+      },
+    },
+    light: {
+      before: {
+        borderColor: '#000000',
+      },
+    },
+  })
+
   async function updateAnnotation(editor = window.activeTextEditor) {
     try {
       const doc = editor?.document
@@ -67,10 +90,46 @@ export async function registerAnnotations(
 
       const result = await ctx.uno.generate(code, { id, preflights: false, minify: true })
 
+      const theme = ctx.uno.config.theme as Theme
+
+      const attributifyRE = /(?<=^\[.+~?=").*(?="\]$)/
+      const colorsMap = new Map<string, string>()
+
+      for (const i of result.matched) {
+        const matchedAttr = i.match(attributifyRE)
+        const body = matchedAttr ? matchedAttr[0].split(':').at(-1) ?? '' : i // remove prefix e.g. `dark:` `hover:`
+
+        // remove color body's prefix e.g. `bg-` `border-` `text-`
+        for (const part of body.split(/\d|-/)) {
+          if (theme.colors?.[part]) {
+            const subStart = body.indexOf(part)
+            const parsedResult = parseColor(body.substring(subStart), theme)
+
+            if (parsedResult?.color) {
+              const rgbaValue = hex2rgba(parsedResult.color)
+              colorsMap.set(i.replace('~', ''), rgbaValue ? `rgba(${rgbaValue.join(',')},${parsedResult.alpha ?? 1})` : '')
+            }
+          }
+        }
+      }
+
+      const colorRanges: DecorationOptions[] = []
+
+      const positionCache = new Map<string, string>()
+
       const ranges: DecorationOptions[] = (
         await Promise.all(
           getMatchedPositions(code, Array.from(result.matched))
             .map(async (i): Promise<DecorationOptions> => {
+              // side-effect: update colorRanges
+              if (colorsMap.has(i[2]) && !positionCache.has(`${i[0]}:${i[1]}`)) {
+                positionCache.set(`${i[0]}:${i[1]}`, i[2])
+                colorRanges.push({
+                  range: new Range(doc.positionAt(i[0]), doc.positionAt(i[1])),
+                  renderOptions: { before: { backgroundColor: colorsMap.get(i[2]) } },
+                })
+              }
+
               try {
                 const md = await getPrettiedMarkdown(ctx!.uno, i[2])
                 return {
@@ -89,6 +148,8 @@ export async function registerAnnotations(
         )
       ).filter(Boolean)
 
+      editor.setDecorations(colorDecoration, colorRanges)
+
       if (underline) {
         editor.setDecorations(NoneDecoration, [])
         editor.setDecorations(UnderlineDecoration, ranges)
@@ -105,6 +166,7 @@ export async function registerAnnotations(
       function reset() {
         editor?.setDecorations(UnderlineDecoration, [])
         editor?.setDecorations(NoneDecoration, [])
+        editor?.setDecorations(colorDecoration, [])
         status.hide()
       }
     }

--- a/packages/vscode/src/annotation.ts
+++ b/packages/vscode/src/annotation.ts
@@ -13,14 +13,14 @@ export async function registerAnnotations(
   ext: ExtensionContext,
 ) {
   let underline: boolean = workspace.getConfiguration().get('unocss.underline') ?? true
-  let colorPreview: boolean = workspace.getConfiguration().get('unocss.colorPreview') ?? false
+  let colorPreview: boolean = workspace.getConfiguration().get('unocss.colorPreview') ?? true
   ext.subscriptions.push(workspace.onDidChangeConfiguration((event) => {
     if (event.affectsConfiguration('unocss.underline')) {
       underline = workspace.getConfiguration().get('unocss.underline') ?? true
       updateAnnotation()
     }
     if (event.affectsConfiguration('unocss.colorPreview')) {
-      colorPreview = workspace.getConfiguration().get('unocss.colorPreview') ?? false
+      colorPreview = workspace.getConfiguration().get('unocss.colorPreview') ?? true
       updateAnnotation()
     }
   }))

--- a/packages/vscode/src/annotation.ts
+++ b/packages/vscode/src/annotation.ts
@@ -54,20 +54,20 @@ export async function registerAnnotations(
 
   const colorDecoration = window.createTextEditorDecorationType({
     before: {
-      width: '0.8em',
-      height: '0.8em',
+      width: '0.9em',
+      height: '0.9em',
       contentText: ' ',
-      border: '0.1em solid',
-      margin: '0.1em 0.2em 0',
+      border: '1px solid',
+      margin: 'auto 0.2em auto 0;vertical-align: middle;border-radius:50%;',
     },
     dark: {
       before: {
-        borderColor: '#eeeeee',
+        borderColor: '#eeeeee50',
       },
     },
     light: {
       before: {
-        borderColor: '#000000',
+        borderColor: '#00000050',
       },
     },
   })

--- a/packages/vscode/src/annotation.ts
+++ b/packages/vscode/src/annotation.ts
@@ -13,9 +13,14 @@ export async function registerAnnotations(
   ext: ExtensionContext,
 ) {
   let underline: boolean = workspace.getConfiguration().get('unocss.underline') ?? true
+  let colorPreview: boolean = workspace.getConfiguration().get('unocss.colorPreview') ?? false
   ext.subscriptions.push(workspace.onDidChangeConfiguration((event) => {
     if (event.affectsConfiguration('unocss.underline')) {
       underline = workspace.getConfiguration().get('unocss.underline') ?? true
+      updateAnnotation()
+    }
+    if (event.affectsConfiguration('unocss.colorPreview')) {
+      colorPreview = workspace.getConfiguration().get('unocss.colorPreview') ?? false
       updateAnnotation()
     }
   }))
@@ -96,7 +101,7 @@ export async function registerAnnotations(
           getMatchedPositions(code, Array.from(result.matched))
             .map(async (i): Promise<DecorationOptions> => {
               // side-effect: update colorRanges
-              if (colorsMap.has(i[2]) && !_colorPositionsCache.has(`${i[0]}:${i[1]}`)) {
+              if (colorPreview && colorsMap.has(i[2]) && !_colorPositionsCache.has(`${i[0]}:${i[1]}`)) {
                 _colorPositionsCache.set(`${i[0]}:${i[1]}`, i[2])
                 colorRanges.push({
                   range: new Range(doc.positionAt(i[0]), doc.positionAt(i[1])),

--- a/packages/vscode/src/utils.ts
+++ b/packages/vscode/src/utils.ts
@@ -53,8 +53,10 @@ export function getColorsMap(uno: UnoGenerator, result: GenerateResult) {
       const nameIndex = body.indexOf(colorName)
       if (nameIndex > -1) {
         const parsedResult = parseColor(body.substring(nameIndex), theme)
-        if (parsedResult?.color)
-          colorsMap.set(i.replace('~', ''), parsedResult.color)
+        if (parsedResult?.cssColor) {
+          const { alpha: cssAlpha, components } = parsedResult.cssColor
+          colorsMap.set(i.replace('~', ''), `rgba(${components.join(',')},${parsedResult.alpha ?? cssAlpha ?? 1})`)
+        }
 
         break
       }


### PR DESCRIPTION
Resolves #993 

Works well on [Vitesse](https://github.com/antfu/vitesse). I haven't tested too much on other frameworks, so it might not be stable. Set the option `"unocss.colorPreview": false` in `setting.json` to disable this feature. 