### PR TITLE
docs(examples): Next.js: added information on HMR usage

### DIFF
--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -85,6 +85,27 @@ const Home: NextPage = () => {
 
 <br>
 
+## Hot Module Reload 
+To support HMR you have to opt-out of webpacks caching.
+
+```diff
+// next.config.js
+
+const nextConfig = {
+  reactStrictMode: true,
+  webpack: (config) => {
++   config.cache = false
+    config.plugins.push(
+      UnoCSS({
+        //...
+      })
+    )
+    return config
+  }
+}
+```
+<br>
+
 ## Troubleshooting
 
 #### Error concerning virtual module

--- a/examples/next/next.config.js
+++ b/examples/next/next.config.js
@@ -4,6 +4,7 @@ const UnoCSS = require('@unocss/webpack').default
 const nextConfig = {
   reactStrictMode: true,
   webpack: (config) => {
+    config.cache = false
     config.plugins.push(
       UnoCSS(),
     )


### PR DESCRIPTION
Added information on how to disable webpacks caching in nextjs so that HMR works with unocss.