### PR TITLE
feat(core): utils level prefix

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -14,8 +14,8 @@ export function resolveShortcuts(shortcuts: UserShortcuts): Shortcut[] {
 export function resolvePreset(preset: Preset): Preset {
   if (preset.prefix) {
     preset.rules?.forEach((i) => {
-      if (i[2])
-        i[2].prefix ||= preset.prefix
+      if (i[2] && i[2].prefix == null)
+        i[2].prefix = preset.prefix
       else
         i[2] = { prefix: preset.prefix }
     })

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -14,10 +14,13 @@ export function resolveShortcuts(shortcuts: UserShortcuts): Shortcut[] {
 export function resolvePreset(preset: Preset): Preset {
   if (preset.prefix) {
     preset.rules?.forEach((i) => {
-      if (i[2] && i[2].prefix == null)
-        i[2].prefix = preset.prefix
-      else
+      if (i[2]) {
+        if (i[2].prefix == null)
+          i[2].prefix = preset.prefix
+      }
+      else {
         i[2] = { prefix: preset.prefix }
+      }
     })
   }
   return preset

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -124,14 +124,16 @@ export class UnoGenerator {
 
   async generate(
     input: string | Set<string> | string[],
-    {
+    options: GenerateOptions = {},
+  ): Promise<GenerateResult> {
+    const {
       id,
       scope,
       preflights = true,
       safelist = true,
       minify = false,
-    }: GenerateOptions = {},
-  ): Promise<GenerateResult> {
+    } = options
+
     const tokens: Readonly<Set<string>> = typeof input === 'string'
       ? await this.applyExtractors(input, id)
       : Array.isArray(input)
@@ -279,9 +281,8 @@ export class UnoGenerator {
           .join(nl)
       }
 
-      return layerCache[layer] = !minify && css
-        ? `/* layer: ${layer} */${nl}${css}`
-        : css
+      const layerMark = minify ? '' : `/* layer: ${layer} */${nl}`
+      return layerCache[layer] = css ? layerMark + css : ''
     }
 
     const getLayers = (includes = layers, excludes?: string[]) => {
@@ -295,9 +296,9 @@ export class UnoGenerator {
     return {
       get css() { return getLayers() },
       layers,
+      matched,
       getLayers,
       getLayer,
-      matched,
     }
   }
 
@@ -387,6 +388,7 @@ export class UnoGenerator {
 
     for (const p of this.config.postprocess)
       p(obj)
+
     return obj
   }
 

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -445,7 +445,10 @@ export class UnoGenerator {
 
       // dynamic rules
       const [matcher, handler, meta] = rule
-      const match = processed.match(matcher)
+      if (meta?.prefix && !processed.startsWith(meta.prefix))
+        continue
+      const unprefixed = meta?.prefix ? processed.slice(meta.prefix.length) : processed
+      const match = unprefixed.match(matcher)
       if (!match)
         continue
 

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -123,7 +123,7 @@ export class UnoGenerator {
   }
 
   async generate(
-    input: string | Set<string> = '',
+    input: string | Set<string> | string[],
     {
       id,
       scope,
@@ -132,9 +132,11 @@ export class UnoGenerator {
       minify = false,
     }: GenerateOptions = {},
   ): Promise<GenerateResult> {
-    const tokens = typeof input === 'string'
+    const tokens: Readonly<Set<string>> = typeof input === 'string'
       ? await this.applyExtractors(input, id)
-      : input
+      : Array.isArray(input)
+        ? new Set(input)
+        : input
 
     if (safelist)
       this.config.safelist.forEach(s => tokens.add(s))
@@ -247,11 +249,11 @@ export class UnoGenerator {
               }
 
               const selectors = selectorSortPair
-                ? [...new Set(selectorSortPair
-                    .sort((a, b) => a[1] - b[1] || a[0]?.localeCompare(b[0] || '') || 0)
-                    .map(pair => pair[0])
-                    .filter(Boolean),
-                  )]
+                ? uniq(selectorSortPair
+                  .sort((a, b) => a[1] - b[1] || a[0]?.localeCompare(b[0] || '') || 0)
+                  .map(pair => pair[0])
+                  .filter(Boolean),
+                )
                 : []
 
               return selectors.length
@@ -338,7 +340,7 @@ export class UnoGenerator {
     return [raw, processed, handlers, variants]
   }
 
-  applyVariants(parsed: ParsedUtil, variantHandlers = parsed[4], raw = parsed[1]): UtilObject {
+  private applyVariants(parsed: ParsedUtil, variantHandlers = parsed[4], raw = parsed[1]): UtilObject {
     const handler = [...variantHandlers]
       .sort((a, b) => (a.order || 0) - (b.order || 0))
       .reverse()

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -158,6 +158,11 @@ export interface RuleMeta {
   autocomplete?: Arrayable<AutoCompleteTemplate>
 
   /**
+   * Matching prefix before this util
+   */
+  prefix?: string
+
+  /**
    * Internal rules will only be matched for shortcuts but not the user code.
    * @default false
    */
@@ -449,6 +454,10 @@ export interface Preset<Theme extends {} = {}> extends ConfigBase<Theme> {
    * Preset options for other tools like IDE to consume
    */
   options?: PresetOptions
+  /**
+   * Apply prefix to all utilities
+   */
+  prefix?: string
 }
 
 export interface GeneratorOptions {

--- a/packages/preset-icons/src/index.ts
+++ b/packages/preset-icons/src/index.ts
@@ -76,7 +76,7 @@ export const preset = (options: IconsOptions = {}): Preset => {
     options,
     layers: { icons: -30 },
     rules: [[
-      new RegExp(`^${prefix}([a-z0-9:-]+)(?:\\?(mask|bg|auto))?$`),
+      /^([a-z0-9:-]+)(?:\?(mask|bg|auto))?$/,
       async ([full, body, _mode = mode]) => {
         let collection = ''
         let name = ''
@@ -132,7 +132,7 @@ export const preset = (options: IconsOptions = {}): Preset => {
           }
         }
       },
-      { layer },
+      { layer, prefix },
     ]],
   }
 }

--- a/packages/preset-mini/src/index.ts
+++ b/packages/preset-mini/src/index.ts
@@ -24,6 +24,12 @@ export interface PresetMiniOptions extends PresetOptions {
    * @default 'un-'
    */
   variablePrefix?: string
+  /**
+   * Utils prefix
+   *
+   * @default undefined
+   */
+  prefix?: string
 }
 
 export const presetMini = (options: PresetMiniOptions = {}): Preset<Theme> => {
@@ -40,6 +46,7 @@ export const presetMini = (options: PresetMiniOptions = {}): Preset<Theme> => {
       ? VarPrefixPostprocessor(options.variablePrefix)
       : undefined,
     preflights,
+    prefix: options.prefix,
   }
 }
 

--- a/packages/preset-uno/src/index.ts
+++ b/packages/preset-uno/src/index.ts
@@ -23,6 +23,7 @@ export const presetUno = (options: PresetUnoOptions = {}): Preset<Theme> => {
     ],
     options,
     preflights,
+    prefix: options.prefix,
   }
 }
 

--- a/packages/preset-wind/src/index.ts
+++ b/packages/preset-wind/src/index.ts
@@ -26,6 +26,7 @@ export const presetWind = (options: PresetWindOptions = {}): Preset<Theme> => {
     variants: variants(options),
     options,
     preflights,
+    prefix: options.prefix,
   }
 }
 

--- a/test/__snapshots__/prefix.test.ts.snap
+++ b/test/__snapshots__/prefix.test.ts.snap
@@ -1,29 +1,8 @@
 // Vitest Snapshot v1
 
-exports[`prefix 1`] = `
-"/* layer: icons */
-.dark .uno\\\\:dark\\\\:i-carbon-moon{--un-icon:url(\\"data:image/svg+xml;utf8,%3Csvg preserveAspectRatio='xMidYMid meet' viewBox='0 0 32 32' width='1em' height='1em' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill='currentColor' d='M13.502 5.414a15.075 15.075 0 0 0 11.594 18.194a11.113 11.113 0 0 1-7.975 3.39c-.138 0-.278.005-.418 0a11.094 11.094 0 0 1-3.2-21.584M14.98 3a1.002 1.002 0 0 0-.175.016a13.096 13.096 0 0 0 1.825 25.981c.164.006.328 0 .49 0a13.072 13.072 0 0 0 10.703-5.555a1.01 1.01 0 0 0-.783-1.565A13.08 13.08 0 0 1 15.89 4.38A1.015 1.015 0 0 0 14.98 3Z'/%3E%3C/svg%3E\\");mask:var(--un-icon) no-repeat;mask-size:100% 100%;-webkit-mask:var(--un-icon) no-repeat;-webkit-mask-size:100% 100%;background-color:currentColor;width:1em;height:1em;}
-/* layer: shortcuts */
-.uno\\\\:btn{margin-right:2.5rem;}
-.uno\\\\:btn1{margin-left:2.5rem;margin-right:2.5rem;}
-/* layer: default */
-.uno\\\\:\\\\!p-5px{padding:5px !important;}
-.uno\\\\:hover\\\\:p-4:hover{padding:1rem;}
-.uno\\\\:pl-10px{padding-left:10px;}
-@media (min-width: 640px){
-.uno\\\\:sm\\\\:p-6{padding:1.5rem;}
-}"
-`;
-
-exports[`tailwind prefix 1`] = `
-"/* layer: shortcuts */
-.uno-btn{margin-right:2.5rem;}
-.uno\\\\:btn1{margin-left:2.5rem;margin-right:2.5rem;}
-/* layer: default */
-.\\\\!uno\\\\:p-5px{padding:5px !important;}
-.hover\\\\:uno\\\\:p-4:hover{padding:1rem;}
-.uno\\\\:pl-10px{padding-left:10px;}
-@media (min-width: 640px){
-.sm\\\\:uno\\\\:p-6{padding:1.5rem;}
-}"
+exports[`prefix > preset prefix 2`] = `
+"/* layer: default */
+.hover\\\\:foo-p4:hover{padding:1rem;}
+.foo-text-red{--un-text-opacity:1;color:rgba(248,113,113,var(--un-text-opacity));}
+.bar-bar{color:bar;}"
 `;

--- a/test/__snapshots__/preprocess.test.ts.snap
+++ b/test/__snapshots__/preprocess.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1
+
+exports[`preprocess > prefix 1`] = `
+"/* layer: icons */
+.dark .uno\\\\:dark\\\\:i-carbon-moon{--un-icon:url(\\"data:image/svg+xml;utf8,%3Csvg preserveAspectRatio='xMidYMid meet' viewBox='0 0 32 32' width='1em' height='1em' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill='currentColor' d='M13.502 5.414a15.075 15.075 0 0 0 11.594 18.194a11.113 11.113 0 0 1-7.975 3.39c-.138 0-.278.005-.418 0a11.094 11.094 0 0 1-3.2-21.584M14.98 3a1.002 1.002 0 0 0-.175.016a13.096 13.096 0 0 0 1.825 25.981c.164.006.328 0 .49 0a13.072 13.072 0 0 0 10.703-5.555a1.01 1.01 0 0 0-.783-1.565A13.08 13.08 0 0 1 15.89 4.38A1.015 1.015 0 0 0 14.98 3Z'/%3E%3C/svg%3E\\");mask:var(--un-icon) no-repeat;mask-size:100% 100%;-webkit-mask:var(--un-icon) no-repeat;-webkit-mask-size:100% 100%;background-color:currentColor;width:1em;height:1em;}
+/* layer: shortcuts */
+.uno\\\\:btn{margin-right:2.5rem;}
+.uno\\\\:btn1{margin-left:2.5rem;margin-right:2.5rem;}
+/* layer: default */
+.uno\\\\:\\\\!p-5px{padding:5px !important;}
+.uno\\\\:hover\\\\:p-4:hover{padding:1rem;}
+.uno\\\\:pl-10px{padding-left:10px;}
+@media (min-width: 640px){
+.uno\\\\:sm\\\\:p-6{padding:1.5rem;}
+}"
+`;
+
+exports[`preprocess > tailwind prefix 1`] = `
+"/* layer: shortcuts */
+.uno-btn{margin-right:2.5rem;}
+.uno\\\\:btn1{margin-left:2.5rem;margin-right:2.5rem;}
+/* layer: default */
+.\\\\!uno\\\\:p-5px{padding:5px !important;}
+.hover\\\\:uno\\\\:p-4:hover{padding:1rem;}
+.uno\\\\:pl-10px{padding-left:10px;}
+@media (min-width: 640px){
+.sm\\\\:uno\\\\:p-6{padding:1.5rem;}
+}"
+`;

--- a/test/prefix.test.ts
+++ b/test/prefix.test.ts
@@ -1,75 +1,35 @@
 import { createGenerator } from '@unocss/core'
-import presetUno from '@unocss/preset-uno'
-import presetIcons from '@unocss/preset-icons'
-import { expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
+import presetMini from '@unocss/preset-mini'
 
-test('prefix', async () => {
-  const positive = [
-    'uno:pl-10px',
-    'uno:hover:p-4',
-    'uno:sm:p-6',
-    'uno:!p-5px',
-    'uno:btn',
-    'uno:btn1',
-    'uno:dark:i-carbon-moon',
-  ]
+describe('prefix', () => {
+  test('preset prefix', async () => {
+    const uno = createGenerator({
+      presets: [
+        presetMini({ prefix: 'foo-' }),
+      ],
+      rules: [
+        ['bar', { color: 'bar' }, { prefix: 'bar-' }],
+      ],
+    })
 
-  const negative = [
-    'pl-10px',
-    'hover:p-4',
-    '!p-5px',
-    'btn',
-    'btn1',
-    'i-carbon-moon',
-  ]
+    const { css, matched } = await uno.generate(new Set([
+      'text-red',
+      'foo-text-red',
+      'hover:p4',
+      'hover:foo-p4',
+      'bar',
+      'bar-bar',
+    ]), { preflights: false })
 
-  const uno = createGenerator({
-    preprocess: m => m.startsWith('uno:') ? m.substr(4) : '',
-    presets: [
-      presetUno(),
-      presetIcons(),
-    ],
-    shortcuts: {
-      btn: 'mr-10',
-      btn1: 'ml-10 btn',
-    },
+    expect(matched).toMatchInlineSnapshot(`
+      Set {
+        "bar-bar",
+        "foo-text-red",
+        "hover:foo-p4",
+      }
+    `)
+
+    expect(css).toMatchSnapshot()
   })
-  const { css, matched } = await uno.generate(new Set([...positive, ...negative]), { preflights: false })
-  expect(matched).eql(new Set(positive))
-  expect(css).toMatchSnapshot()
-})
-
-test('tailwind prefix', async () => {
-  const positive = [
-    'uno:pl-10px',
-    'hover:uno:p-4',
-    'sm:uno:p-6',
-    '!uno:p-5px',
-    'uno-btn',
-    'uno:btn1',
-  ]
-
-  const negative = [
-    'pl-10px',
-    'hover:p-4',
-    '!p-5px',
-    'btn',
-    'btn1',
-  ]
-
-  const prefixRE = /uno[:-]/
-  const uno = createGenerator({
-    preprocess: m => prefixRE.test(m) ? m.replace(prefixRE, '') : '',
-    presets: [
-      presetUno(),
-      presetIcons(),
-    ],
-    shortcuts: {
-      btn: 'mr-10',
-      btn1: 'ml-10 btn',
-    },
-  })
-  const { css, matched } = await uno.generate(new Set([...positive, ...negative]), { preflights: false })
-  expect(matched).eql(new Set(positive))
-  expect(css).toMatchSnapshot()
 })

--- a/test/preprocess.test.ts
+++ b/test/preprocess.test.ts
@@ -1,0 +1,77 @@
+import { createGenerator } from '@unocss/core'
+import presetUno from '@unocss/preset-uno'
+import presetIcons from '@unocss/preset-icons'
+import { describe, expect, test } from 'vitest'
+
+describe('preprocess', () => {
+  test('prefix', async () => {
+    const positive = [
+      'uno:pl-10px',
+      'uno:hover:p-4',
+      'uno:sm:p-6',
+      'uno:!p-5px',
+      'uno:btn',
+      'uno:btn1',
+      'uno:dark:i-carbon-moon',
+    ]
+
+    const negative = [
+      'pl-10px',
+      'hover:p-4',
+      '!p-5px',
+      'btn',
+      'btn1',
+      'i-carbon-moon',
+    ]
+
+    const uno = createGenerator({
+      preprocess: m => m.startsWith('uno:') ? m.substr(4) : '',
+      presets: [
+        presetUno(),
+        presetIcons(),
+      ],
+      shortcuts: {
+        btn: 'mr-10',
+        btn1: 'ml-10 btn',
+      },
+    })
+    const { css, matched } = await uno.generate(new Set([...positive, ...negative]), { preflights: false })
+    expect(matched).eql(new Set(positive))
+    expect(css).toMatchSnapshot()
+  })
+
+  test('tailwind prefix', async () => {
+    const positive = [
+      'uno:pl-10px',
+      'hover:uno:p-4',
+      'sm:uno:p-6',
+      '!uno:p-5px',
+      'uno-btn',
+      'uno:btn1',
+    ]
+
+    const negative = [
+      'pl-10px',
+      'hover:p-4',
+      '!p-5px',
+      'btn',
+      'btn1',
+    ]
+
+    const prefixRE = /uno[:-]/
+    const uno = createGenerator({
+      preprocess: m => prefixRE.test(m) ? m.replace(prefixRE, '') : '',
+      presets: [
+        presetUno(),
+        presetIcons(),
+      ],
+      shortcuts: {
+        btn: 'mr-10',
+        btn1: 'ml-10 btn',
+      },
+    })
+    const { css, matched } = await uno.generate(new Set([...positive, ...negative]), { preflights: false })
+    expect(matched).eql(new Set(positive))
+    expect(css).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
This PR adds the prefix support in core,

```ts
{
  rules: [
    [/^p-(\d+)$/, () => '...', { prefix: 'foo-' }]]
  ]
}
```

would make it match the prefix first and then the body of rules, e.g. `foo-p-1`

it's also available for preset to define the prefix that apply to all nested rules,


```ts
{
  name: 'my-preset',
  prefix: 'foo-',
  rules: [
    [/^p-(\d+)$/, () => '...']],
    [/^m-(\d+)$/, () => '...']]
  ]
}
```