### PR TITLE
fix(playground): refresh transforms at initial

### DIFF
--- a/playground/src/logics/uno.ts
+++ b/playground/src/logics/uno.ts
@@ -22,9 +22,15 @@ let customConfig: UserConfig = {}
 let autocomplete = createAutocomplete(uno)
 
 const reGenerate = () => {
-  uno.setConfig(customConfig, defaultConfig.value)
-  generate()
-  autocomplete = createAutocomplete(uno)
+  // Make it force refresh
+  const lastInput = inputHTML.value
+  inputHTML.value = ''
+  nextTick(() => {
+    inputHTML.value = lastInput
+    uno.setConfig(customConfig, defaultConfig.value)
+    generate()
+    autocomplete = createAutocomplete(uno)
+  })
 }
 
 export const transformedHTML = computedAsync(async () => {


### PR DESCRIPTION
If user provides `transformers` in config, `applyTransformers` got the `transformers` from `uno.config` was a `[]`. So `transformedHTML` need force refresh to apply `transformers`.

<img width="750" alt="image" src="https://user-images.githubusercontent.com/42139754/177040452-9c7d8136-f246-4f0c-b4af-7aabeb424a68.png">



