### PR TITLE
fix(extractor-pug): use any whitespace instead LF on regexp

### DIFF
--- a/packages/extractor-pug/src/index.ts
+++ b/packages/extractor-pug/src/index.ts
@@ -1,6 +1,6 @@
 import type { Extractor } from '@unocss/core'
 
-const regexVueTemplate = /<template.*?lang=['"]pug['"][^>]*?>\n([\s\S]*?\n)<\/template>/gm
+const regexVueTemplate = /<template.*?lang=['"]pug['"][^>]*?>\s*([\s\S]*?\s*)<\/template>/gm
 
 export default function extractorPug(): Extractor {
   async function compile(code: string, id: string) {


### PR DESCRIPTION
On Windows, the regex will never succeed since the `new line` is `\r\n`.

closes #1150