### PR TITLE
fix(vite): add default `layer: preflights` css when mode is `per-module`

### DIFF
--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -42,7 +42,7 @@ export default function UnocssPlugin<Theme extends {}>(
     plugins.push(UnocssInspector(ctx))
 
   if (mode === 'per-module') {
-    plugins.push(PerModuleModePlugin(ctx))
+    plugins.push(...PerModuleModePlugin(ctx))
   }
   else if (mode === 'vue-scoped') {
     plugins.push(VueScopedPlugin(ctx))


### PR DESCRIPTION
Currently, in "per-module" mode, some class names(e.g. "shadow", "ring") do not work as expected because they lack the "layout: preflights" predefined css vars.
![image](https://user-images.githubusercontent.com/35426360/178152519-4b6e133d-ab50-45da-84f7-03e9ffa8f358.png)
