### PR TITLE
fix(preset-mini): selector match variantSpaceAndDivide

### DIFF
--- a/packages/preset-wind/src/variants/misc.ts
+++ b/packages/preset-wind/src/variants/misc.ts
@@ -5,7 +5,7 @@ export const variantSpaceAndDivide: Variant = (matcher) => {
     return {
       matcher,
       selector: (input) => {
-        return `${input}>:not([hidden])~:not([hidden])`
+        return `${input}>:not([hidden])`
       },
     }
   }

--- a/test/__snapshots__/preset-wind.test.ts.snap
+++ b/test/__snapshots__/preset-wind.test.ts.snap
@@ -191,36 +191,36 @@ exports[`preset-wind > targets 1`] = `
 .break-inside-revert{break-inside:revert;}
 .break-after-column{break-after:column;}
 .break-after-unset{break-after:unset;}
-.-space-x-4>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(-1rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(-1rem * var(--un-space-x-reverse));}
-.space-x-\\\\$space>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(var(--space) * calc(1 - var(--un-space-x-reverse)));margin-right:calc(var(--space) * var(--un-space-x-reverse));}
-.space-x-2>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(0.5rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(0.5rem * var(--un-space-x-reverse));}
-.space-y-4>:not([hidden])~:not([hidden]){--un-space-y-reverse:0;margin-top:calc(1rem * calc(1 - var(--un-space-y-reverse)));margin-bottom:calc(1rem * var(--un-space-y-reverse));}
-.space-y-none>:not([hidden])~:not([hidden]){--un-space-y-reverse:0;margin-top:calc(0rem * calc(1 - var(--un-space-y-reverse)));margin-bottom:calc(0rem * var(--un-space-y-reverse));}
-.space-x-reverse>:not([hidden])~:not([hidden]){--un-space-x-reverse:1;}
+.-space-x-4>:not([hidden]){--un-space-x-reverse:0;margin-left:calc(-1rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(-1rem * var(--un-space-x-reverse));}
+.space-x-\\\\$space>:not([hidden]){--un-space-x-reverse:0;margin-left:calc(var(--space) * calc(1 - var(--un-space-x-reverse)));margin-right:calc(var(--space) * var(--un-space-x-reverse));}
+.space-x-2>:not([hidden]){--un-space-x-reverse:0;margin-left:calc(0.5rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(0.5rem * var(--un-space-x-reverse));}
+.space-y-4>:not([hidden]){--un-space-y-reverse:0;margin-top:calc(1rem * calc(1 - var(--un-space-y-reverse)));margin-bottom:calc(1rem * var(--un-space-y-reverse));}
+.space-y-none>:not([hidden]){--un-space-y-reverse:0;margin-top:calc(0rem * calc(1 - var(--un-space-y-reverse)));margin-bottom:calc(0rem * var(--un-space-y-reverse));}
+.space-x-reverse>:not([hidden]){--un-space-x-reverse:1;}
 .space-block-4{--un-space-block-reverse:0;margin-block-start:calc(1rem * calc(1 - var(--un-space-block-reverse)));margin-block-end:calc(1rem * calc(1 - var(--un-space-block-reverse)));}
 .space-block-none{--un-space-block-reverse:0;margin-block-start:calc(0rem * calc(1 - var(--un-space-block-reverse)));margin-block-end:calc(0rem * calc(1 - var(--un-space-block-reverse)));}
 .space-inline-\\\\$space{--un-space-inline-reverse:0;margin-inline-start:calc(var(--space) * calc(1 - var(--un-space-inline-reverse)));margin-inline-end:calc(var(--space) * calc(1 - var(--un-space-inline-reverse)));}
 .space-inline-2{--un-space-inline-reverse:0;margin-inline-start:calc(0.5rem * calc(1 - var(--un-space-inline-reverse)));margin-inline-end:calc(0.5rem * calc(1 - var(--un-space-inline-reverse)));}
 .space-inline-reverse{--un-space-inline-reverse:1;}
-.divide-x-\\\\$variable>:not([hidden])~:not([hidden]){--un-divide-x-reverse:0;border-left-width:calc(var(--variable) * calc(1 - var(--un-divide-x-reverse)));border-right-width:calc(var(--variable) * var(--un-divide-x-reverse));border-left-style:solid;border-right-style:solid;}
-.divide-x-4>:not([hidden])~:not([hidden]){--un-divide-x-reverse:0;border-left-width:calc(4px * calc(1 - var(--un-divide-x-reverse)));border-right-width:calc(4px * var(--un-divide-x-reverse));border-left-style:solid;border-right-style:solid;}
-.divide-x-none>:not([hidden])~:not([hidden]){--un-divide-x-reverse:0;border-left-width:calc(0px * calc(1 - var(--un-divide-x-reverse)));border-right-width:calc(0px * var(--un-divide-x-reverse));border-left-style:solid;border-right-style:solid;}
-.divide-y-4>:not([hidden])~:not([hidden]){--un-divide-y-reverse:0;border-top-width:calc(4px * calc(1 - var(--un-divide-y-reverse)));border-bottom-width:calc(4px * var(--un-divide-y-reverse));border-top-style:solid;border-bottom-style:solid;}
-.divide-x-reverse>:not([hidden])~:not([hidden]){--un-divide-x-reverse:1;}
-.divide-block-4>:not([hidden])~:not([hidden]){--un-divide-block-reverse:0;border-block-start-width:calc(4px * calc(1 - var(--un-divide-block-reverse)));border-block-end-width:calc(4px * calc(1 - var(--un-divide-block-reverse)));border-block-start-style:solid;border-block-end-style:solid;}
-.divide-inline-\\\\$variable>:not([hidden])~:not([hidden]){--un-divide-inline-reverse:0;border-inline-start-width:calc(var(--variable) * calc(1 - var(--un-divide-inline-reverse)));border-inline-end-width:calc(var(--variable) * calc(1 - var(--un-divide-inline-reverse)));border-inline-start-style:solid;border-inline-end-style:solid;}
-.divide-inline-4>:not([hidden])~:not([hidden]){--un-divide-inline-reverse:0;border-inline-start-width:calc(4px * calc(1 - var(--un-divide-inline-reverse)));border-inline-end-width:calc(4px * calc(1 - var(--un-divide-inline-reverse)));border-inline-start-style:solid;border-inline-end-style:solid;}
-.divide-inline-none>:not([hidden])~:not([hidden]){--un-divide-inline-reverse:0;border-inline-start-width:calc(0px * calc(1 - var(--un-divide-inline-reverse)));border-inline-end-width:calc(0px * calc(1 - var(--un-divide-inline-reverse)));border-inline-start-style:solid;border-inline-end-style:solid;}
-.divide-inline-reverse>:not([hidden])~:not([hidden]){--un-divide-inline-reverse:1;}
-.divide-\\\\$variable>:not([hidden])~:not([hidden]){border-color:var(--variable);}
-.divide-current>:not([hidden])~:not([hidden]){border-color:currentColor;}
-.divide-green-500>:not([hidden])~:not([hidden]){--un-divide-opacity:1;border-color:rgba(34,197,94,var(--un-divide-opacity));}
-.divide-transparent>:not([hidden])~:not([hidden]){border-color:transparent;}
-.divide-opacity-50>:not([hidden])~:not([hidden]){--un-divide-opacity:0.5;}
-.divide-dashed>:not([hidden])~:not([hidden]){border-style:dashed;}
-.divide-dotted>:not([hidden])~:not([hidden]){border-style:dotted;}
-.divide-none>:not([hidden])~:not([hidden]){border-style:none;}
-.divide-ridge>:not([hidden])~:not([hidden]){border-style:ridge;}
+.divide-x-\\\\$variable>:not([hidden]){--un-divide-x-reverse:0;border-left-width:calc(var(--variable) * calc(1 - var(--un-divide-x-reverse)));border-right-width:calc(var(--variable) * var(--un-divide-x-reverse));border-left-style:solid;border-right-style:solid;}
+.divide-x-4>:not([hidden]){--un-divide-x-reverse:0;border-left-width:calc(4px * calc(1 - var(--un-divide-x-reverse)));border-right-width:calc(4px * var(--un-divide-x-reverse));border-left-style:solid;border-right-style:solid;}
+.divide-x-none>:not([hidden]){--un-divide-x-reverse:0;border-left-width:calc(0px * calc(1 - var(--un-divide-x-reverse)));border-right-width:calc(0px * var(--un-divide-x-reverse));border-left-style:solid;border-right-style:solid;}
+.divide-y-4>:not([hidden]){--un-divide-y-reverse:0;border-top-width:calc(4px * calc(1 - var(--un-divide-y-reverse)));border-bottom-width:calc(4px * var(--un-divide-y-reverse));border-top-style:solid;border-bottom-style:solid;}
+.divide-x-reverse>:not([hidden]){--un-divide-x-reverse:1;}
+.divide-block-4>:not([hidden]){--un-divide-block-reverse:0;border-block-start-width:calc(4px * calc(1 - var(--un-divide-block-reverse)));border-block-end-width:calc(4px * calc(1 - var(--un-divide-block-reverse)));border-block-start-style:solid;border-block-end-style:solid;}
+.divide-inline-\\\\$variable>:not([hidden]){--un-divide-inline-reverse:0;border-inline-start-width:calc(var(--variable) * calc(1 - var(--un-divide-inline-reverse)));border-inline-end-width:calc(var(--variable) * calc(1 - var(--un-divide-inline-reverse)));border-inline-start-style:solid;border-inline-end-style:solid;}
+.divide-inline-4>:not([hidden]){--un-divide-inline-reverse:0;border-inline-start-width:calc(4px * calc(1 - var(--un-divide-inline-reverse)));border-inline-end-width:calc(4px * calc(1 - var(--un-divide-inline-reverse)));border-inline-start-style:solid;border-inline-end-style:solid;}
+.divide-inline-none>:not([hidden]){--un-divide-inline-reverse:0;border-inline-start-width:calc(0px * calc(1 - var(--un-divide-inline-reverse)));border-inline-end-width:calc(0px * calc(1 - var(--un-divide-inline-reverse)));border-inline-start-style:solid;border-inline-end-style:solid;}
+.divide-inline-reverse>:not([hidden]){--un-divide-inline-reverse:1;}
+.divide-\\\\$variable>:not([hidden]){border-color:var(--variable);}
+.divide-current>:not([hidden]){border-color:currentColor;}
+.divide-green-500>:not([hidden]){--un-divide-opacity:1;border-color:rgba(34,197,94,var(--un-divide-opacity));}
+.divide-transparent>:not([hidden]){border-color:transparent;}
+.divide-opacity-50>:not([hidden]){--un-divide-opacity:0.5;}
+.divide-dashed>:not([hidden]){border-style:dashed;}
+.divide-dotted>:not([hidden]){border-style:dotted;}
+.divide-none>:not([hidden]){border-style:none;}
+.divide-ridge>:not([hidden]){border-style:ridge;}
 .overscroll-contain{overscroll-behavior:contain;}
 .overscroll-none{overscroll-behavior:none;}
 .overscroll-revert-layer{overscroll-behavior:revert-layer;}

--- a/test/__snapshots__/preset-wind.test.ts.snap
+++ b/test/__snapshots__/preset-wind.test.ts.snap
@@ -192,6 +192,8 @@ exports[`preset-wind > targets 1`] = `
 .break-after-column{break-after:column;}
 .break-after-unset{break-after:unset;}
 .-space-x-4>:not([hidden]){--un-space-x-reverse:0;margin-left:calc(-1rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(-1rem * var(--un-space-x-reverse));}
+.children\\\\:space-y-2>:not([hidden])>*,
+.next\\\\:space-y-2>:not([hidden])+*{--un-space-y-reverse:0;margin-top:calc(0.5rem * calc(1 - var(--un-space-y-reverse)));margin-bottom:calc(0.5rem * var(--un-space-y-reverse));}
 .space-x-\\\\$space>:not([hidden]){--un-space-x-reverse:0;margin-left:calc(var(--space) * calc(1 - var(--un-space-x-reverse)));margin-right:calc(var(--space) * var(--un-space-x-reverse));}
 .space-x-2>:not([hidden]){--un-space-x-reverse:0;margin-left:calc(0.5rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(0.5rem * var(--un-space-x-reverse));}
 .space-y-4>:not([hidden]){--un-space-y-reverse:0;margin-top:calc(1rem * calc(1 - var(--un-space-y-reverse)));margin-bottom:calc(1rem * var(--un-space-y-reverse));}

--- a/test/assets/preset-wind-targets.ts
+++ b/test/assets/preset-wind-targets.ts
@@ -390,6 +390,10 @@ export const presetWindTargets: string[] = [
 
   // variants - multiple parents
   '@dark:contrast-more:p-10',
+
+  // combinator
+  'next:space-y-2',
+  'children:space-y-2',
 ]
 
 export const presetWindNonTargets: string[] = [


### PR DESCRIPTION
fix [1246](https://github.com/unocss/unocss/issues/1246)

I'm not sure if the current solution is correct because I don't understand why the `~` selector was used before