### PR TITLE
fix(vscode): add html to the default includes

### DIFF
--- a/packages/shared-integration/src/defaults.ts
+++ b/packages/shared-integration/src/defaults.ts
@@ -1,4 +1,4 @@
 import { cssIdRE } from '@unocss/core'
 
 export const defaultExclude = [cssIdRE]
-export const defaultInclude = [/\.vue$/, /\.vue\?vue/, /\.svelte$/, /\.[jt]sx$/, /\.mdx?$/, /\.astro$/, /\.elm$/]
+export const defaultInclude = [/\.vue$/, /\.vue\?vue/, /\.svelte$/, /\.[jt]sx$/, /\.mdx?$/, /\.astro$/, /\.elm$/, /\.html$/]


### PR DESCRIPTION
As mentioned in the [readme](https://github.com/unocss/unocss#scanning):

> By default UnoCSS will scan for components files like: .jsx, .tsx, .vue, .md, **.html**, .svelte, .astro.

But it wasn't in the array. Feel free to close if this isn't necessary.

It was a bit confusing to me how index.html _was_ included when I was using the [vite plugin](https://github.com/unocss/unocss/blob/163be1b4a6a20020af2305e437405ceb8be99a98/packages/vite/src/transformers.ts#L13), but when I was using the vscode extension, it _wasn't_ included.