### PR TITLE
fix(nuxt): use defineNuxtPlugin

### DIFF
--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -37,7 +37,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
         getContents: () => {
           const lines = [
             'import \'uno.css\'',
-            'export default () => {};',
+            'export default defineNuxtPlugin(() => {})',
           ]
           if (options.preflight)
             lines.unshift('import \'@unocss/reset/tailwind.css\'')


### PR DESCRIPTION
### Linked issues

Fixes #1264 

### Description

Starting from `nuxt@3.0.0-rc.5`, Nuxt plugins not using `defineNuxtPlugin` are considered as invalid and will throw a warning (https://github.com/nuxt/framework/pull/5857).

This PR makes `@unocss/nuxt` inner Nuxt plugin valid by simply using `defineNuxtPlugin`.
