### PR TITLE
fix:change button selector in reset tailwind.css

### DIFF
--- a/packages/reset/tailwind.css
+++ b/packages/reset/tailwind.css
@@ -177,7 +177,7 @@ select {
 */
 
 button,
-[type='button'],
+:not(button)[type='button'],
 [type='reset'],
 [type='submit'] {
   -webkit-appearance: button; /* 1 */


### PR DESCRIPTION
This PR change this:
- `reset/tailwind.css`
- When `< button type= "button" / >` is excluded, prevent the property selector from being higher than the class selector on button
fix #1315