### PR TITLE
feat(runtime)!: try to decode page's html on default `extractAll` using textarea

### DIFF
--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -29,3 +29,13 @@ export function autoPrefixer(style: CSSStyleDeclaration): Postprocessor {
       e[0] = autoPrefix(e[0])
   })
 }
+
+let textareaDecoder: HTMLTextAreaElement
+export function decodeHtml(html: string): string {
+  if (!textareaDecoder)
+    textareaDecoder = document.createElement('textarea')
+  textareaDecoder.innerHTML = html
+  html = textareaDecoder.value
+  textareaDecoder.innerHTML = ''
+  return html
+}


### PR DESCRIPTION
May be breaking due to:
- signature change on `extractAll`
- behavior change on default `extractAll` by trying both raw stringified html and its decoded version

Closes #1323

There are 3 decoding alternatives:
- textarea decode (this PR)
- regex. We need mostly the `&` character and most likely `>`. There's no need decode the whole html entities untill more character is added in the rules,
- [he](https://www.npmjs.com/package/he) package. While good, this would unecessarily increase the bundle size.