### PR TITLE
fix: add await before fs.emptyDir

### DIFF
--- a/test/vite.test.ts
+++ b/test/vite.test.ts
@@ -7,7 +7,7 @@ import fg from 'fast-glob'
 describe('vite', () => {
   it('build', async () => {
     const root = resolve(__dirname, 'fixtures/vite')
-    fs.emptyDir(join(root, 'dist'))
+    await fs.emptyDir(join(root, 'dist'))
     await build({
       root,
       logLevel: 'warn',


### PR DESCRIPTION
emptyDir type declarations
```ts
export function emptyDir(path: string): Promise<void>;

export function emptyDir(path: string, callback: (err: Error) => void): void;
```

This will return `string`, so `emptyDir` will return a `Promise<void>`, so it should be add `await` before it
```ts
join(root, 'dist')
```