### PR TITLE
fix(core)!: overide array on theme merging, revert shallow merge of theme

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -79,7 +79,7 @@ export function resolveConfig(
   const theme = clone([
     ...sortedPresets.map(p => p.theme || {}),
     config.theme || {},
-  ].reduce((a, p) => mergeDeep(a, p, 1), {}))
+  ].reduce((a, p) => mergeDeep(a, p), {}))
 
   ;(mergePresets('extendTheme') as ThemeExtender<any>[]).forEach(extendTheme => extendTheme(theme))
 

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -47,12 +47,12 @@ export function isObject(item: any): item is Record<string, any> {
   return (item && typeof item === 'object' && !Array.isArray(item))
 }
 
-export function mergeDeep<T>(original: T, patch: DeepPartial<T>, level = Infinity): T {
+export function mergeDeep<T>(original: T, patch: DeepPartial<T>): T {
   const o = original as any
   const p = patch as any
 
   if (Array.isArray(o) && Array.isArray(p))
-    return [...o, ...p] as any
+    return [...p] as any
 
   if (Array.isArray(o))
     return [...o] as any
@@ -60,8 +60,8 @@ export function mergeDeep<T>(original: T, patch: DeepPartial<T>, level = Infinit
   const output = { ...o }
   if (isObject(o) && isObject(p)) {
     Object.keys(p).forEach((key) => {
-      if (level > 0 && ((isObject(o[key]) && isObject(p[key])) || (Array.isArray(o[key]) && Array.isArray(p[key]))))
-        output[key] = mergeDeep(o[key], p[key], level - 1)
+      if (((isObject(o[key]) && isObject(p[key])) || (Array.isArray(o[key]) && Array.isArray(p[key]))))
+        output[key] = mergeDeep(o[key], p[key])
       else
         Object.assign(output, { [key]: p[key] })
     })

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -51,11 +51,8 @@ export function mergeDeep<T>(original: T, patch: DeepPartial<T>): T {
   const o = original as any
   const p = patch as any
 
-  if (Array.isArray(o) && Array.isArray(p))
-    return [...p] as any
-
   if (Array.isArray(o))
-    return [...o] as any
+    return [...p] as any
 
   const output = { ...o }
   if (isObject(o) && isObject(p)) {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -14,7 +14,6 @@ it('mergeDeep', () => {
     .toMatchInlineSnapshot(`
       {
         "arr": [
-          1,
           2,
         ],
         "bar": {},


### PR DESCRIPTION
This PR change `mergeDeep` use override logic when `origin` and `patch` both arrays.

I think it isn't a good way to resolve #1340 
Is there a better way to solve it? please guide me

fix #1340 