### PR TITLE
feat(runtime): try to decode page's html on default `extractAll` using regex

### DIFF
--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -29,3 +29,10 @@ export function autoPrefixer(style: CSSStyleDeclaration): Postprocessor {
       e[0] = autoPrefix(e[0])
   })
 }
+
+export function decodeHtml(html: string): string {
+  return html
+    .replace(/&amp;/g, '&')
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+}

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -2,7 +2,7 @@ import { createGenerator } from '@unocss/core'
 import presetUno from '@unocss/preset-uno'
 import presetTagify from '@unocss/preset-tagify'
 import { describe, expect, test } from 'vitest'
-import { autoPrefixer } from '../packages/runtime/src/utils'
+import { autoPrefixer, decodeHtml } from '../packages/runtime/src/utils'
 
 function mockElementWithStyle() {
   const store: any = {}
@@ -82,5 +82,20 @@ describe('runtime auto prefixer', () => {
       </flex>
     `, { preflights: false })
     expect(css).toMatchSnapshot()
+  })
+})
+
+describe('runtime decode html', () => {
+  test('decode function', async () => {
+    expect(decodeHtml('<tag class="[&_*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&_*]:text-red>\\""')
+    expect(decodeHtml('<tag class="[&amp;_*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&_*]:text-red>\\""')
+    expect(decodeHtml('<tag class="[&amp;>*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&>*]:text-red>\\""')
+    expect(decodeHtml('<tag class="[&amp;&gt;*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&>*]:text-red>\\""')
+    expect(decodeHtml('<tag class="[&<*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&<*]:text-red>\\""')
+    expect(decodeHtml('<tag class="[&&lt;*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&<*]:text-red>\\""')
+  })
+
+  test('not decoding all entities', async () => {
+    expect(decodeHtml('<tag class="[&_*]:content-[&nbsp;]>"')).toMatchInlineSnapshot('"<tag class=\\"[&_*]:content-[&nbsp;]>\\""')
   })
 })


### PR DESCRIPTION
This PR uses simple regex to replace only 3 encoded entities: `&`, `<` and `>`
Alternative to #1325
Closes #1323