### PR TITLE
feat(runtime)!: try to decode page's html on default `extractAll` using `he` package

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -41,8 +41,10 @@
     "dev": "nr watch & live-server --open=/play"
   },
   "dependencies": {
+    "@types/he": "^1.1.2",
     "@unocss/core": "workspace:*",
     "@unocss/preset-attributify": "workspace:*",
-    "@unocss/preset-uno": "workspace:*"
+    "@unocss/preset-uno": "workspace:*",
+    "he": "^1.2.0"
   }
 }

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -1,4 +1,5 @@
 import type { Postprocessor } from '@unocss/core'
+import he from 'he'
 
 const camelize = (str: string) => str.replace(/-(\w)/g, (_, c) => c ? c.toUpperCase() : '')
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
@@ -28,4 +29,8 @@ export function autoPrefixer(style: CSSStyleDeclaration): Postprocessor {
     if (!e[0].startsWith('--'))
       e[0] = autoPrefix(e[0])
   })
+}
+
+export function decodeHtml(html: string): string {
+  return he.decode(html)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,13 +421,17 @@ importers:
 
   packages/runtime:
     specifiers:
+      '@types/he': ^1.1.2
       '@unocss/core': workspace:*
       '@unocss/preset-attributify': workspace:*
       '@unocss/preset-uno': workspace:*
+      he: ^1.2.0
     dependencies:
+      '@types/he': 1.1.2
       '@unocss/core': link:../core
       '@unocss/preset-attributify': link:../preset-attributify
       '@unocss/preset-uno': link:../preset-uno
+      he: 1.2.0
 
   packages/scope:
     specifiers: {}
@@ -1858,6 +1862,10 @@ packages:
     dependencies:
       '@types/node': 18.6.2
     dev: true
+
+  /@types/he/1.1.2:
+    resolution: {integrity: sha512-kSJPcLO1x+oolc0R89pUl2kozldQ/fVQ1C1p5mp8fPoLdF/ZcBvckaTC2M8xXh3GYendXvCpy5m/a2eSbfgNgw==}
+    dev: false
 
   /@types/js-levenshtein/1.1.1:
     resolution: {integrity: sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==}
@@ -5076,6 +5084,11 @@ packages:
 
   /hash-sum/2.0.0:
     resolution: {integrity: sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==}
+
+  /he/1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+    dev: false
 
   /headers-polyfill/3.0.7:
     resolution: {integrity: sha512-JoLCAdCEab58+2/yEmSnOlficyHFpIl0XJqwu3l+Unkm1gXpFUYsThz6Yha3D6tNhocWkCPfyW0YVIGWFqTi7w==}

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -2,7 +2,7 @@ import { createGenerator } from '@unocss/core'
 import presetUno from '@unocss/preset-uno'
 import presetTagify from '@unocss/preset-tagify'
 import { describe, expect, test } from 'vitest'
-import { autoPrefixer } from '../packages/runtime/src/utils'
+import { autoPrefixer, decodeHtml } from '../packages/runtime/src/utils'
 
 function mockElementWithStyle() {
   const store: any = {}
@@ -82,5 +82,20 @@ describe('runtime auto prefixer', () => {
       </flex>
     `, { preflights: false })
     expect(css).toMatchSnapshot()
+  })
+})
+
+describe('runtime decode html', () => {
+  test('decode function', async () => {
+    expect(decodeHtml('<tag class="[&_*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&_*]:text-red>\\""')
+    expect(decodeHtml('<tag class="[&amp;_*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&_*]:text-red>\\""')
+    expect(decodeHtml('<tag class="[&amp;>*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&>*]:text-red>\\""')
+    expect(decodeHtml('<tag class="[&amp;&gt;*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&>*]:text-red>\\""')
+    expect(decodeHtml('<tag class="[&<*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&<*]:text-red>\\""')
+    expect(decodeHtml('<tag class="[&&lt;*]:text-red>"')).toMatchInlineSnapshot('"<tag class=\\"[&<*]:text-red>\\""')
+  })
+
+  test('decoding other entities', async () => {
+    expect(decodeHtml('<tag class="[&_*]:content-[&nbsp;]>"')).toMatchInlineSnapshot('"<tag class=\\"[&_*]:content-[ ]>\\""')
   })
 })


### PR DESCRIPTION
This PR uses the [he package](https://www.npmjs.com/package/he) to do the entity decoding. Considerably complete solution at the expanse of ~88kb file increase (non gzipped)

Alternative to #1325
Closes #1323