### PR TITLE
fix(vite): does not found CSS placeholder in the generated chunks

### DIFF
--- a/test/fixtures/vite-lib/index.html
+++ b/test/fixtures/vite-lib/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/test/fixtures/vite-lib/lib/main.css
+++ b/test/fixtures/vite-lib/lib/main.css
@@ -1,0 +1,8 @@
+.foo {
+  @apply flex;
+  @apply gap-1;
+}
+
+.bar {
+  --at-apply: gap-2;
+}

--- a/test/fixtures/vite-lib/lib/main.ts
+++ b/test/fixtures/vite-lib/lib/main.ts
@@ -1,0 +1,19 @@
+import '@unocss/reset/tailwind.css'
+import './main.css'
+import 'uno.css'
+
+// @unocss-include
+const html = String.raw
+document.querySelector<HTMLDivElement>('#app')!.innerHTML = html`
+  <div class="font-sans p4">
+    <p class="text-red">
+      Red
+    </p>
+    <p class=":uno: text-green text-xl">
+      Green Large
+    </p>
+    <p class="text-(blue sm)">
+      Blue Small
+    </p>
+  </div>
+`

--- a/test/fixtures/vite-lib/package.json
+++ b/test/fixtures/vite-lib/package.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  }
+}

--- a/test/fixtures/vite-lib/unocss.config.ts
+++ b/test/fixtures/vite-lib/unocss.config.ts
@@ -1,0 +1,22 @@
+import {
+  defineConfig,
+  presetAttributify,
+  presetIcons,
+  presetUno,
+  transformerCompileClass,
+  transformerDirectives,
+  transformerVariantGroup,
+} from 'unocss'
+
+export default defineConfig({
+  presets: [
+    presetAttributify(),
+    presetUno(),
+    presetIcons(),
+  ],
+  transformers: [
+    transformerCompileClass(),
+    transformerVariantGroup(),
+    transformerDirectives(),
+  ],
+})

--- a/test/fixtures/vite-lib/vite.config.ts
+++ b/test/fixtures/vite-lib/vite.config.ts
@@ -1,0 +1,23 @@
+import { resolve } from 'path'
+import { defineConfig } from 'vite'
+import UnoCSS from '@unocss/vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'lib/main.ts'),
+      name: 'MyLib',
+      fileName: 'my-lib',
+      formats: [
+        'cjs',
+        'es',
+        'iife',
+        'umd',
+      ],
+    },
+    cssCodeSplit: true,
+  },
+  plugins: [
+    UnoCSS(),
+  ],
+})


### PR DESCRIPTION
fix: #1341

I think it is only necessary to handle js files if the format is umd/amd/iife.