### PR TITLE
`user-select` Compatibility issues

### DIFF
--- a/packages/preset-mini/src/rules/static.ts
+++ b/packages/preset-mini/src/rules/static.ts
@@ -47,8 +47,8 @@ export const resizes: Rule[] = [
 export const userSelects: Rule[] = [
   ['select-auto', { 'user-select': 'auto' }],
   ['select-all', { 'user-select': 'all' }],
-  ['select-text', { 'user-select': 'text' }],
-  ['select-none', { 'user-select': 'none' }],
+  ['select-text', { 'user-select': 'text', '-webkit-user-select': 'text' }],
+  ['select-none', { 'user-select': 'none', '-webkit-user-select': 'none' }],
   ...makeGlobalStaticRules('select', 'user-select'),
 ]
 


### PR DESCRIPTION
> 'user-select' is not supported by Safari, Safari on iOS. Add '-webkit-user-select' to support Safari 3+, Safari on iOS 3+

Added two rules for static.ts