### PR TITLE
feat(core): variant group supports bracket selector

### DIFF
--- a/packages/core/src/utils/variantGroup.ts
+++ b/packages/core/src/utils/variantGroup.ts
@@ -1,6 +1,6 @@
 import type MagicString from 'magic-string'
 
-export const regexClassGroup = /([!\w+:_/-]+?)([:-])\(((?:[~!\w\s:/\\,%#.$-]|\[.*?\])*?)\)/gm
+export const regexClassGroup = /((?:[!\w+:_/-]|\[.*?\])+?)([:-])\(((?:[~!\w\s:/\\,%#.$-]|\[.*?\])*?)\)/gm
 
 export function expandVariantGroup(str: string, seperators?: ('-' | ':')[]): string
 export function expandVariantGroup(str: MagicString, seperators?: ('-' | ':')[]): MagicString

--- a/packages/core/src/utils/variantGroup.ts
+++ b/packages/core/src/utils/variantGroup.ts
@@ -1,6 +1,6 @@
 import type MagicString from 'magic-string'
 
-export const regexClassGroup = /((?:[!\w+:_/-]|\[.*?\])+?)([:-])\(((?:[~!\w\s:/\\,%#.$-]|\[.*?\])*?)\)/gm
+export const regexClassGroup = /((?:[!\w+:_/-]|\[&?>?:.+?\])+?)([:-])\(((?:[~!\w\s:/\\,%#.$-]|\[.*?\])*?)\)/gm
 
 export function expandVariantGroup(str: string, seperators?: ('-' | ':')[]): string
 export function expandVariantGroup(str: MagicString, seperators?: ('-' | ':')[]): MagicString

--- a/test/variant-group.test.ts
+++ b/test/variant-group.test.ts
@@ -28,4 +28,8 @@ describe('variant-group', () => {
   test('spaces', () => {
     expect(expandVariantGroup('a-( ~ b c )')).toEqual('a a-b a-c')
   })
+
+  test('square bracket', async () => {
+    expect(expandVariantGroup('b:[&:not(c)]:d:(!a z)')).toEqual('!b:[&:not(c)]:d:a b:[&:not(c)]:d:z')
+  })
 })


### PR DESCRIPTION
variant group supports :not selector syntax:

```css
[&:not(h1)]:(text-sm text-white)
```