### PR TITLE
feat: whitespace support in attributifyRE

### DIFF
--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -1,6 +1,6 @@
 import type { ParsedUtil, RawUtil, StringifiedUtil, Variant, VariantObject } from '../types'
 
-export const attributifyRE = /^\[(.+?)~?="(.*)"\]$/
+export const attributifyRE = /^\[(.+?)~?\s=\s"(.*)"\]$/
 export const cssIdRE = /\.(css|postcss|sass|scss|less|stylus|styl)$/
 export const validateFilterRE = /(?!\d|-{2}|-\d)[a-zA-Z0-9\u00A0-\uFFFF-_:%-?]/
 export const CONTROL_SHORTCUT_NO_MERGE = '$$shortcut-no-merge'

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -1,6 +1,6 @@
 import type { ParsedUtil, RawUtil, StringifiedUtil, Variant, VariantObject } from '../types'
 
-export const attributifyRE = /^\[(.+?)~?\s=\s"(.*)"\]$/
+export const attributifyRE = /^\[(.+?)~?\s?=\s?"(.*)"\]$/
 export const cssIdRE = /\.(css|postcss|sass|scss|less|stylus|styl)$/
 export const validateFilterRE = /(?!\d|-{2}|-\d)[a-zA-Z0-9\u00A0-\uFFFF-_:%-?]/
 export const CONTROL_SHORTCUT_NO_MERGE = '$$shortcut-no-merge'


### PR DESCRIPTION
Changed [`attributifyRE`](https://github.com/unocss/unocss/blob/main/packages/core/src/utils/helpers.ts#L3) from `/^\[(.+?)~?="(.*)"\]$/` to `/^\[(.+?)~?\s=\s"(.*)"\]$/` to support whitespace before and after the `=` that separates the attribute name and value.