### PR TITLE
fix: parsing html tag correctly

### DIFF
--- a/packages/core/src/extractors/split.ts
+++ b/packages/core/src/extractors/split.ts
@@ -1,7 +1,19 @@
 import type { Extractor } from '../types'
 import { isValidSelector } from '../utils'
 
-export const splitCode = (code: string) => code.split(/\\?[\s'"`;={}]+/g).filter(isValidSelector)
+export const splitCode = (code: string) => {
+  const spliteArray = code.split(/\\?[\s'"`;={}]+/g).filter(isValidSelector)
+  const result: string[] = []
+  spliteArray.forEach((s) => {
+    if (s.endsWith('/>') && s.length !== 2)
+      result.push(s.substring(0, s.length - 2), '/>')
+    else if (s.endsWith('>') && s.length !== 1)
+      result.push(s.substring(0, s.length - 1), '>')
+    else
+      result.push(s)
+  })
+  return result
+}
 
 export const extractorSplit: Extractor = {
   name: 'split',

--- a/test/__snapshots__/runtime.test.ts.snap
+++ b/test/__snapshots__/runtime.test.ts.snap
@@ -39,3 +39,14 @@ exports[`runtime auto prefixer > without autoprefixer 1`] = `
 .hyphens-auto{-webkit-hyphens:auto;-ms-hyphens:auto;hyphens:auto;}
 .filter{filter:var(--un-blur) var(--un-brightness) var(--un-contrast) var(--un-drop-shadow) var(--un-grayscale) var(--un-hue-rotate) var(--un-invert) var(--un-saturate) var(--un-sepia);}"
 `;
+
+exports[`runtime code split > html tag code split 1`] = `
+Set {
+  "m-1",
+  "m-2",
+  "m-3",
+  "p-1",
+  "m-4",
+  "p-2",
+}
+`;

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -99,3 +99,26 @@ describe('runtime decode html', () => {
     expect(decodeHtml('<tag class="[&_*]:content-[&nbsp;]>"')).toMatchInlineSnapshot('"<tag class=\\"[&_*]:content-[&nbsp;]>\\""')
   })
 })
+
+describe('runtime code split', () => {
+  test('html tag code split', async () => {
+    const uno = createGenerator({
+      presets: [
+        presetUno(),
+      ],
+    })
+    const { matched } = await uno.generate(`
+    <div m-1>
+      123
+    </div>
+    <div m-2/>
+    <div m-3 p-1>
+      223
+    </div>
+    <div m-4 p-2/>
+    `,
+    { preflights: false, minify: true },
+    )
+    expect(matched).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
some css are missing during the parsing phase.
`<div m-1>` will be splitted into `<div` and `m-1>`
the further process will not recognize  `m-1>`  because of the html tag
(such as function  [counting css util](https://github.com/unocss/unocss/blob/main/packages/vscode/src/annotation.ts#L145]))

adding split logic for '>' and '/>' (it seems `<>` are having special meaning and could not included in regex?)