### PR TITLE
feat(editor): editor highlight for variant groups

### DIFF
--- a/packages/core/src/extractors/split.ts
+++ b/packages/core/src/extractors/split.ts
@@ -1,7 +1,7 @@
 import type { Extractor } from '../types'
 import { isValidSelector } from '../utils'
 
-export const splitCode = (code: string) => code.split(/\\?(?:[\s'"`;={}]|:\(|\)"|\)\s)+/g).filter(isValidSelector)
+export const splitCode = (code: string) => code.split(/\\?[\s'"`;={}]+/g).filter(isValidSelector)
 
 export const extractorSplit: Extractor = {
   name: 'split',

--- a/packages/core/src/extractors/split.ts
+++ b/packages/core/src/extractors/split.ts
@@ -1,7 +1,7 @@
 import type { Extractor } from '../types'
 import { isValidSelector } from '../utils'
 
-export const splitCode = (code: string) => code.split(/\\?[\s'"`;={}]+/g).filter(isValidSelector)
+export const splitCode = (code: string) => code.split(/\\?(?:[\s'"`;={}]|:\(|\)"|\)\s)+/g).filter(isValidSelector)
 
 export const extractorSplit: Extractor = {
   name: 'split',

--- a/packages/inspector/client/components/CodeMirror.vue
+++ b/packages/inspector/client/components/CodeMirror.vue
@@ -71,7 +71,7 @@ onMounted(async () => {
   function highlight() {
     // clear previous
     decorations.forEach(i => i.clear())
-    getMatchedPositions(props.modelValue, Array.from(props.matched || []))
+    getMatchedPositions(props.modelValue, Array.from(props.matched || []), true)
       .forEach(i => mark(i[0], i[1]))
   }
 

--- a/packages/shared-common/src/index.ts
+++ b/packages/shared-common/src/index.ts
@@ -44,11 +44,11 @@ export function getMatchedPositions(code: string, matched: string[]) {
 
   // hightlight for plain classes
   let start = 0
-  code.split(/[\s"'`;<>]/g).forEach((i) => {
+  code.split(/([\s"'`;<>]|:\(|\)"|\)\s)/g).forEach((i) => {
     const end = start + i.length
     if (plain.has(i))
       result.push([start, end, i])
-    start = end + 1
+    start = end
   })
 
   // attributify values

--- a/packages/vscode/src/annotation.ts
+++ b/packages/vscode/src/annotation.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import type { DecorationOptions, ExtensionContext, StatusBarItem } from 'vscode'
 import { DecorationRangeBehavior, MarkdownString, Range, window, workspace } from 'vscode'
-import { INCLUDE_COMMENT_IDE, getMatchedPositions, isCssId } from './integration'
+import { INCLUDE_COMMENT_IDE, getMatchedPositionsFromCode, isCssId } from './integration'
 import { log } from './log'
 import { getColorsMap, getPrettiedMarkdown, isSubdir, throttle } from './utils'
 import type { ContextLoader } from './contextLoader'
@@ -101,7 +101,7 @@ export async function registerAnnotations(
 
       const ranges: DecorationOptions[] = (
         await Promise.all(
-          getMatchedPositions(code, Array.from(result.matched))
+          (await getMatchedPositionsFromCode(ctx.uno, code))
             .map(async (i): Promise<DecorationOptions> => {
               // side-effect: update colorRanges
               if (colorPreview && colorsMap.has(i[2]) && !_colorPositionsCache.has(`${i[0]}:${i[1]}`)) {

--- a/test/pos.test.ts
+++ b/test/pos.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test } from 'vitest'
 import presetAttributify from '@unocss/preset-attributify'
 import presetUno from '@unocss/preset-uno'
-import { createGenerator, UnoGenerator } from '@unocss/core'
+import type { UnoGenerator } from '@unocss/core'
+import { createGenerator } from '@unocss/core'
 import { getMatchedPositions } from '@unocss/shared-common'
-import { transformerVariantGroup } from "unocss";
+import transformerVariantGroup from '@unocss/transformer-variant-group'
 
 describe('matched-positions', async () => {
   async function match(code: string, uno: UnoGenerator) {
     const result = await uno.generate(code, { preflights: false })
-    console.log(result);    
     return getMatchedPositions(code, [...result.matched])
   }
 
@@ -19,7 +19,7 @@ describe('matched-positions', async () => {
         presetUno({ attributifyPseudo: true }),
       ],
     })
-  
+
     expect(await match('<div border="b gray4"></div>', uno))
       .toMatchInlineSnapshot(`
         [
@@ -72,8 +72,8 @@ describe('matched-positions', async () => {
         presetUno(),
       ],
       transformers: [
-        transformerVariantGroup()
-      ]
+        transformerVariantGroup(),
+      ],
     })
 
     expect(await match('<div class="hover:(h-4 w-4 bg-green-300) disabled:opacity-50"></div>', uno))

--- a/test/pos.test.ts
+++ b/test/pos.test.ts
@@ -1,17 +1,11 @@
 import { describe, expect, test } from 'vitest'
 import presetAttributify from '@unocss/preset-attributify'
 import presetUno from '@unocss/preset-uno'
-import type { UnoGenerator } from '@unocss/core'
 import { createGenerator } from '@unocss/core'
-import { getMatchedPositions } from '@unocss/shared-common'
+import { getMatchedPositionsFromCode as match } from '@unocss/shared-common'
 import transformerVariantGroup from '@unocss/transformer-variant-group'
 
 describe('matched-positions', async () => {
-  async function match(code: string, uno: UnoGenerator) {
-    const result = await uno.generate(code, { preflights: false })
-    return getMatchedPositions(code, [...result.matched])
-  }
-
   test('attributify', async () => {
     const uno = createGenerator({
       presets: [
@@ -20,18 +14,18 @@ describe('matched-positions', async () => {
       ],
     })
 
-    expect(await match('<div border="b gray4"></div>', uno))
+    expect(await match(uno, '<div border="b gray4"></div>'))
       .toMatchInlineSnapshot(`
         [
-          [
-            15,
-            20,
-            "[border=\\"gray4\\"]",
-          ],
           [
             13,
             14,
             "[border=\\"b\\"]",
+          ],
+          [
+            15,
+            20,
+            "[border=\\"gray4\\"]",
           ],
         ]
       `)
@@ -44,7 +38,7 @@ describe('matched-positions', async () => {
       ],
     })
 
-    expect(await match('<div class="bg-gray-900 h-4 hover:scale-100"></div>', uno))
+    expect(await match(uno, '<div class="bg-gray-900 h-4 hover:scale-100"></div>'))
       .toMatchInlineSnapshot(`
       [
         [
@@ -76,31 +70,31 @@ describe('matched-positions', async () => {
       ],
     })
 
-    expect(await match('<div class="hover:(h-4 w-4 bg-green-300) disabled:opacity-50"></div>', uno))
+    expect(await match(uno, '<div class="hover:(h-4 w-4 bg-green-300) disabled:opacity-50"></div>'))
       .toMatchInlineSnapshot(`
-      [
         [
-          19,
-          22,
-          "h-4",
-        ],
-        [
-          23,
-          26,
-          "w-4",
-        ],
-        [
-          27,
-          39,
-          "bg-green-300",
-        ],
-        [
-          41,
-          60,
-          "disabled:opacity-50",
-        ],
-      ]
-    `)
+          [
+            19,
+            22,
+            "hover:h-4",
+          ],
+          [
+            23,
+            26,
+            "hover:w-4",
+          ],
+          [
+            27,
+            39,
+            "hover:bg-green-300",
+          ],
+          [
+            41,
+            60,
+            "disabled:opacity-50",
+          ],
+        ]
+      `)
   })
 })
 

--- a/test/pos.test.ts
+++ b/test/pos.test.ts
@@ -1,35 +1,106 @@
-import { expect, it } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import presetAttributify from '@unocss/preset-attributify'
 import presetUno from '@unocss/preset-uno'
-import { createGenerator } from '@unocss/core'
+import { createGenerator, UnoGenerator } from '@unocss/core'
 import { getMatchedPositions } from '@unocss/shared-common'
+import { transformerVariantGroup } from "unocss";
 
-it('getMatchedPositions', async () => {
-  const uno = createGenerator({
-    presets: [
-      presetAttributify({ strict: true }),
-      presetUno({ attributifyPseudo: true }),
-    ],
-  })
-
-  async function match(code: string) {
+describe('matched-positions', async () => {
+  async function match(code: string, uno: UnoGenerator) {
     const result = await uno.generate(code, { preflights: false })
+    console.log(result);    
     return getMatchedPositions(code, [...result.matched])
   }
 
-  expect(await match('<div border="b gray4"></div>'))
-    .toMatchInlineSnapshot(`
+  test('attributify', async () => {
+    const uno = createGenerator({
+      presets: [
+        presetAttributify({ strict: true }),
+        presetUno({ attributifyPseudo: true }),
+      ],
+    })
+  
+    expect(await match('<div border="b gray4"></div>', uno))
+      .toMatchInlineSnapshot(`
+        [
+          [
+            15,
+            20,
+            "[border=\\"gray4\\"]",
+          ],
+          [
+            13,
+            14,
+            "[border=\\"b\\"]",
+          ],
+        ]
+      `)
+  })
+
+  test('class-based', async () => {
+    const uno = createGenerator({
+      presets: [
+        presetUno(),
+      ],
+    })
+
+    expect(await match('<div class="bg-gray-900 h-4 hover:scale-100"></div>', uno))
+      .toMatchInlineSnapshot(`
       [
         [
-          15,
-          20,
-          "[border=\\"gray4\\"]",
+          12,
+          23,
+          "bg-gray-900",
         ],
         [
-          13,
-          14,
-          "[border=\\"b\\"]",
+          24,
+          27,
+          "h-4",
+        ],
+        [
+          28,
+          43,
+          "hover:scale-100",
         ],
       ]
     `)
+  })
+
+  test('variant-group', async () => {
+    const uno = createGenerator({
+      presets: [
+        presetUno(),
+      ],
+      transformers: [
+        transformerVariantGroup()
+      ]
+    })
+
+    expect(await match('<div class="hover:(h-4 w-4 bg-green-300) disabled:opacity-50"></div>', uno))
+      .toMatchInlineSnapshot(`
+      [
+        [
+          19,
+          22,
+          "h-4",
+        ],
+        [
+          23,
+          26,
+          "w-4",
+        ],
+        [
+          27,
+          39,
+          "bg-green-300",
+        ],
+        [
+          41,
+          60,
+          "disabled:opacity-50",
+        ],
+      ]
+    `)
+  })
 })
+


### PR DESCRIPTION
- Updated extractor regex
- Updated `getMatchedPositions`
- Added and updated tests

Currently, only the classes inside of the variant group are highlighted, not the variant itself (e.g. with `hover:(bg-red-400 h-4)`, `hover:` will still not be highlighted).