### PR TITLE
fix(icons): correctly combine loaders

### DIFF
--- a/packages/preset-icons/src/core.ts
+++ b/packages/preset-icons/src/core.ts
@@ -120,9 +120,9 @@ export function createPresetIcons(lookupIconLoader: (options: IconsOptions) => P
 }
 
 export function combineLoaders(loaders: UniversalIconLoader[]) {
-  return <UniversalIconLoader>((...args) => {
+  return <UniversalIconLoader>(async (...args) => {
     for (const loader of loaders) {
-      const result = loader(...args)
+      const result = await loader(...args)
       if (result)
         return result
     }


### PR DESCRIPTION
The `result` of UniversalIconLoader  maybe a promise object. so that the checking  `if (result)` will never be false.