### PR TITLE
chore(example): fix plugins' order in the react example 

### DIFF
--- a/examples/vite-react/vite.config.ts
+++ b/examples/vite-react/vite.config.ts
@@ -8,7 +8,6 @@ import presetUno from '@unocss/preset-uno'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    React(),
     UnoCSS({
       shortcuts: [
         { logo: 'i-logos-react w-6em h-6em transform transition-800 hover:rotate-180' },
@@ -24,5 +23,6 @@ export default defineConfig({
         }),
       ],
     }),
+    React(),
   ],
 })


### PR DESCRIPTION
We must put UnoCSS() before React() to make sure that attributes are compiled to classNames.

See https://github.com/unocss/unocss/tree/main/packages/vite#:~:text=preset%2Dattributify%2C-,you%20must%20add%20the%20plugin%20before,-%40vitejs/plugin%2Dreact