### PR TITLE
feat(attributify-jsx): support rewriting colon operator

### DIFF
--- a/packages/transformer-attributify-jsx/README.md
+++ b/packages/transformer-attributify-jsx/README.md
@@ -73,8 +73,6 @@ export default defineConfig({
 ```html
 <div translate-x-100% /> <!-- cannot end with `%` -->
 
-<div hover:text-2xl /> <!-- cannot contain `:` -->
-
 <div translate-x-[100px] /> <!-- cannot contain `[` or `]` -->
 ```
 
@@ -82,8 +80,6 @@ Instead, you may want to use valued attributes instead:
 
 ```html
 <div translate="x-100%" />
-
-<div hover="text-2xl" />
 
 <div translate="x-[100px]" />
 ```

--- a/packages/transformer-attributify-jsx/src/index.ts
+++ b/packages/transformer-attributify-jsx/src/index.ts
@@ -73,7 +73,7 @@ export default function transformerAttributifyJsx(options: TransformerAttributif
 
       for (const item of Array.from(code.original.matchAll(elementRE))) {
         for (const attr of item[3].matchAll(attributeRE)) {
-          const matchedRule = attr[0]
+          const matchedRule = attr[0].replace(/\:/i, '-')
           if (matchedRule.includes('=') || isBlocked(matchedRule))
             continue
 

--- a/test/transformer-attributify-jsx.test.ts
+++ b/test/transformer-attributify-jsx.test.ts
@@ -15,7 +15,7 @@ describe('transformerAttributifyJs', () => {
     <div op30 text-lg fw300 m1>
       The instant on-demand Atomic CSS engine.
     </div>
-    <div m2 flex justify-center text-2xl op30 hover="op80">
+    <div m2 flex justify-center text-2xl op30 hover:op80 hover:text-2xl>
       <a
         i-carbon-logo-github
         text-inherit
@@ -50,7 +50,7 @@ describe('transformerAttributifyJs', () => {
           <div op30=\\"\\" text-lg=\\"\\" fw300=\\"\\" m1=\\"\\">
             The instant on-demand Atomic CSS engine.
           </div>
-          <div m2=\\"\\" flex=\\"\\" justify-center=\\"\\" text-2xl=\\"\\" op30=\\"\\" hover=\\"op80\\">
+          <div m2=\\"\\" flex=\\"\\" justify-center=\\"\\" text-2xl=\\"\\" op30=\\"\\" hover-op80=\\"\\" hover-text-2xl=\\"\\">
             <a
               i-carbon-logo-github
               text-inherit=\\"\\"
@@ -68,7 +68,7 @@ describe('transformerAttributifyJs', () => {
 
   test('blocklist', async () => {
     const code = new MagicString(originalCode)
-    const blocklist = ['flex', 'absolute', /op[0-9]+/]
+    const blocklist: (string | RegExp)[] = ['flex', 'absolute']
 
     await transformerAttributifyJsx({
       blocklist,
@@ -80,10 +80,10 @@ describe('transformerAttributifyJs', () => {
           <div text-5xl=\\"\\" fw100=\\"\\" animate-bounce-alt=\\"\\" animate-count-infinite=\\"\\" animate-duration-1s=\\"\\">
             unocss
           </div>
-          <div op30 text-lg=\\"\\" fw300=\\"\\" m1=\\"\\">
+          <div op30=\\"\\" text-lg=\\"\\" fw300=\\"\\" m1=\\"\\">
             The instant on-demand Atomic CSS engine.
           </div>
-          <div m2=\\"\\" flex justify-center=\\"\\" text-2xl=\\"\\" op30 hover=\\"op80\\">
+          <div m2=\\"\\" flex justify-center=\\"\\" text-2xl=\\"\\" op30=\\"\\" hover-op80=\\"\\" hover-text-2xl=\\"\\">
             <a
               i-carbon-logo-github
               text-inherit=\\"\\"
@@ -93,7 +93,7 @@ describe('transformerAttributifyJs', () => {
           </div>
         </div>
       </div>
-      <div absolute bottom-5=\\"\\" right-0=\\"\\" left-0=\\"\\" text-center=\\"\\" op30 fw300=\\"\\">
+      <div absolute bottom-5=\\"\\" right-0=\\"\\" left-0=\\"\\" text-center=\\"\\" op30=\\"\\" fw300=\\"\\">
         on-demand · instant · fully customizable
       </div>"
     `)


### PR DESCRIPTION
Although the react jsx doesn't support the colon operator, we can try to change the colon operator into a short dash operator  so that we can avoid the limitation of react. And then we can use some more semantic grammars like `hover:op30` instead of `hover-op30`.