### PR TITLE
chore: switch default web font provider

### DIFF
--- a/packages/preset-web-fonts/README.md
+++ b/packages/preset-web-fonts/README.md
@@ -16,7 +16,7 @@ Unocss({
   presets: [
     presetUno(),
     presetWebFonts({
-      provider: 'google', // default provider
+      provider: 'bunny', // default provider
       fonts: {
         // these will extend the default theme
         sans: 'Roboto',
@@ -43,7 +43,7 @@ Unocss({
 The following CSS will be generated
 
 ```css
-@import url('https://fonts.googleapis.com/css2?family=Roboto&family=Fira+Code&family=Fira+Mono:wght@400;700&family=Lobster&family=Lato:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+@import url('https://fonts.bunny.net/css?family=Roboto&family=Fira+Code&family=Fira+Mono:wght@400;700&family=Lobster&family=Lato:ital,wght@0,400;0,700;1,400;1,700&display=swap');
 
 /* layer: default */
 .font-lato {

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -29,7 +29,7 @@ const providers = {
 
 const preset = (options: WebFontsOptions = {}): Preset<any> => {
   const {
-    provider: defaultProvider = 'google',
+    provider: defaultProvider = 'bunny',
     extendTheme = true,
     inlineImports = true,
     themeKey = 'fontFamily',


### PR DESCRIPTION
Google Fonts tracks >20% of the web traffic. No need to add to that.

![Screenshot 2022-09-08 at 10 00 54 AM](https://user-images.githubusercontent.com/74390/189056232-e257397b-599d-422f-844e-a6149f1da5e4.png)

Source: https://whotracks.me/trackers/google_fonts.html

Signed-off-by: Patrick Heneise <patrick@zentered.co>