### PR TITLE
chore: example code is missing a semicolon

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ preflights: [
   {
     getCSS: ({ theme }) => `
       * {
-        color: ${theme.colors.gray?.[700] ?? '#333'}
+        color: ${theme.colors.gray?.[700] ?? '#333'};
         padding: 0;
         margin: 0;
       }


### PR DESCRIPTION
If copy the Preflight example code to your own project directly, and you will receive the following error message.

```
Internal server error: /__uno.css:5:29: Missed semicolon
```