### PR TITLE
fix(cli): remove filename of input

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -104,7 +104,7 @@ export async function build(_options: CliOptions) {
   async function generate(options: ResolvedCliOptions) {
     const outFile = resolve(options.cwd || process.cwd(), options.outFile ?? 'uno.css')
     const { css, matched } = await uno.generate(
-      [...fileCache].join('\n'),
+      [...fileCache.values()].join('\n'),
       {
         preflights: options.preflights,
         minify: options.minify,


### PR DESCRIPTION
When using `[...fileCache]`to convert Map to an array, the key of `fileCache` as filename, will also be passed. That's not what we want.