### PR TITLE
feat(core)!: generate preflights after utilties

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -174,7 +174,8 @@ export class UnoGenerator {
       }
     })
 
-    const preflightPromise = (async () => {
+    await Promise.all(tokenPromises)
+    await (async () => {
       if (!preflights)
         return
 
@@ -205,11 +206,6 @@ export class UnoGenerator {
         )),
       )
     })()
-
-    await Promise.all([
-      ...tokenPromises,
-      preflightPromise,
-    ])
 
     const layers = this.config.sortLayers(Array
       .from(layerSet)

--- a/test/generate-async.test.ts
+++ b/test/generate-async.test.ts
@@ -31,7 +31,7 @@ describe('generate-async', () => {
         [/^rule$/, () => new Promise(resolve => setTimeout(() => {
           order.push(1)
           resolve('/* rule */')
-        }, 1000))],
+        }, 20))],
       ],
       preflights: [
         {

--- a/test/generate-async.test.ts
+++ b/test/generate-async.test.ts
@@ -24,21 +24,21 @@ describe('generate-async', () => {
     expect(order).eql([1, 2])
   })
 
-  test('preflight-first', async () => {
+  test('preflight at the end', async () => {
     const order: number[] = []
     const uno = createGenerator({
       rules: [
         [/^rule$/, () => new Promise(resolve => setTimeout(() => {
-          order.push(2)
+          order.push(1)
           resolve('/* rule */')
-        }, 20))],
+        }, 1000))],
       ],
       preflights: [
         {
-          getCSS: () => new Promise(resolve => setTimeout(() => {
-            order.push(1)
+          getCSS: () => new Promise((resolve) => {
+            order.push(2)
             resolve('/* preflight */')
-          }, 10)),
+          }),
         },
       ],
     })

--- a/test/generate-async.test.ts
+++ b/test/generate-async.test.ts
@@ -23,26 +23,4 @@ describe('generate-async', () => {
     await uno.generate('rule')
     expect(order).eql([1, 2])
   })
-
-  test('preflight-first', async () => {
-    const order: number[] = []
-    const uno = createGenerator({
-      rules: [
-        [/^rule$/, () => new Promise(resolve => setTimeout(() => {
-          order.push(2)
-          resolve('/* rule */')
-        }, 20))],
-      ],
-      preflights: [
-        {
-          getCSS: () => new Promise(resolve => setTimeout(() => {
-            order.push(1)
-            resolve('/* preflight */')
-          }, 10)),
-        },
-      ],
-    })
-    await uno.generate('rule')
-    expect(order).eql([1, 2])
-  })
 })

--- a/test/generate-async.test.ts
+++ b/test/generate-async.test.ts
@@ -23,4 +23,26 @@ describe('generate-async', () => {
     await uno.generate('rule')
     expect(order).eql([1, 2])
   })
+
+  test('preflight-first', async () => {
+    const order: number[] = []
+    const uno = createGenerator({
+      rules: [
+        [/^rule$/, () => new Promise(resolve => setTimeout(() => {
+          order.push(2)
+          resolve('/* rule */')
+        }, 20))],
+      ],
+      preflights: [
+        {
+          getCSS: () => new Promise(resolve => setTimeout(() => {
+            order.push(1)
+            resolve('/* preflight */')
+          }, 10)),
+        },
+      ],
+    })
+    await uno.generate('rule')
+    expect(order).eql([1, 2])
+  })
 })


### PR DESCRIPTION
### Motivation

PR: #1407

I want to collect the used theme in postprocess and return it in preflights. But preflights will be executed faster.

### Purpose

Add theme variables collected by `postprocess` to preflight