### PR TITLE
chore(deps): add specific version of jiti to pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "overrides": {
       "@nuxt/kit-edge": "npm:@nuxt/kit@latest",
       "vite": "^3.1.2",
-      "nuxt": "3.0.0-rc.9"
+      "nuxt": "3.0.0-rc.9",
+      "jiti": "1.16.0"
     }
   },
   "simple-git-hooks": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ overrides:
   '@nuxt/kit-edge': npm:@nuxt/kit@latest
   vite: ^3.1.2
   nuxt: 3.0.0-rc.9
+  jiti: 1.16.0
 
 importers:
 
@@ -154,7 +155,7 @@ importers:
       lz-string: 1.4.4
       magic-string: 0.26.3
       msw: 0.47.3_typescript@4.8.3
-      nuxt: 3.0.0-rc.9_bl7lvocflkyvbrqfu5zopi7eki
+      nuxt: 3.0.0-rc.9_sgypswyl2qhjagm5gyqma46mmq
       nuxt-tsconfig-stub: 0.0.2
       pnpm: 7.11.0
       prettier: 2.7.1
@@ -168,8 +169,8 @@ importers:
       typescript: 4.8.3
       unbuild: 0.8.11
       unocss: link:packages/unocss
-      unplugin-auto-import: 0.11.2_n3tqqlru4qqd2r2s3afj2lwvg4
-      unplugin-vue-components: 0.22.7_ojf5i3ldatw6oymnser7cijypu
+      unplugin-auto-import: 0.11.2_xhttxuaspog4dlg5ri763ccavu
+      unplugin-vue-components: 0.22.7_a35c2tzqgijav5jkbfyu2c5dqu
       vite: 3.1.2_terser@5.15.0
       vite-plugin-inspect: 0.7.1_vite@3.1.2
       vite-plugin-pages: 0.26.0_vite@3.1.2
@@ -198,7 +199,7 @@ importers:
       fs-extra: 10.1.0
       local-pkg: 0.4.2
       postcss: 8.4.16
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.16
       unocss: link:../packages/unocss
       vite: 3.1.2
       vite-plugin-windicss: 1.8.8_vite@3.1.2
@@ -592,7 +593,7 @@ importers:
       '@unocss/nuxt': workspace:*
       '@unocss/preset-uno': workspace:*
       esno: ^0.16.3
-      jiti: ^1.15.0
+      jiti: 1.16.0
       prettier: ^2.7.1
       tsup: ^6.2.3
       unconfig: ^0.3.6
@@ -601,7 +602,7 @@ importers:
       '@unocss/nuxt': link:../nuxt
       '@unocss/preset-uno': link:../preset-uno
       esno: 0.16.3
-      jiti: 1.15.0
+      jiti: 1.16.0
       prettier: 2.7.1
       tsup: 6.2.3
       unconfig: 0.3.6
@@ -1199,6 +1200,17 @@ packages:
       get-tsconfig: 4.2.0
     dev: true
 
+  /@esbuild/android-arm/0.15.8:
+    resolution: {integrity: sha512-CyEWALmn+no/lbgbAJsbuuhT8s2J19EJGHkeyAwjbFJMrj80KJ9zuYsoAvidPTU7BgBf87r/sgae8Tw0dbOc4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dependencies:
+      esbuild-wasm: 0.15.8
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64/0.14.54:
     resolution: {integrity: sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==}
     engines: {node: '>=12'}
@@ -1210,6 +1222,15 @@ packages:
 
   /@esbuild/linux-loong64/0.15.7:
     resolution: {integrity: sha512-IKznSJOsVUuyt7cDzzSZyqBEcZe+7WlBqTVXiF1OXP/4Nm387ToaXZ0fyLwI1iBlI/bzpxVq411QE2/Bt2XWWw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64/0.15.8:
+    resolution: {integrity: sha512-pE5RQsOTSERCtfZdfCT25wzo7dfhOSlhAXcsZmuvRYhendOv7djcdvtINdnDp2DAjP17WXlBB4nBO6sHLczmsg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -1498,7 +1519,7 @@ packages:
       globby: 13.1.2
       hash-sum: 2.0.0
       ignore: 5.2.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       knitwork: 0.1.2
       lodash.template: 4.5.0
       mlly: 0.5.14
@@ -1517,18 +1538,18 @@ packages:
       - webpack
     dev: false
 
-  /@nuxt/kit/3.0.0-rc.10_gdklb7vs65oca6qjnjub6mgwyy:
+  /@nuxt/kit/3.0.0-rc.10_dtdvqnq7rqavoryvihrftyo2yy:
     resolution: {integrity: sha512-sJEuvM6JTOWULRTLN0R4vZZYxus0ylevrCUELnez3GHedeDPopFrjFd8G+pZWTid9wix4SS3izWBvOJx9mLGlQ==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     dependencies:
-      '@nuxt/schema': 3.0.0-rc.10_gdklb7vs65oca6qjnjub6mgwyy
+      '@nuxt/schema': 3.0.0-rc.10_dtdvqnq7rqavoryvihrftyo2yy
       c12: 0.2.12
       consola: 2.15.3
       defu: 6.1.0
       globby: 13.1.2
       hash-sum: 2.0.0
       ignore: 5.2.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       knitwork: 0.1.2
       lodash.template: 4.5.0
       mlly: 0.5.14
@@ -1536,8 +1557,8 @@ packages:
       pkg-types: 0.3.5
       scule: 0.3.2
       semver: 7.3.7
-      unctx: 2.0.2_gdklb7vs65oca6qjnjub6mgwyy
-      unimport: 0.6.7_gdklb7vs65oca6qjnjub6mgwyy
+      unctx: 2.0.2_dtdvqnq7rqavoryvihrftyo2yy
+      unimport: 0.6.7_dtdvqnq7rqavoryvihrftyo2yy
       untyped: 0.5.0
     transitivePeerDependencies:
       - esbuild
@@ -1558,7 +1579,7 @@ packages:
       globby: 13.1.2
       hash-sum: 2.0.0
       ignore: 5.2.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       knitwork: 0.1.2
       lodash.template: 4.5.0
       mlly: 0.5.14
@@ -1569,6 +1590,36 @@ packages:
       unctx: 2.0.2_rollup@2.79.0+vite@3.1.2
       unimport: 0.6.7_rollup@2.79.0+vite@3.1.2
       untyped: 0.5.0
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - supports-color
+      - vite
+      - webpack
+    dev: true
+
+  /@nuxt/kit/3.0.0-rc.9_dtdvqnq7rqavoryvihrftyo2yy:
+    resolution: {integrity: sha512-Y+db0iw/1pKiLMEG7L/6HCq8O9xsbVJT/ksePY1Q8o3fV40Q9gCWI0YumCIzVdBiAFFEOCNASsxmGj7kPSdpCA==}
+    engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
+    dependencies:
+      '@nuxt/schema': 3.0.0-rc.9_dtdvqnq7rqavoryvihrftyo2yy
+      c12: 0.2.12
+      consola: 2.15.3
+      defu: 6.1.0
+      globby: 13.1.2
+      hash-sum: 2.0.0
+      ignore: 5.2.0
+      jiti: 1.16.0
+      knitwork: 0.1.2
+      lodash.template: 4.5.0
+      mlly: 0.5.14
+      pathe: 0.3.7
+      pkg-types: 0.3.5
+      scule: 0.3.2
+      semver: 7.3.7
+      unctx: 2.0.2_dtdvqnq7rqavoryvihrftyo2yy
+      unimport: 0.6.7_dtdvqnq7rqavoryvihrftyo2yy
+      untyped: 0.4.7
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -1588,7 +1639,7 @@ packages:
       globby: 13.1.2
       hash-sum: 2.0.0
       ignore: 5.2.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       knitwork: 0.1.2
       lodash.template: 4.5.0
       mlly: 0.5.14
@@ -1618,7 +1669,7 @@ packages:
       globby: 13.1.2
       hash-sum: 2.0.0
       ignore: 5.2.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       knitwork: 0.1.2
       lodash.template: 4.5.0
       mlly: 0.5.14
@@ -1644,7 +1695,7 @@ packages:
       c12: 0.2.12
       create-require: 1.1.1
       defu: 6.1.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       pathe: 0.3.7
       pkg-types: 0.3.5
       postcss-import-resolver: 2.0.0
@@ -1658,21 +1709,21 @@ packages:
       - vite
       - webpack
 
-  /@nuxt/schema/3.0.0-rc.10_gdklb7vs65oca6qjnjub6mgwyy:
+  /@nuxt/schema/3.0.0-rc.10_dtdvqnq7rqavoryvihrftyo2yy:
     resolution: {integrity: sha512-mHb+5qp3H07QvASA/fGEnUWx4S3plBt6nqZmPewxDuBys2au/PCBJBQiwKioBLgQvFPqysirScpLYPFKy3qdJw==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     dependencies:
       c12: 0.2.12
       create-require: 1.1.1
       defu: 6.1.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       pathe: 0.3.7
       pkg-types: 0.3.5
       postcss-import-resolver: 2.0.0
       scule: 0.3.2
       std-env: 3.2.1
       ufo: 0.8.5
-      unimport: 0.6.7_gdklb7vs65oca6qjnjub6mgwyy
+      unimport: 0.6.7_dtdvqnq7rqavoryvihrftyo2yy
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -1687,7 +1738,7 @@ packages:
       c12: 0.2.12
       create-require: 1.1.1
       defu: 6.1.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       pathe: 0.3.7
       pkg-types: 0.3.5
       postcss-import-resolver: 2.0.0
@@ -1702,6 +1753,27 @@ packages:
       - webpack
     dev: true
 
+  /@nuxt/schema/3.0.0-rc.9_dtdvqnq7rqavoryvihrftyo2yy:
+    resolution: {integrity: sha512-oxrsJE3v7WC8tqTPxutK4LFxR/6u00Zt2PfPm1XTWwx8fojDk4C5iCv5mxydHwXffsIp5JeP5hddd/oqnbDSpQ==}
+    engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
+    dependencies:
+      c12: 0.2.12
+      create-require: 1.1.1
+      defu: 6.1.0
+      jiti: 1.16.0
+      pathe: 0.3.7
+      postcss-import-resolver: 2.0.0
+      scule: 0.3.2
+      std-env: 3.2.1
+      ufo: 0.8.5
+      unimport: 0.6.7_dtdvqnq7rqavoryvihrftyo2yy
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+    dev: true
+
   /@nuxt/schema/3.0.0-rc.9_gdklb7vs65oca6qjnjub6mgwyy:
     resolution: {integrity: sha512-oxrsJE3v7WC8tqTPxutK4LFxR/6u00Zt2PfPm1XTWwx8fojDk4C5iCv5mxydHwXffsIp5JeP5hddd/oqnbDSpQ==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
@@ -1709,7 +1781,7 @@ packages:
       c12: 0.2.12
       create-require: 1.1.1
       defu: 6.1.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       pathe: 0.3.7
       postcss-import-resolver: 2.0.0
       scule: 0.3.2
@@ -1730,7 +1802,7 @@ packages:
       c12: 0.2.12
       create-require: 1.1.1
       defu: 6.1.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       pathe: 0.3.7
       postcss-import-resolver: 2.0.0
       scule: 0.3.2
@@ -1744,11 +1816,11 @@ packages:
       - webpack
     dev: true
 
-  /@nuxt/telemetry/2.1.5_gdklb7vs65oca6qjnjub6mgwyy:
+  /@nuxt/telemetry/2.1.5_dtdvqnq7rqavoryvihrftyo2yy:
     resolution: {integrity: sha512-Goi35DKG0Na7k/lPcaZkEvb+TWPdXKtyRixvcMMtvdbzjqGD/+gMy9BtHuS051LxdVZBNWBFyGVwT+DqlkVZKw==}
     hasBin: true
     dependencies:
-      '@nuxt/kit': 3.0.0-rc.10_gdklb7vs65oca6qjnjub6mgwyy
+      '@nuxt/kit': 3.0.0-rc.10_dtdvqnq7rqavoryvihrftyo2yy
       chalk: 5.0.1
       ci-info: 3.4.0
       consola: 2.15.3
@@ -1760,7 +1832,7 @@ packages:
       git-url-parse: 13.1.0
       inquirer: 9.1.1
       is-docker: 3.0.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       mri: 1.2.0
       nanoid: 4.0.0
       node-fetch: 3.2.10
@@ -1792,7 +1864,7 @@ packages:
       git-url-parse: 13.1.0
       inquirer: 9.1.1
       is-docker: 3.0.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       mri: 1.2.0
       nanoid: 4.0.0
       node-fetch: 3.2.10
@@ -2818,7 +2890,7 @@ packages:
     resolution: {integrity: sha512-kNas/zMkwsDFMcJPmHoPDJlQi1MHvYwx8BSxo9JKcbCW7Gaj8Rg2CnEImX5YdT+ZcFQqQ+kUn0Vi/ScsAxhGEw==}
     dependencies:
       debug: 4.3.4
-      jiti: 1.15.0
+      jiti: 1.16.0
       windicss: 3.5.6
     transitivePeerDependencies:
       - supports-color
@@ -3388,7 +3460,7 @@ packages:
       defu: 6.1.0
       dotenv: 16.0.2
       gittar: 0.1.1
-      jiti: 1.15.0
+      jiti: 1.16.0
       mlly: 0.5.14
       pathe: 0.3.7
       pkg-types: 0.3.5
@@ -4333,6 +4405,17 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-android-64/0.15.8:
+    resolution: {integrity: sha512-bVh8FIKOolF7/d4AMzt7xHlL0Ljr+mYKSHI39TJWDkybVWHdn6+4ODL3xZGHOxPpdRpitemXA1WwMKYBsw8dGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dependencies:
+      esbuild-wasm: 0.15.8
+    dev: true
+    optional: true
+
   /esbuild-android-arm64/0.14.54:
     resolution: {integrity: sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==}
     engines: {node: '>=12'}
@@ -4344,6 +4427,15 @@ packages:
 
   /esbuild-android-arm64/0.15.7:
     resolution: {integrity: sha512-L775l9ynJT7rVqRM5vo+9w5g2ysbOCfsdLV4CWanTZ1k/9Jb3IYlQ06VCI1edhcosTYJRECQFJa3eAvkx72eyQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.15.8:
+    resolution: {integrity: sha512-ReAMDAHuo0H1h9LxRabI6gwYPn8k6WiUeyxuMvx17yTrJO+SCnIfNc/TSPFvDwtK9MiyiKG/2dBYHouT/M0BXQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -4369,6 +4461,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-darwin-64/0.15.8:
+    resolution: {integrity: sha512-KaKcGfJ+yto7Fo5gAj3xwxHMd1fBIKatpCHK8znTJLVv+9+NN2/tIPBqA4w5rBwjX0UqXDeIE2v1xJP+nGEXgA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-darwin-arm64/0.14.54:
     resolution: {integrity: sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==}
     engines: {node: '>=12'}
@@ -4380,6 +4481,15 @@ packages:
 
   /esbuild-darwin-arm64/0.15.7:
     resolution: {integrity: sha512-kBIHvtVqbSGajN88lYMnR3aIleH3ABZLLFLxwL2stiuIGAjGlQW741NxVTpUHQXUmPzxi6POqc9npkXa8AcSZQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.15.8:
+    resolution: {integrity: sha512-8tjEaBgAKnXCkP7bhEJmEqdG9HEV6oLkF36BrMzpfW2rgaw0c48Zrxe+9RlfeGvs6gDF4w+agXyTjikzsS3izw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -4405,6 +4515,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-freebsd-64/0.15.8:
+    resolution: {integrity: sha512-jaxcsGHYzn2L0/lffON2WfH4Nc+d/EwozVTP5K2v016zxMb5UQMhLoJzvLgBqHT1SG0B/mO+a+THnJCMVg15zw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-freebsd-arm64/0.14.54:
     resolution: {integrity: sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==}
     engines: {node: '>=12'}
@@ -4416,6 +4535,15 @@ packages:
 
   /esbuild-freebsd-arm64/0.15.7:
     resolution: {integrity: sha512-dLFR0ChH5t+b3J8w0fVKGvtwSLWCv7GYT2Y2jFGulF1L5HftQLzVGN+6pi1SivuiVSmTh28FwUhi9PwQicXI6Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.15.8:
+    resolution: {integrity: sha512-2xp2UlljMvX8HExtcg7VHaeQk8OBU0CSl1j18B5CcZmSDkLF9p3utuMXIopG3a08fr9Hv+Dz6+seSXUow/G51w==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -4441,6 +4569,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-32/0.15.8:
+    resolution: {integrity: sha512-9u1E54BRz1FQMl86iaHK146+4ID2KYNxL3trLZT4QLLx3M7Q9n4lGG3lrzqUatGR2cKy8c33b0iaCzsItZWkFg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-64/0.14.54:
     resolution: {integrity: sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==}
     engines: {node: '>=12'}
@@ -4452,6 +4589,15 @@ packages:
 
   /esbuild-linux-64/0.15.7:
     resolution: {integrity: sha512-LxXEfLAKwOVmm1yecpMmWERBshl+Kv5YJ/1KnyAr6HRHFW8cxOEsEfisD3sVl/RvHyW//lhYUVSuy9jGEfIRAQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.15.8:
+    resolution: {integrity: sha512-4HxrsN9eUzJXdVGMTYA5Xler82FuZUu21bXKN42zcLHHNKCAMPUzD62I+GwDhsdgUBAUj0tRXDdsQHgaP6v0HA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -4477,6 +4623,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-arm/0.15.8:
+    resolution: {integrity: sha512-7DVBU9SFjX4+vBwt8tHsUCbE6Vvl6y6FQWHAgyw1lybC5gULqn/WnjHYHN2/LJaZRsDBvxWT4msEgwLGq1Wd3Q==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-arm64/0.14.54:
     resolution: {integrity: sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==}
     engines: {node: '>=12'}
@@ -4488,6 +4643,15 @@ packages:
 
   /esbuild-linux-arm64/0.15.7:
     resolution: {integrity: sha512-P3cfhudpzWDkglutWgXcT2S7Ft7o2e3YDMrP1n0z2dlbUZghUkKCyaWw0zhp4KxEEzt/E7lmrtRu/pGWnwb9vw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.15.8:
+    resolution: {integrity: sha512-1OCm7Aq0tEJT70PbxmHSGYDLYP8DKH8r4Nk7/XbVzWaduo9beCjGBB+tGZIHK6DdTQ3h00/4Tb/70YMH/bOtKg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -4513,6 +4677,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-mips64le/0.15.8:
+    resolution: {integrity: sha512-yeFoNPVFPEzZvFYBfUQNG2TjGRaCyV1E27OcOg4LOtnGrxb2wA+mkW3luckyv1CEyd00mpAg7UdHx8nlx3ghgA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-ppc64le/0.14.54:
     resolution: {integrity: sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==}
     engines: {node: '>=12'}
@@ -4524,6 +4697,15 @@ packages:
 
   /esbuild-linux-ppc64le/0.15.7:
     resolution: {integrity: sha512-6mGuC19WpFN7NYbecMIJjeQgvDb5aMuvyk0PDYBJrqAEMkTwg3Z98kEKuCm6THHRnrgsdr7bp4SruSAxEM4eJw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.15.8:
+    resolution: {integrity: sha512-CEyMMUUNabXibw8OSNmBXhOIGhnjNVl5Lpseiuf00iKN0V47oqDrbo4dsHz1wH62m49AR8iG8wpDlTqfYgKbtg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -4549,6 +4731,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-riscv64/0.15.8:
+    resolution: {integrity: sha512-OCGSOaspMUjexSCU8ZiA0UnV/NiRU+s2vIfEcAQWQ6u32R+2luyfh/4ZaY6jFbylJE07Esc/yRvb9Q5fXuClXA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-s390x/0.14.54:
     resolution: {integrity: sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==}
     engines: {node: '>=12'}
@@ -4560,6 +4751,15 @@ packages:
 
   /esbuild-linux-s390x/0.15.7:
     resolution: {integrity: sha512-+tO+xOyTNMc34rXlSxK7aCwJgvQyffqEM5MMdNDEeMU3ss0S6wKvbBOQfgd5jRPblfwJ6b+bKiz0g5nABpY0QQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.15.8:
+    resolution: {integrity: sha512-RHdpdfxRTSrZXZJlFSLazFU4YwXLB5Rgf6Zr5rffqSsO4y9JybgtKO38bFwxZNlDXliYISXN/YROKrG9s7mZQA==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -4585,6 +4785,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-netbsd-64/0.15.8:
+    resolution: {integrity: sha512-VolFFRatBH09T5QMWhiohAWCOien1R1Uz9K0BRVVTBgBaVBt7eArsXTKxVhUgRf2vwu2c2SXkuP0r7HLG0eozw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-openbsd-64/0.14.54:
     resolution: {integrity: sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==}
     engines: {node: '>=12'}
@@ -4596,6 +4805,15 @@ packages:
 
   /esbuild-openbsd-64/0.15.7:
     resolution: {integrity: sha512-GsimbwC4FSR4lN3wf8XmTQ+r8/0YSQo21rWDL0XFFhLHKlzEA4SsT1Tl8bPYu00IU6UWSJ+b3fG/8SB69rcuEQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.15.8:
+    resolution: {integrity: sha512-HTAPlg+n4kUeE/isQxlCfsOz0xJGNoT5LJ9oYZWFKABfVf4Ycu7Zlf5ITgOnrdheTkz8JeL/gISIOCFAoOXrSA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -4621,6 +4839,23 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-sunos-64/0.15.8:
+    resolution: {integrity: sha512-qMP/jR/FzcIOwKj+W+Lb+8Cfr8GZHbHUJxAPi7DUhNZMQ/6y7sOgRzlOSpRrbbUntrRZh0MqOyDhJ3Gpo6L1QA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-wasm/0.15.8:
+    resolution: {integrity: sha512-Y7uCl5RNO4URjlemjdx++ukVHEMt5s5AfMWYUnMiK4Sry+pPCvQIctzXq6r6FKCyGKjX6/NGMCqR2OX6aLxj0w==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-32/0.14.54:
     resolution: {integrity: sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==}
     engines: {node: '>=12'}
@@ -4632,6 +4867,15 @@ packages:
 
   /esbuild-windows-32/0.15.7:
     resolution: {integrity: sha512-cOnKXUEPS8EGCzRSFa1x6NQjGhGsFlVgjhqGEbLTPsA7x4RRYiy2RKoArNUU4iR2vHmzqS5Gr84MEumO/wxYKA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32/0.15.8:
+    resolution: {integrity: sha512-RKR1QHh4iWzjUhkP8Yqi75PPz/KS+b8zw3wUrzw6oAkj+iU5Qtyj61ZDaSG3Qf2vc6hTIUiPqVTqBH0NpXFNwg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -4657,6 +4901,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-windows-64/0.15.8:
+    resolution: {integrity: sha512-ag9ptYrsizgsR+PQE8QKeMqnosLvAMonQREpLw4evA4FFgOBMLEat/dY/9txbpozTw9eEOYyD3a4cE9yTu20FA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-arm64/0.14.54:
     resolution: {integrity: sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==}
     engines: {node: '>=12'}
@@ -4668,6 +4921,15 @@ packages:
 
   /esbuild-windows-arm64/0.15.7:
     resolution: {integrity: sha512-R06nmqBlWjKHddhRJYlqDd3Fabx9LFdKcjoOy08YLimwmsswlFBJV4rXzZCxz/b7ZJXvrZgj8DDv1ewE9+StMw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.15.8:
+    resolution: {integrity: sha512-dbpAb0VyPaUs9mgw65KRfQ9rqiWCHpNzrJusoPu+LpEoswosjt/tFxN7cd2l68AT4qWdBkzAjDLRon7uqMeWcg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -4731,6 +4993,36 @@ packages:
       esbuild-windows-32: 0.15.7
       esbuild-windows-64: 0.15.7
       esbuild-windows-arm64: 0.15.7
+    dev: true
+
+  /esbuild/0.15.8:
+    resolution: {integrity: sha512-Remsk2dmr1Ia65sU+QasE6svJbsHe62lzR+CnjpUvbZ+uSYo1SitiOWPRfZQkCu82YWZBBKXiD/j0i//XWMZ+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.15.8
+      '@esbuild/linux-loong64': 0.15.8
+      esbuild-android-64: 0.15.8
+      esbuild-android-arm64: 0.15.8
+      esbuild-darwin-64: 0.15.8
+      esbuild-darwin-arm64: 0.15.8
+      esbuild-freebsd-64: 0.15.8
+      esbuild-freebsd-arm64: 0.15.8
+      esbuild-linux-32: 0.15.8
+      esbuild-linux-64: 0.15.8
+      esbuild-linux-arm: 0.15.8
+      esbuild-linux-arm64: 0.15.8
+      esbuild-linux-mips64le: 0.15.8
+      esbuild-linux-ppc64le: 0.15.8
+      esbuild-linux-riscv64: 0.15.8
+      esbuild-linux-s390x: 0.15.8
+      esbuild-netbsd-64: 0.15.8
+      esbuild-openbsd-64: 0.15.8
+      esbuild-sunos-64: 0.15.8
+      esbuild-windows-32: 0.15.8
+      esbuild-windows-64: 0.15.8
+      esbuild-windows-arm64: 0.15.8
     dev: true
 
   /escalade/3.1.1:
@@ -6334,8 +6626,8 @@ packages:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  /jiti/1.15.0:
-    resolution: {integrity: sha512-cClBkETOCVIpPMjX3ULlivuBvmt8l2Xtz+SHrULO06OqdtV0QFR2cuhc4FJnXByjUUX4CY0pl1nph0aFh9D3yA==}
+  /jiti/1.16.0:
+    resolution: {integrity: sha512-L3BJStEf5NAqNuzrpfbN71dp43mYIcBUlCRea/vdyv5dW/AYa1d4bpelko4SHdY3I6eN9Wzyasxirj1/vv5kmg==}
     hasBin: true
 
   /joycon/3.1.1:
@@ -7368,7 +7660,7 @@ packages:
       esbuild: 0.14.54
       fs-extra: 10.1.0
       globby: 11.1.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       mri: 1.2.0
       pathe: 0.2.0
       typescript: 4.8.3
@@ -7505,7 +7797,7 @@ packages:
       hookable: 5.3.0
       http-proxy: 1.18.1
       is-primitive: 3.0.1
-      jiti: 1.15.0
+      jiti: 1.16.0
       klona: 2.0.5
       knitwork: 0.1.2
       listhen: 0.2.15
@@ -7669,72 +7961,6 @@ packages:
       fast-glob: 3.2.12
     dev: true
 
-  /nuxt/3.0.0-rc.9_bl7lvocflkyvbrqfu5zopi7eki:
-    resolution: {integrity: sha512-fXaqm+Vha/p+MztueluJdEc9hqj6gwjFeuCgOBwIYnV+3nFbHu3EAro8QbPcoYZaj5oot+qY7YuyGczBvlNZuQ==}
-    engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
-    hasBin: true
-    dependencies:
-      '@nuxt/devalue': 2.0.0
-      '@nuxt/kit': 3.0.0-rc.9_gdklb7vs65oca6qjnjub6mgwyy
-      '@nuxt/schema': 3.0.0-rc.9_gdklb7vs65oca6qjnjub6mgwyy
-      '@nuxt/telemetry': 2.1.5_gdklb7vs65oca6qjnjub6mgwyy
-      '@nuxt/ui-templates': 0.3.3
-      '@nuxt/vite-builder': 3.0.0-rc.9_jg2x3mreiplbckcixq5lavj2im
-      '@vue/reactivity': 3.2.39
-      '@vue/shared': 3.2.39
-      '@vueuse/head': 0.7.12_vue@3.2.39
-      chokidar: 3.5.3
-      cookie-es: 0.5.0
-      defu: 6.1.0
-      destr: 1.1.1
-      escape-string-regexp: 5.0.0
-      fs-extra: 10.1.0
-      globby: 13.1.2
-      h3: 0.7.21
-      hash-sum: 2.0.0
-      hookable: 5.3.0
-      knitwork: 0.1.2
-      magic-string: 0.26.3
-      mlly: 0.5.14
-      nitropack: 0.5.3_vite@3.1.2
-      nuxi: 3.0.0-rc.9
-      ohash: 0.1.5
-      ohmyfetch: 0.4.18
-      pathe: 0.3.7
-      perfect-debounce: 0.1.3
-      scule: 0.3.2
-      strip-literal: 0.4.2
-      ufo: 0.8.5
-      unctx: 2.0.2_gdklb7vs65oca6qjnjub6mgwyy
-      unenv: 0.6.2
-      unimport: 0.6.7_gdklb7vs65oca6qjnjub6mgwyy
-      unplugin: 0.9.5_gdklb7vs65oca6qjnjub6mgwyy
-      untyped: 0.4.7
-      vue: 3.2.39
-      vue-bundle-renderer: 0.4.3
-      vue-devtools-stub: 0.1.0
-      vue-router: 4.1.5_vue@3.2.39
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - bufferutil
-      - debug
-      - encoding
-      - esbuild
-      - eslint
-      - less
-      - rollup
-      - sass
-      - stylus
-      - supports-color
-      - terser
-      - typescript
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - webpack
-    dev: true
-
   /nuxt/3.0.0-rc.9_rollup@2.79.0+vite@3.1.2:
     resolution: {integrity: sha512-fXaqm+Vha/p+MztueluJdEc9hqj6gwjFeuCgOBwIYnV+3nFbHu3EAro8QbPcoYZaj5oot+qY7YuyGczBvlNZuQ==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
@@ -7775,6 +8001,72 @@ packages:
       unenv: 0.6.2
       unimport: 0.6.7_rollup@2.79.0+vite@3.1.2
       unplugin: 0.9.5_rollup@2.79.0+vite@3.1.2
+      untyped: 0.4.7
+      vue: 3.2.39
+      vue-bundle-renderer: 0.4.3
+      vue-devtools-stub: 0.1.0
+      vue-router: 4.1.5_vue@3.2.39
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - bufferutil
+      - debug
+      - encoding
+      - esbuild
+      - eslint
+      - less
+      - rollup
+      - sass
+      - stylus
+      - supports-color
+      - terser
+      - typescript
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - webpack
+    dev: true
+
+  /nuxt/3.0.0-rc.9_sgypswyl2qhjagm5gyqma46mmq:
+    resolution: {integrity: sha512-fXaqm+Vha/p+MztueluJdEc9hqj6gwjFeuCgOBwIYnV+3nFbHu3EAro8QbPcoYZaj5oot+qY7YuyGczBvlNZuQ==}
+    engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
+    hasBin: true
+    dependencies:
+      '@nuxt/devalue': 2.0.0
+      '@nuxt/kit': 3.0.0-rc.9_dtdvqnq7rqavoryvihrftyo2yy
+      '@nuxt/schema': 3.0.0-rc.9_dtdvqnq7rqavoryvihrftyo2yy
+      '@nuxt/telemetry': 2.1.5_dtdvqnq7rqavoryvihrftyo2yy
+      '@nuxt/ui-templates': 0.3.3
+      '@nuxt/vite-builder': 3.0.0-rc.9_jg2x3mreiplbckcixq5lavj2im
+      '@vue/reactivity': 3.2.39
+      '@vue/shared': 3.2.39
+      '@vueuse/head': 0.7.12_vue@3.2.39
+      chokidar: 3.5.3
+      cookie-es: 0.5.0
+      defu: 6.1.0
+      destr: 1.1.1
+      escape-string-regexp: 5.0.0
+      fs-extra: 10.1.0
+      globby: 13.1.2
+      h3: 0.7.21
+      hash-sum: 2.0.0
+      hookable: 5.3.0
+      knitwork: 0.1.2
+      magic-string: 0.26.3
+      mlly: 0.5.14
+      nitropack: 0.5.3_vite@3.1.2
+      nuxi: 3.0.0-rc.9
+      ohash: 0.1.5
+      ohmyfetch: 0.4.18
+      pathe: 0.3.7
+      perfect-debounce: 0.1.3
+      scule: 0.3.2
+      strip-literal: 0.4.2
+      ufo: 0.8.5
+      unctx: 2.0.2_dtdvqnq7rqavoryvihrftyo2yy
+      unenv: 0.6.2
+      unimport: 0.6.7_dtdvqnq7rqavoryvihrftyo2yy
+      unplugin: 0.9.5_dtdvqnq7rqavoryvihrftyo2yy
       untyped: 0.4.7
       vue: 3.2.39
       vue-bundle-renderer: 0.4.3
@@ -9096,7 +9388,7 @@ packages:
       '@babel/code-frame': 7.18.6
     dev: true
 
-  /rollup-plugin-esbuild/4.10.1_uu2p2v3owefbwsafzxfcsbbrxa:
+  /rollup-plugin-esbuild/4.10.1_smomlxmjgt6y4akd764agnhchu:
     resolution: {integrity: sha512-/ymcRB283zjFp1JTBXO8ekxv0c9vRc2L6OTljghsLthQ4vqeDSDWa9BVz1tHiVrx6SbUnUpDPLC0K/MXK7j5TA==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -9106,7 +9398,7 @@ packages:
       '@rollup/pluginutils': 4.2.1
       debug: 4.3.4
       es-module-lexer: 0.9.3
-      esbuild: 0.15.7
+      esbuild: 0.15.8
       joycon: 3.1.1
       jsonc-parser: 3.2.0
       rollup: 2.79.0
@@ -9707,10 +9999,12 @@ packages:
       tslib: 2.4.0
     dev: true
 
-  /tailwindcss/3.1.8:
+  /tailwindcss/3.1.8_postcss@8.4.16:
     resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -10138,10 +10432,10 @@ packages:
       chalk: 5.0.1
       consola: 2.15.3
       defu: 6.1.0
-      esbuild: 0.15.7
+      esbuild: 0.15.8
       globby: 13.1.2
       hookable: 5.3.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       magic-string: 0.26.3
       mkdirp: 1.0.4
       mkdist: 0.3.13_typescript@4.8.3
@@ -10153,7 +10447,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.0
       rollup-plugin-dts: 4.2.2_ihkqvyh37tzxtjmovjyy2yrv7m
-      rollup-plugin-esbuild: 4.10.1_uu2p2v3owefbwsafzxfcsbbrxa
+      rollup-plugin-esbuild: 4.10.1_smomlxmjgt6y4akd764agnhchu
       scule: 0.3.2
       typescript: 4.8.3
       untyped: 0.5.0
@@ -10166,7 +10460,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.5.2
       defu: 6.1.0
-      jiti: 1.15.0
+      jiti: 1.16.0
 
   /unctx/2.0.2:
     resolution: {integrity: sha512-3lcXTlDoOaguRVC1GqG3mrawy17yoycSAQDDnUayQYZ17v9to+Gn6Zyssroc/GD2ppJ0wF5V8adOcKkrNKVWow==}
@@ -10181,6 +10475,20 @@ packages:
       - vite
       - webpack
     dev: false
+
+  /unctx/2.0.2_dtdvqnq7rqavoryvihrftyo2yy:
+    resolution: {integrity: sha512-3lcXTlDoOaguRVC1GqG3mrawy17yoycSAQDDnUayQYZ17v9to+Gn6Zyssroc/GD2ppJ0wF5V8adOcKkrNKVWow==}
+    dependencies:
+      acorn: 8.8.0
+      estree-walker: 3.0.1
+      magic-string: 0.26.3
+      unplugin: 0.9.5_dtdvqnq7rqavoryvihrftyo2yy
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+    dev: true
 
   /unctx/2.0.2_gdklb7vs65oca6qjnjub6mgwyy:
     resolution: {integrity: sha512-3lcXTlDoOaguRVC1GqG3mrawy17yoycSAQDDnUayQYZ17v9to+Gn6Zyssroc/GD2ppJ0wF5V8adOcKkrNKVWow==}
@@ -10257,6 +10565,26 @@ packages:
       - rollup
       - vite
       - webpack
+
+  /unimport/0.6.7_dtdvqnq7rqavoryvihrftyo2yy:
+    resolution: {integrity: sha512-EMoVqDjswHkU+nD098QYHXH7Mkw7KwGDQAyeRF2lgairJnuO+wpkhIcmCqrD1OPJmsjkTbJ2tW6Ap8St0PuWZA==}
+    dependencies:
+      '@rollup/pluginutils': 4.2.1
+      escape-string-regexp: 5.0.0
+      fast-glob: 3.2.12
+      local-pkg: 0.4.2
+      magic-string: 0.26.3
+      mlly: 0.5.14
+      pathe: 0.3.7
+      scule: 0.3.2
+      strip-literal: 0.4.2
+      unplugin: 0.9.5_dtdvqnq7rqavoryvihrftyo2yy
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+    dev: true
 
   /unimport/0.6.7_gdklb7vs65oca6qjnjub6mgwyy:
     resolution: {integrity: sha512-EMoVqDjswHkU+nD098QYHXH7Mkw7KwGDQAyeRF2lgairJnuO+wpkhIcmCqrD1OPJmsjkTbJ2tW6Ap8St0PuWZA==}
@@ -10379,7 +10707,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unplugin-auto-import/0.11.2_n3tqqlru4qqd2r2s3afj2lwvg4:
+  /unplugin-auto-import/0.11.2_xhttxuaspog4dlg5ri763ccavu:
     resolution: {integrity: sha512-1+VwBfn9dtiYv9SQLKP1AvZolUbK9xTVeAT+iOcEk4EHSFUlmIqBVLEKI76cifSQTLOJ3rZyPrEgptf3SZNLlQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -10393,8 +10721,8 @@ packages:
       '@vueuse/core': 9.2.0_vue@3.2.39
       local-pkg: 0.4.2
       magic-string: 0.26.3
-      unimport: 0.6.7_gdklb7vs65oca6qjnjub6mgwyy
-      unplugin: 0.9.5_gdklb7vs65oca6qjnjub6mgwyy
+      unimport: 0.6.7_dtdvqnq7rqavoryvihrftyo2yy
+      unplugin: 0.9.5_dtdvqnq7rqavoryvihrftyo2yy
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -10402,7 +10730,7 @@ packages:
       - webpack
     dev: true
 
-  /unplugin-vue-components/0.22.7_ojf5i3ldatw6oymnser7cijypu:
+  /unplugin-vue-components/0.22.7_a35c2tzqgijav5jkbfyu2c5dqu:
     resolution: {integrity: sha512-MJEAKJF9bRykTRvJ4WXF0FNMAyt1PX3iwpu2NN+li35sAKjQv6sC1col5aZDLiwDZDo2AGwxNkzLJFKaun9qHw==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -10421,7 +10749,7 @@ packages:
       magic-string: 0.26.3
       minimatch: 5.1.0
       resolve: 1.22.1
-      unplugin: 0.9.5_gdklb7vs65oca6qjnjub6mgwyy
+      unplugin: 0.9.5_dtdvqnq7rqavoryvihrftyo2yy
       vue: 3.2.39
     transitivePeerDependencies:
       - esbuild
@@ -10452,6 +10780,32 @@ packages:
       chokidar: 3.5.3
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.4.5
+
+  /unplugin/0.9.5_dtdvqnq7rqavoryvihrftyo2yy:
+    resolution: {integrity: sha512-luraheyfxwtvkvHpsOvMNv7IjLdORTWKZp0gWYNHGLi2ImON3iIZOj464qEyyEwLA/EMt12fC415HW9zRpOfTg==}
+    peerDependencies:
+      esbuild: '>=0.13'
+      rollup: ^2.50.0
+      vite: ^2.3.0 || ^3.0.0-0
+      webpack: 4 || 5
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+    dependencies:
+      acorn: 8.8.0
+      chokidar: 3.5.3
+      esbuild: 0.15.8
+      rollup: 2.79.0
+      vite: 3.1.2_terser@5.15.0
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.4.5
+    dev: true
 
   /unplugin/0.9.5_gdklb7vs65oca6qjnjub6mgwyy:
     resolution: {integrity: sha512-luraheyfxwtvkvHpsOvMNv7IjLdORTWKZp0gWYNHGLi2ImON3iIZOj464qEyyEwLA/EMt12fC415HW9zRpOfTg==}


### PR DESCRIPTION
It will be fixed https://github.com/unjs/jiti/issues/84

`pnpm run test fixtures` and `pnpm run play` won't be errors.