### PR TITLE
fix(vscode): windows pathe format

### DIFF
--- a/packages/vscode/src/contextLoader.ts
+++ b/packages/vscode/src/contextLoader.ts
@@ -5,6 +5,7 @@ import type { UnocssPluginContext, UserConfig, UserConfigDefaults } from '@unocs
 import { notNull } from '@unocss/core'
 import { sourceObjectFields, sourcePluginFactory } from 'unconfig/presets'
 import presetUno from '@unocss/preset-uno'
+import { normalizePath } from 'vite'
 import { resolveOptions as resolveNuxtOptions } from '../../nuxt/src/options'
 import { createNanoEvents } from '../../core/src/utils/events'
 import { createContext, isCssId } from './integration'
@@ -83,7 +84,6 @@ export class ContextLoader {
   }
 
   async loadContextInDirectory(dir: string) {
-    const normalizedDir = normalizeWindowsPath(dir)
     const cached = this.contextsMap.get(dir)
     if (cached !== undefined)
       return cached
@@ -136,7 +136,7 @@ export class ContextLoader {
         return null
 
       const baseDir = dirname(sources[0])
-      if (baseDir !== normalizedDir) {
+      if (baseDir !== normalizePath(dir)) {
         // exists on upper level, skip
         this.contextsMap.set(dir, null)
         return null
@@ -250,12 +250,4 @@ export class ContextLoader {
 
     return this.defaultContext
   }
-}
-
-// Util to normalize windows paths to posix
-function normalizeWindowsPath(input = '') {
-  if (!input || !input.includes('\\'))
-    return input
-
-  return input.replace(/\\/g, '/')
 }

--- a/packages/vscode/src/contextLoader.ts
+++ b/packages/vscode/src/contextLoader.ts
@@ -83,6 +83,7 @@ export class ContextLoader {
   }
 
   async loadContextInDirectory(dir: string) {
+    const normalizedDir = normalizeWindowsPath(dir)
     const cached = this.contextsMap.get(dir)
     if (cached !== undefined)
       return cached
@@ -135,7 +136,7 @@ export class ContextLoader {
         return null
 
       const baseDir = dirname(sources[0])
-      if (baseDir !== dir) {
+      if (baseDir !== normalizedDir) {
         // exists on upper level, skip
         this.contextsMap.set(dir, null)
         return null
@@ -249,4 +250,12 @@ export class ContextLoader {
 
     return this.defaultContext
   }
+}
+
+// Util to normalize windows paths to posix
+function normalizeWindowsPath(input = '') {
+  if (!input || !input.includes('\\'))
+    return input
+
+  return input.replace(/\\/g, '/')
 }


### PR DESCRIPTION
Linked issue: #1644

Linked Commit: #1632 

function `pathe:dirname` will change the slash of path
https://github.com/unjs/pathe/blob/main/test/index.spec.ts#L86

This cause unequal on Windows and could not load config file.
![image](https://user-images.githubusercontent.com/22554452/192314314-326bca82-33b4-44c5-b486-3fd85a4628cb.png)
