### PR TITLE
fix(preset-rem-to-px): convert all rem values

### DIFF
--- a/packages/preset-rem-to-px/src/index.ts
+++ b/packages/preset-rem-to-px/src/index.ts
@@ -20,7 +20,7 @@ export default function remToPxPreset(options: RemToPxOptions = {}): Preset {
     postprocess: (util) => {
       util.entries.forEach((i) => {
         const value = i[1]
-        if (value && typeof value === 'string')
+        if (value && typeof value === 'string' && remRE.test(value))
           i[1] = value.replace(remRE, (_, p1) => `${p1 * baseFontSize}px`)
       })
     },

--- a/packages/preset-rem-to-px/src/index.ts
+++ b/packages/preset-rem-to-px/src/index.ts
@@ -1,6 +1,6 @@
 import type { Preset } from '@unocss/core'
 
-const remRE = /^-?[\.\d]+rem$/
+const remRE = /(-?[\.\d]+)rem/g
 
 export interface RemToPxOptions {
   /**
@@ -20,8 +20,8 @@ export default function remToPxPreset(options: RemToPxOptions = {}): Preset {
     postprocess: (util) => {
       util.entries.forEach((i) => {
         const value = i[1]
-        if (value && typeof value === 'string' && remRE.test(value))
-          i[1] = `${+value.slice(0, -3) * baseFontSize}px`
+        if (value && typeof value === 'string')
+          i[1] = value.replace(remRE, (_, p1) => `${p1 * baseFontSize}px`)
       })
     },
   }

--- a/test/preset-rem-to-px.test.ts
+++ b/test/preset-rem-to-px.test.ts
@@ -23,8 +23,8 @@ describe('rem-to-px', () => {
         .gap2{grid-gap:8px;gap:8px;}"
       `)
   })
-  
-    test('important prefix should works', async () => {
+
+  test('important prefix should works', async () => {
     expect((await uno.generate(
       new Set(['!m4', '!mx2', '!-p2', '!gap2']),
       { preflights: false })).css)

--- a/test/preset-rem-to-px.test.ts
+++ b/test/preset-rem-to-px.test.ts
@@ -23,4 +23,17 @@ describe('rem-to-px', () => {
         .gap2{grid-gap:8px;gap:8px;}"
       `)
   })
+  
+    test('`!` prefix should works', async () => {
+    expect((await uno.generate(
+      new Set(['!m4', '!mx2', '!-p2', '!gap2']),
+      { preflights: false })).css)
+      .toMatchInlineSnapshot(`
+        "/* layer: default */
+        .\\\\!-p2{padding:-8px !important;}
+        .\\\\!m4{margin:16px !important;}
+        .\\\\!mx2{margin-left:8px !important;margin-right:8px !important;}
+        .\\\\!gap2{grid-gap:8px !important;gap:8px !important;}"
+      `)
+  })
 })

--- a/test/preset-rem-to-px.test.ts
+++ b/test/preset-rem-to-px.test.ts
@@ -24,7 +24,7 @@ describe('rem-to-px', () => {
       `)
   })
   
-    test('`!` prefix should works', async () => {
+    test('important prefix should works', async () => {
     expect((await uno.generate(
       new Set(['!m4', '!mx2', '!-p2', '!gap2']),
       { preflights: false })).css)


### PR DESCRIPTION
### 原因
无法转换!important修饰的属性

### 例子
在 [playground](https://uno.antfu.me/play/?html=DwEwlgbgBAxgNgQwM5ILwCIAuBTAHpgWiQFsoBCHfI0ywgbQEYAGAJ22IF1zaDHX2O6KLQwlyJdAD5gAenARJAKCA&config=JYWwDg9gTgLgBAbwFBzgEwKYDNgDsMDCEuOA5gDQpxhQYDOGMAsnsJajfYwIIwxTAARgFcYwLAE9KAXzhYoEEHADkw3BADGdOsqShIsarQYwAShhAAVCAAUAHnIVLlAATWbtAek4mAtLRBfGAhfMDtdJAw7A3hMLABDYQAbWOw8QmIyAApkDmNGOgAuOABtKjyuZlYsgEp2VCNK3n4hUXEJWvqKk3MrWztaqgBdJGkapCA&options=N4IgTgpgzgDg9gOygSwG4RALgGYEMA2UEANCAC5i5LZxgC2WehEAvkA) 查看 output css

html
```html
<div class="text-sm !text-sm text-[10rem] !text-[10rem]" text="sm !sm"></div>
```
output
```css
.\!text-\[10rem\]{font-size:10rem !important;}
.\!text-sm,
[text~="\!sm"]{font-size:0.875rem !important;line-height:1.25rem !important;}
.text-\[10rem\]{font-size:160px;}
.text-sm,
[text~="sm"]{font-size:14px;line-height:20px;}
```
可以看到!important的属性并未被转换

### 修复后的输出
```css
.\!text-\[10rem\]{font-size:160px !important;}
.\!text-sm,
[text~="\!sm"]{font-size:14px !important;line-height:20px !important;}
.text-\[10rem\]{font-size:160px;}
.text-sm,
[text~="sm"]{font-size:14px;line-height:20px;}
```
