### PR TITLE
feat(core): generator events

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -13,6 +13,8 @@ export class UnoGenerator {
   public parentOrders = new Map<string, number>()
   public events = createNanoEvents<{
     config: (config: ResolvedConfig) => void
+    tokens: (context: { tokens: Set<string> }) => void
+    preflights: (context: { preflights: Set<string> }) => void
   }>()
 
   constructor(
@@ -144,63 +146,66 @@ export class UnoGenerator {
     const sheet = new Map<string, StringifiedUtil[]>()
     let preflightsMap: Record<string, string> = {}
 
-    const tokenPromises = Array.from(tokens).map(async (raw) => {
-      if (matched.has(raw))
-        return
+    const tokensPromise = (async () => {
+      await Promise.all(Array.from(tokens).map(async (raw) => {
+        if (matched.has(raw))
+          return
 
-      const payload = await this.parseToken(raw)
-      if (payload == null)
-        return
+        const payload = await this.parseToken(raw)
+        if (payload == null)
+          return
 
-      matched.add(raw)
+        matched.add(raw)
 
-      for (const item of payload) {
-        const parent = item[3] || ''
-        const layer = item[4]?.layer
-        if (!sheet.has(parent))
-          sheet.set(parent, [])
-        sheet.get(parent)!.push(item)
-        if (layer)
-          layerSet.add(layer)
-      }
-    })
+        for (const item of payload) {
+          const parent = item[3] || ''
+          const layer = item[4]?.layer
+          if (!sheet.has(parent))
+            sheet.set(parent, [])
+          sheet.get(parent)!.push(item)
+          if (layer)
+            layerSet.add(layer)
+        }
+      }))
 
-    const preflightPromise = (async () => {
-      if (!preflights)
-        return
-
-      const preflightContext: PreflightContext = {
-        generator: this,
-        theme: this.config.theme,
-      }
-
-      const preflightLayerSet = new Set<string>([])
-      this.config.preflights.forEach(({ layer = LAYER_PREFLIGHTS }) => {
-        layerSet.add(layer)
-        preflightLayerSet.add(layer)
-      })
-
-      preflightsMap = Object.fromEntries(
-        await Promise.all(Array.from(preflightLayerSet).map(
-          async (layer) => {
-            const preflights = await Promise.all(
-              this.config.preflights
-                .filter(i => (i.layer || LAYER_PREFLIGHTS) === layer)
-                .map(async i => await i.getCSS(preflightContext)),
-            )
-            const css = preflights
-              .filter(Boolean)
-              .join(nl)
-            return [layer, css]
-          },
-        )),
-      )
+      this.events.emit('tokens', { tokens: new Set(matched) })
     })()
 
-    await Promise.all([
-      ...tokenPromises,
-      preflightPromise,
-    ])
+    const preflightsPromise = (async () => {
+      const generatedPreflights = new Set<string>()
+
+      if (preflights) {
+        const preflightContext: PreflightContext = {
+          generator: this,
+          theme: this.config.theme,
+        }
+
+        const preflightLayerSet = new Set<string>([])
+        this.config.preflights.forEach(({ layer = LAYER_PREFLIGHTS }) => {
+          layerSet.add(layer)
+          preflightLayerSet.add(layer)
+        })
+
+        preflightsMap = Object.fromEntries(
+          await Promise.all(Array.from(preflightLayerSet).map(
+            async (layer) => {
+              const preflights = (await Promise.all(
+                this.config.preflights
+                  .filter(i => (i.layer || LAYER_PREFLIGHTS) === layer)
+                  .map(async i => await i.getCSS(preflightContext)),
+              )).filter(Boolean) as string[]
+
+              preflights.forEach(p => generatedPreflights.add(p))
+              return [layer, preflights.join(nl)]
+            },
+          )),
+        )
+      }
+
+      this.events.emit('preflights', { preflights: generatedPreflights })
+    })()
+
+    await Promise.all([tokensPromise, preflightsPromise])
 
     const layers = this.config.sortLayers(Array
       .from(layerSet)

--- a/test/generate-async.test.ts
+++ b/test/generate-async.test.ts
@@ -46,3 +46,81 @@ describe('generate-async', () => {
     expect(order).eql([1, 2])
   })
 })
+
+describe('firing-events', () => {
+  test('config-event', async () => {
+    const order: number[] = []
+    const uno = createGenerator()
+
+    uno.events.on('config', () => order.push(order.length))
+    expect(order).eql([])
+
+    uno.setConfig({})
+    expect(order).eql([0])
+  })
+
+  test('tokens-generated-event', async () => {
+    const order: number[] = []
+    const uno = createGenerator({
+      rules: [
+        [/^rule$/, () => new Promise(resolve => setTimeout(() => {
+          order.push(1)
+          resolve('/* rule */')
+        }, 10))],
+      ],
+      preflights: [
+        {
+          getCSS: () => new Promise(resolve => setTimeout(() => {
+            order.push(2)
+            resolve('/* preflight */')
+          }, 20)),
+        },
+      ],
+    })
+    uno.events.on('tokens', () => order.push(3))
+    await uno.generate('rule')
+    expect(order).eql([1, 3, 2])
+  })
+
+  test('preflight-generated-event', async () => {
+    const order: number[] = []
+    const uno = createGenerator({
+      rules: [
+        [/^rule$/, () => new Promise(resolve => setTimeout(() => {
+          order.push(2)
+          resolve('/* rule */')
+        }, 20))],
+      ],
+      preflights: [
+        {
+          getCSS: () => new Promise(resolve => setTimeout(() => {
+            order.push(1)
+            resolve('/* preflight */')
+          }, 10)),
+        },
+      ],
+    })
+    uno.events.on('preflights', () => order.push(3))
+    await uno.generate('rule')
+    expect(order).eql([1, 3, 2])
+  })
+
+  test('preflight-event-fires-without-preflight', async () => {
+    const order: number[] = []
+    const uno = createGenerator({
+      rules: [
+        [/^rule$/, () => new Promise(resolve => setTimeout(() => {
+          order.push(10)
+          resolve('/* rule */')
+        }, 10))],
+      ],
+    })
+    uno.events.on('preflights', () => order.push(order.length))
+
+    await uno.generate('rule', { preflights: false })
+    expect(order).eql([0, 10])
+
+    await uno.generate('rule', { preflights: true })
+    expect(order).eql([0, 10, 2])
+  })
+})


### PR DESCRIPTION
Add events after each of tokens and preflights are generated. This should help usecases like #1617.

I'm unsure what data should be passed to the event. As for now, tokens & preflights event gets what each of them would normally produce, except in a cloned set to prevent modification.
