### PR TITLE
feat(core): generator extended events

### DIFF
--- a/test/generate-async.test.ts
+++ b/test/generate-async.test.ts
@@ -46,3 +46,113 @@ describe('generate-async', () => {
     expect(order).eql([1, 2])
   })
 })
+
+describe('firing-events', () => {
+  test('config-event', async () => {
+    const order: number[] = []
+    const uno = createGenerator()
+
+    uno.events.on('config', () => order.push(order.length))
+    expect(order).eql([])
+
+    uno.setConfig({})
+    expect(order).eql([0])
+  })
+
+  test('extracted-event', async () => {
+    const order: number[] = []
+    const uno = createGenerator({
+      rules: [
+        [/^rule$/, () => '/* rule */'],
+      ],
+    })
+    uno.events.on('extracted', () => order.push(order.length))
+
+    await uno.generate('rule')
+    expect(order).eql([0])
+
+    await uno.generate('rule')
+    expect(order).eql([0, 1])
+  })
+
+  test('tokens-generated-event', async () => {
+    const order: number[] = []
+    const uno = createGenerator({
+      rules: [
+        [/^rule$/, () => new Promise(resolve => setTimeout(() => {
+          order.push(1)
+          resolve('/* rule */')
+        }, 10))],
+      ],
+      preflights: [
+        {
+          getCSS: () => new Promise(resolve => setTimeout(() => {
+            order.push(2)
+            resolve('/* preflight */')
+          }, 20)),
+        },
+      ],
+    })
+    uno.events.on('tokens', () => order.push(3))
+    await uno.generate('rule')
+    expect(order).eql([1, 3, 2])
+  })
+
+  test('preflight-generated-event', async () => {
+    const order: number[] = []
+    const uno = createGenerator({
+      rules: [
+        [/^rule$/, () => new Promise(resolve => setTimeout(() => {
+          order.push(2)
+          resolve('/* rule */')
+        }, 20))],
+      ],
+      preflights: [
+        {
+          getCSS: () => new Promise(resolve => setTimeout(() => {
+            order.push(1)
+            resolve('/* preflight */')
+          }, 10)),
+        },
+      ],
+    })
+    uno.events.on('preflights', () => order.push(3))
+    await uno.generate('rule')
+    expect(order).eql([1, 3, 2])
+  })
+
+  test('preflight-event-fires-without-preflight', async () => {
+    const order: number[] = []
+    const uno = createGenerator({
+      rules: [
+        [/^rule$/, () => new Promise(resolve => setTimeout(() => {
+          order.push(10)
+          resolve('/* rule */')
+        }, 10))],
+      ],
+    })
+    uno.events.on('preflights', () => order.push(order.length))
+
+    await uno.generate('rule', { preflights: false })
+    expect(order).eql([0, 10])
+
+    await uno.generate('rule', { preflights: true })
+    expect(order).eql([0, 10, 2])
+  })
+
+  test('generated-event', async () => {
+    const order: number[] = []
+    const uno = createGenerator({
+      rules: [
+        [/^rule$/, () => '/* rule */'],
+      ],
+    })
+    uno.events.on('generated', () => order.push(order.length))
+
+    await uno.generate('rule')
+    expect(order).eql([0])
+
+    await uno.generate('rule')
+    expect(order).eql([0, 1])
+  })
+})


### PR DESCRIPTION
Building on top of #1695, this PR adds two more events, extracted and generated.
If this is too much, please close this PR.

For the `extracted` event it sends the original token list hence can be modified before use, acting as global tokens preprocessor.
