### PR TITLE
feat(preset-mini)!: update @media variant

### DIFF
--- a/packages/preset-mini/src/_variants/media.ts
+++ b/packages/preset-mini/src/_variants/media.ts
@@ -1,21 +1,34 @@
 import type { Variant, VariantContext, VariantObject } from '@unocss/core'
 import type { Theme } from '../theme'
-import { variantParentMatcher } from '../utils'
+import { getComponent, handler as h, variantParentMatcher } from '../utils'
 
 export const variantPrint: Variant = variantParentMatcher('print', '@media print')
 
 export const variantCustomMedia: VariantObject = {
   name: 'media',
   match(matcher, { theme }: VariantContext<Theme>) {
-    const match = matcher.match(/^media-([_\d\w]+)[:-]/)
-    if (match) {
-      const media = theme.media?.[match[1]] ?? `(--${match[1]})`
-      return {
-        matcher: matcher.slice(match[0].length),
-        handle: (input, next) => next({
-          ...input,
-          parent: `${input.parent ? `${input.parent} $$ ` : ''}@media ${media}`,
-        }),
+    if (matcher.startsWith('media-')) {
+      const matcherValue = matcher.substring(6)
+
+      const [match, rest] = getComponent(matcherValue, '[', ']', ':') ?? []
+      if (!(match && rest && rest !== ''))
+        return
+
+      let media = h.bracket(match) ?? ''
+      if (media === '') {
+        const themeValue = theme.media?.[match]
+        if (themeValue)
+          media = themeValue
+      }
+
+      if (media) {
+        return {
+          matcher: rest,
+          handle: (input, next) => next({
+            ...input,
+            parent: `${input.parent ? `${input.parent} $$ ` : ''}@media ${media}`,
+          }),
+        }
       }
     }
   },

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -905,7 +905,7 @@ div:hover .group-\\\\[div\\\\:hover\\\\]-\\\\[combinator\\\\:test-4\\\\]{combina
 .layer-utility\\\\:block{display:block;}
 }
 @media (--cssvar){
-.media-cssvar\\\\:block{display:block;}
+.media-\\\\[\\\\(--cssvar\\\\)\\\\]\\\\:block{display:block;}
 }
 @media (prefers-color-scheme: dark){
 .dark\\\\:text-xl{font-size:1.25rem;line-height:1.75rem;}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -915,7 +915,7 @@ export const presetMiniTargets: string[] = [
   'supports-[(display:_grid)]:block',
 
   // variants media
-  'media-cssvar:block',
+  'media-[(--cssvar)]:block',
 
   // variants prints
   'print:block',


### PR DESCRIPTION
With `getComponent` helper, `media-x` variant can more safely accept bracket value.

This PR remove the auto variable for the media-x value, instead opting for bracket to achieve similar functionality. Bracket value is now supported and theme lookup is unchanged.

This also aligns `media-x` syntax with `support-x` syntax