### PR TITLE
feat(preset-mini): add handler bracket types

### DIFF
--- a/packages/preset-mini/src/_utils/handlers/handlers.ts
+++ b/packages/preset-mini/src/_utils/handlers/handlers.ts
@@ -91,16 +91,21 @@ export function fraction(str: string) {
     return `${round(num * 100)}%`
 }
 
-const bracketTypeRe = /^\[(color|length|position):/i
-function bracketWithType(str: string, type?: string) {
+const bracketTypeRe = /^\[(color|length|position|raw|string):/i
+function bracketWithType(str: string, requiredType?: string) {
   if (str && str.startsWith('[') && str.endsWith(']')) {
     let base: string | undefined
+    let hintedType: string | undefined
 
     const match = str.match(bracketTypeRe)
-    if (!match)
+    if (!match) {
       base = str.slice(1, -1)
-    else if (type && match[1] === type)
+    }
+    else {
+      if (!requiredType)
+        hintedType = match[1]
       base = str.slice(match[0].length, -1)
+    }
 
     if (!base)
       return
@@ -119,9 +124,19 @@ function bracketWithType(str: string, type?: string) {
     if (curly)
       return
 
+    switch (hintedType) {
+      case 'raw': return base
+
+      case 'string': return base
+        .replace(/(^|[^\\])_/g, '$1 ')
+        .replace(/\\_/g, '_')
+        .replace(/'/g, "\'")
+        .replace(/^(.+)$/, "'$1'")
+    }
+
     return base
       .replace(/(url\(.*?\))/g, v => v.replace(/_/g, '\\_'))
-      .replace(/([^\\])_/g, '$1 ')
+      .replace(/(^|[^\\])_/g, '$1 ')
       .replace(/\\_/g, '_')
       .replace(/(?:calc|clamp|max|min)\((.*)/g, (v) => {
         return v.replace(/(-?\d*\.?\d(?!\b-.+[,)](?![^+\-/*])\D)(?:%|[a-z]+)?|\))([+\-/*])/g, '$1 $2 ')

--- a/packages/preset-mini/src/_utils/handlers/handlers.ts
+++ b/packages/preset-mini/src/_utils/handlers/handlers.ts
@@ -130,8 +130,8 @@ function bracketWithType(str: string, requiredType?: string) {
       case 'string': return base
         .replace(/(^|[^\\])_/g, '$1 ')
         .replace(/\\_/g, '_')
-        .replace(/'/g, "\'")
-        .replace(/^(.+)$/, "'$1'")
+        .replace(/(['\\])/g, '\\$1')
+        .replace(/^(.+)$/, '\'$1\'')
     }
 
     return base

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -24,9 +24,24 @@ describe('value handler', () => {
   it('bracket underscore', () => {
     expect(h.bracket('[a_b]')).eql('a b')
     expect(h.bracket('[a\\_b]')).eql('a_b')
+    expect(h.bracket('[_b_only]')).eql(' b only')
+    expect(h.bracket('[\\_b]')).eql('_b')
     expect(h.bracket('[url(a_b)]')).eql('url(a_b)')
     expect(h.bracket('[url(a\\_b)]')).eql('url(a\\_b)')
     expect(h.bracket('[var(--A_B)]')).eql('var(--A B)')
     expect(h.bracket('[var(--A\\_B)]')).eql('var(--A_B)')
+  })
+
+  it('bracket raw-type', () => {
+    expect(h.bracket('[raw:a b]')).eql('a b')
+    expect(h.bracket('[raw:a_b]')).eql('a_b')
+    expect(h.bracket('[raw:a\\_b]')).eql('a\\_b')
+    expect(h.bracket('[raw:attr("data-label") ":" attr("data-value")]')).eql('attr("data-label") ":" attr("data-value")')
+  })
+
+  it('bracket string-type', () => {
+    expect(h.bracket('[string:a_b]')).eql("'a b'")
+    expect(h.bracket('[string:a\\_b]')).eql("'a_b'")
+    expect(h.bracket('[string:with-\'-and-"]')).eql("'with-\'-and-\"'")
   })
 })

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -40,8 +40,8 @@ describe('value handler', () => {
   })
 
   it('bracket string-type', () => {
-    expect(h.bracket('[string:a_b]')).eql("'a b'")
-    expect(h.bracket('[string:a\\_b]')).eql("'a_b'")
-    expect(h.bracket('[string:with-\'-and-"]')).eql("'with-\'-and-\"'")
+    expect(h.bracket('[string:a_b]')).eql('\'a b\'')
+    expect(h.bracket('[string:a\\_b]')).eql('\'a_b\'')
+    expect(h.bracket('[string:with-\\,-\'-and-"]')).eql('\'with-\\\\,-\\\'-and-"\'')
   })
 })


### PR DESCRIPTION
This PR adds handler types:
- `[raw:x]`: The value will be placed as is, without any alteration. This may not always be viable in extraction but could be useful in manual `generate()` method.
- `[string:x]`: only the underscore bracket logic will be applied and the value will then be single-quoted. `url` and `calc` replacements are not applied