### PR TITLE
docs: improve sentence

### DIFF
--- a/packages/preset-icons/README.md
+++ b/packages/preset-icons/README.md
@@ -80,7 +80,7 @@ By default, this preset will choose the rendering modes automatically for each i
 - `?bg` for `background-img` - renders the icon as a background image
 - `?mask` for `mask` - renders the icon as a mask image
 
-For example, `vscode-icons:file-type-light-db`, an icon with colors that will be rendered as a mask image and bypass it's colors. Use `vscode-icons:file-type-light-db?bg` to render it as a background image.
+For example, `vscode-icons:file-type-light-pnpm`, an icon with colors (the `svg` doesn't contain `currentColor`) that will be rendered as a background image. Use `vscode-icons:file-type-light-pnpm?mask` to render it as a mask image and bypass it's colors.
 
 ## Configuring collections and icons resolvers
 

--- a/packages/preset-icons/README.md
+++ b/packages/preset-icons/README.md
@@ -80,7 +80,7 @@ By default, this preset will choose the rendering modes automatically for each i
 - `?bg` for `background-img` - renders the icon as a background image
 - `?mask` for `mask` - renders the icon as a mask image
 
-For example, `vscode-icons:file-type-light-db`, an icon with colors that will be rendered as a background image. Use `vscode-icons:file-type-light-db?mask` to render it as a mask image and bypass it's colors.
+For example, `vscode-icons:file-type-light-db`, an icon with colors that will be rendered as a mask image and bypass it's colors. Use `vscode-icons:file-type-light-db?bg` to render it as a background image.
 
 ## Configuring collections and icons resolvers
 

--- a/packages/preset-icons/README.md
+++ b/packages/preset-icons/README.md
@@ -80,7 +80,7 @@ By default, this preset will choose the rendering modes automatically for each i
 - `?bg` for `background-img` - renders the icon as a background image
 - `?mask` for `mask` - renders the icon as a mask image
 
-For example, `vscode-icons:file-type-light-db`, an icon with colors that will be rendered as a background image. Use `vscode-icons:file-type-light-db?bg` to render it as a mask image and bypass it's colors.
+For example, `vscode-icons:file-type-light-db`, an icon with colors that will be rendered as a background image. Use `vscode-icons:file-type-light-db?mask` to render it as a mask image and bypass it's colors.
 
 ## Configuring collections and icons resolvers
 


### PR DESCRIPTION
typo in the param name