### PR TITLE
feat(transformer-variant-group): support underscore to expand

### DIFF
--- a/packages/core/src/utils/variantGroup.ts
+++ b/packages/core/src/utils/variantGroup.ts
@@ -16,7 +16,7 @@ export function expandVariantGroup(str: string | MagicString, seperators = ['-',
         if (!seperators.includes(sep))
           return from
         return body
-          .split(/\s/g)
+          .split(/[\s_]/g)
           .filter(Boolean)
           .map(i => i === '~' ? pre : i.replace(/^(!?)(.*)/, `$1${pre}${sep}$2`))
           .join(' ')

--- a/test/variant-group.test.ts
+++ b/test/variant-group.test.ts
@@ -47,4 +47,15 @@ describe('variant-group', () => {
       ]
     `)
   })
+
+  test('expand with underscore', () => {
+    const shortcut = 'children-[.a-drawer]-(bg-red_text-white)'
+    expect(expandVariantGroup(shortcut)).toEqual('children-[.a-drawer]-bg-red children-[.a-drawer]-text-white')
+    expect(expandVariantGroup(shortcut.trim()).split(/\s+/g)).toMatchInlineSnapshot(`
+      [
+        "children-[.a-drawer]-bg-red",
+        "children-[.a-drawer]-text-white",
+      ]
+    `)
+  })
 })


### PR DESCRIPTION
#1748 