### PR TITLE
perf(core): improve `applyVariants` method speed

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -338,8 +338,7 @@ export class UnoGenerator {
   private applyVariants(parsed: ParsedUtil, variantHandlers = parsed[4], raw = parsed[1]): UtilObject {
     const handler = [...variantHandlers]
       .sort((a, b) => (a.order || 0) - (b.order || 0))
-      .reverse()
-      .reduce(
+      .reduceRight(
         (previous, v) =>
           (input: VariantHandlerContext) => {
             const entries = v.body?.(input.entries) || input.entries

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -336,7 +336,7 @@ export class UnoGenerator {
   }
 
   private applyVariants(parsed: ParsedUtil, variantHandlers = parsed[4], raw = parsed[1]): UtilObject {
-    const handler = [...variantHandlers]
+    const handler = variantHandlers.slice()
       .sort((a, b) => (a.order || 0) - (b.order || 0))
       .reduceRight(
         (previous, v) =>


### PR DESCRIPTION
<details>
  <summary>thanks</summary>
First of all, I want to thank you for the brilliant framework. While I interested of how it works I started looking into sources. 
</details>

I found that `applyVariants` method could be improved a bit, but it helps to reach 7x speed supremacy over windicss:
* instead of chaining `reduce()` and `reduce()` methods we can simply write `reduceRight()`, as result will be the same (+ original array does not mutate)
* we may use `variantHandlers.slice()` instead of `[...variantHandlers]` as it 2x faster (according to jsbench.me).

I think there are a lot of other possibilities to improve the performance, but I think it's a nice start