### PR TITLE
fix(vscode): attributify value starts with number

### DIFF
--- a/packages/shared-common/src/index.ts
+++ b/packages/shared-common/src/index.ts
@@ -1,5 +1,5 @@
 import type { UnoGenerator } from '@unocss/core'
-import { e, isAttributifySelector, regexClassGroup } from '@unocss/core'
+import { isAttributifySelector, regexClassGroup } from '@unocss/core'
 import MagicString from 'magic-string'
 
 // https://github.com/dsblv/string-replace-async/blob/main/index.js
@@ -78,7 +78,7 @@ export function getMatchedPositions(code: string, matched: string[], hasVariantG
 
   // attributify values
   attributify.forEach(([, name, value]) => {
-    const regex = new RegExp(`(${e(name)}=)(['"])[^\\2]*?${e(value)}[^\\2]*?\\2`, 'g')
+    const regex = new RegExp(`(${name}=)(['"])[^\\2]*?${value}[^\\2]*?\\2`, 'g')
     Array.from(code.matchAll(regex))
       .forEach((match) => {
         const escaped = match[1]

--- a/packages/shared-common/src/index.ts
+++ b/packages/shared-common/src/index.ts
@@ -1,5 +1,5 @@
 import type { UnoGenerator } from '@unocss/core'
-import { isAttributifySelector, regexClassGroup } from '@unocss/core'
+import { escapeRegExp, isAttributifySelector, regexClassGroup } from '@unocss/core'
 import MagicString from 'magic-string'
 
 // https://github.com/dsblv/string-replace-async/blob/main/index.js
@@ -78,7 +78,7 @@ export function getMatchedPositions(code: string, matched: string[], hasVariantG
 
   // attributify values
   attributify.forEach(([, name, value]) => {
-    const regex = new RegExp(`(${name}=)(['"])[^\\2]*?${value}[^\\2]*?\\2`, 'g')
+    const regex = new RegExp(`(${escapeRegExp(name)}=)(['"])[^\\2]*?${escapeRegExp(value)}[^\\2]*?\\2`, 'g')
     Array.from(code.matchAll(regex))
       .forEach((match) => {
         const escaped = match[1]

--- a/test/pos.test.ts
+++ b/test/pos.test.ts
@@ -15,7 +15,7 @@ describe('matched-positions', async () => {
       ],
     })
 
-    expect(await match(uno, '<div border="b gray4"></div>'))
+    expect(await match(uno, '<div border="b gray4 2"></div>'))
       .toMatchInlineSnapshot(`
         [
           [
@@ -27,6 +27,11 @@ describe('matched-positions', async () => {
             15,
             20,
             "[border=\\"gray4\\"]",
+          ],
+          [
+            21,
+            22,
+            "[border=\\"2\\"]",
           ],
         ]
       `)

--- a/test/pos.test.ts
+++ b/test/pos.test.ts
@@ -15,7 +15,7 @@ describe('matched-positions', async () => {
       ],
     })
 
-    expect(await match(uno, '<div border="b gray4 2"></div>'))
+    expect(await match(uno, '<div border="b gray4 2 [&_span]:white"></div>'))
       .toMatchInlineSnapshot(`
         [
           [
@@ -32,6 +32,11 @@ describe('matched-positions', async () => {
             21,
             22,
             "[border=\\"2\\"]",
+          ],
+          [
+            23,
+            37,
+            "[border=\\"[&_span]:white\\"]",
           ],
         ]
       `)


### PR DESCRIPTION
The string to be tested here is the **source code** and does not need to be "escaped".