### PR TITLE
fix(nuxt2): support nuxt2

### DIFF
--- a/.tazerc.json
+++ b/.tazerc.json
@@ -10,6 +10,7 @@
     "unbuild"
   ],
   "packageMode": {
-    "vue": "minor"
+    "vue": "minor",
+    "nuxt": "minor"
   }
 }

--- a/examples/nuxt2-webpack/.npmrc
+++ b/examples/nuxt2-webpack/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/examples/nuxt2-webpack/nuxt.config.ts
+++ b/examples/nuxt2-webpack/nuxt.config.ts
@@ -1,0 +1,13 @@
+export default {
+  buildModules: [
+    '@unocss/nuxt',
+  ],
+  unocss: {
+    attributify: true,
+    icons: true,
+    components: false,
+    shortcuts: [
+      ['btn', 'px-4 py-1 rounded inline-block bg-teal-600 text-white cursor-pointer hover:bg-teal-700 disabled:cursor-default disabled:bg-gray-600 disabled:opacity-50'],
+    ],
+  },
+}

--- a/examples/nuxt2-webpack/package.json
+++ b/examples/nuxt2-webpack/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "start": "nuxt start"
+  },
+  "devDependencies": {
+    "@iconify-json/carbon": "^1.1.9",
+    "@unocss/core": "link:../../packages/core",
+    "@unocss/nuxt": "link:../../packages/nuxt",
+    "@unocss/reset": "link:../../packages/reset",
+    "nuxt": "latest",
+    "unocss": "link:../../packages/unocss"
+  }
+}

--- a/examples/nuxt2-webpack/package.json
+++ b/examples/nuxt2-webpack/package.json
@@ -10,7 +10,7 @@
     "@unocss/core": "link:../../packages/core",
     "@unocss/nuxt": "link:../../packages/nuxt",
     "@unocss/reset": "link:../../packages/reset",
-    "nuxt": "latest",
+    "nuxt": "^2.15.8",
     "unocss": "link:../../packages/unocss"
   }
 }

--- a/examples/nuxt2-webpack/pages/index.vue
+++ b/examples/nuxt2-webpack/pages/index.vue
@@ -1,0 +1,15 @@
+<template>
+  <main class="px-12 py-20 text-center">
+    <span text="blue 5xl hover:red" cursor="default">Hello Nuxt 2</span>
+    <br>
+    <div i-carbon-car text-4xl inline-block />
+    <br>
+    <button btn>
+      Button
+    </button>
+  </main>
+</template>
+
+<style>
+@import '@unocss/reset/tailwind.css';
+</style>

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'url'
 import { addComponentsDir, addPluginTemplate, defineNuxtModule, extendWebpackConfig } from '@nuxt/kit'
 import WebpackPlugin from '@unocss/webpack'
 import VitePlugin from '@unocss/vite'
+import type { NuxtPlugin } from '@nuxt/schema'
 import { resolveOptions } from './options'
 import type { UnocssNuxtOptions } from './types'
 
@@ -37,7 +38,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
         getContents: () => {
           const lines = [
             'import \'uno.css\'',
-            'export default defineNuxtPlugin(() => {})',
+            'export default () => {}',
           ]
           if (options.preflight)
             lines.unshift('import \'@unocss/reset/tailwind.css\'')
@@ -56,6 +57,14 @@ export default defineNuxtModule<UnocssNuxtOptions>({
     nuxt.hook('vite:extend', ({ config }) => {
       config.plugins = config.plugins || []
       config.plugins.unshift(...VitePlugin({}, options))
+    })
+
+    nuxt.hook('config', (config) => {
+      const plugin: NuxtPlugin = { src: 'unocss.mjs', mode: 'client' }
+      if (config.plugins)
+        config.plugins.push(plugin)
+      else
+        config.plugins = [plugin]
     })
 
     extendWebpackConfig((config) => {


### PR DESCRIPTION
fix: #1832

> autoimport unocss will generate the code 
>
> ```ts
> import 'uno.css'
> export default defineNuxtPlugin(() => {})
> ```
>
> but `defineNuxtPlugin` is not autoimport in pure nuxt2 