### PR TITLE
feat: improving some types

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,7 +3,7 @@ import { clone, isStaticRule, mergeDeep, normalizeVariant, toArray, uniq } from 
 import { extractorSplit } from './extractors'
 import { DEFAULT_LAYERS } from './constants'
 
-export function resolveShortcuts(shortcuts: UserShortcuts): Shortcut[] {
+export function resolveShortcuts(shortcuts: UserShortcuts<any>): Shortcut<any>[] {
   return toArray(shortcuts).flatMap((s) => {
     if (Array.isArray(s))
       return [s]
@@ -11,7 +11,7 @@ export function resolveShortcuts(shortcuts: UserShortcuts): Shortcut[] {
   })
 }
 
-export function resolvePreset(preset: Preset): Preset {
+export function resolvePreset(preset: Preset<any>): Preset<any> {
   const shortcuts = preset.shortcuts
     ? resolveShortcuts(preset.shortcuts)
     : undefined
@@ -34,11 +34,11 @@ export function resolvePreset(preset: Preset): Preset {
   return preset
 }
 
-export function resolveConfig(
-  userConfig: UserConfig = {},
-  defaults: UserConfigDefaults = {},
-): ResolvedConfig {
-  const config = Object.assign({}, defaults, userConfig) as UserConfigDefaults
+export function resolveConfig<Theme extends {} = {}>(
+  userConfig: UserConfig<Theme> = {},
+  defaults: UserConfigDefaults<Theme> = {},
+): ResolvedConfig<Theme> {
+  const config = Object.assign({}, defaults, userConfig) as UserConfigDefaults<Theme>
   const rawPresets = (config.presets || []).flatMap(toArray).map(resolvePreset)
 
   const sortedPresets = [
@@ -49,7 +49,7 @@ export function resolveConfig(
 
   const layers = Object.assign(DEFAULT_LAYERS, ...rawPresets.map(i => i.layers), userConfig.layers)
 
-  function mergePresets<T extends 'rules' | 'variants' | 'extractors' | 'shortcuts' | 'preflights' | 'preprocess' | 'postprocess' | 'extendTheme' | 'safelist'>(key: T): Required<UserConfig>[T] {
+  function mergePresets<T extends 'rules' | 'variants' | 'extractors' | 'shortcuts' | 'preflights' | 'preprocess' | 'postprocess' | 'extendTheme' | 'safelist'>(key: T): Required<UserConfig<Theme>>[T] {
     return uniq([
       ...sortedPresets.flatMap(p => toArray(p[key] || []) as any[]),
       ...toArray(config[key] || []) as any[],
@@ -62,7 +62,7 @@ export function resolveConfig(
   extractors.sort((a, b) => (a.order || 0) - (b.order || 0))
 
   const rules = mergePresets('rules')
-  const rulesStaticMap: ResolvedConfig['rulesStaticMap'] = {}
+  const rulesStaticMap: ResolvedConfig<Theme>['rulesStaticMap'] = {}
 
   const rulesSize = rules.length
 
@@ -78,7 +78,7 @@ export function resolveConfig(
       return [i, ...rule]
     })
     .filter(Boolean)
-    .reverse() as ResolvedConfig['rulesDynamic']
+    .reverse() as ResolvedConfig<Theme>['rulesDynamic']
 
   const theme = clone([
     ...sortedPresets.map(p => p.theme || {}),

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,7 +3,7 @@ import { clone, isStaticRule, mergeDeep, normalizeVariant, toArray, uniq } from 
 import { extractorSplit } from './extractors'
 import { DEFAULT_LAYERS } from './constants'
 
-export function resolveShortcuts(shortcuts: UserShortcuts<any>): Shortcut<any>[] {
+export function resolveShortcuts<Theme extends {} = {}>(shortcuts: UserShortcuts<Theme>): Shortcut<Theme>[] {
   return toArray(shortcuts).flatMap((s) => {
     if (Array.isArray(s))
       return [s]
@@ -11,14 +11,14 @@ export function resolveShortcuts(shortcuts: UserShortcuts<any>): Shortcut<any>[]
   })
 }
 
-export function resolvePreset(preset: Preset<any>): Preset<any> {
+export function resolvePreset<Theme extends {} = {}>(preset: Preset<Theme>): Preset<Theme> {
   const shortcuts = preset.shortcuts
     ? resolveShortcuts(preset.shortcuts)
     : undefined
   preset.shortcuts = shortcuts as any
 
   if (preset.prefix || preset.layer) {
-    const apply = (i: Rule | Shortcut) => {
+    const apply = (i: Rule<Theme> | Shortcut) => {
       if (!i[2])
         i[2] = {}
       const meta = i[2]
@@ -80,10 +80,10 @@ export function resolveConfig<Theme extends {} = {}>(
     .filter(Boolean)
     .reverse() as ResolvedConfig<Theme>['rulesDynamic']
 
-  const theme = clone([
+  const theme: Theme = clone([
     ...sortedPresets.map(p => p.theme || {}),
     config.theme || {},
-  ].reduce((a, p) => mergeDeep(a, p), {}))
+  ].reduce<Theme>((a, p) => mergeDeep(a, p), {} as Theme))
 
   ;(mergePresets('extendTheme') as ThemeExtender<any>[]).forEach(extendTheme => extendTheme(theme))
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,7 +64,7 @@ export interface RuleContext<Theme extends {} = {}> {
   /**
    * UnoCSS generator instance
    */
-  generator: UnoGenerator
+  generator: UnoGenerator<Theme>
   /**
    * The theme object
    */
@@ -76,7 +76,7 @@ export interface RuleContext<Theme extends {} = {}> {
   /**
    * The result of variant matching.
    */
-  variantMatch: VariantMatchedResult
+  variantMatch: VariantMatchedResult<Theme>
   /**
    * Construct a custom CSS rule.
    * Variants and selector escaping will be handled automatically.
@@ -85,15 +85,15 @@ export interface RuleContext<Theme extends {} = {}> {
   /**
    * Available only when `details` option is enabled.
    */
-  rules?: Rule[]
+  rules?: Rule<Theme>[]
   /**
    * Available only when `details` option is enabled.
    */
-  shortcuts?: Shortcut[]
+  shortcuts?: Shortcut<Theme>[]
   /**
    * Available only when `details` option is enabled.
    */
-  variants?: Variant[]
+  variants?: Variant<Theme>[]
 }
 
 export interface VariantContext<Theme extends {} = {}> {
@@ -104,7 +104,7 @@ export interface VariantContext<Theme extends {} = {}> {
   /**
    * UnoCSS generator instance
    */
-  generator: UnoGenerator
+  generator: UnoGenerator<Theme>
   /**
    * The theme object
    */
@@ -121,7 +121,7 @@ export interface PreflightContext<Theme extends {} = {}> {
   /**
    * UnoCSS generator instance
    */
-  generator: UnoGenerator
+  generator: UnoGenerator<Theme>
   /**
    * The theme object
    */
@@ -616,18 +616,18 @@ export interface PluginOptions {
 export interface UserConfig<Theme extends {} = {}> extends ConfigBase<Theme>, UserOnlyOptions<Theme>, GeneratorOptions, PluginOptions, CliOptions {}
 export interface UserConfigDefaults<Theme extends {} = {}> extends ConfigBase<Theme>, UserOnlyOptions<Theme> {}
 
-export interface ResolvedConfig extends Omit<
-RequiredByKey<UserConfig, 'mergeSelectors' | 'theme' | 'rules' | 'variants' | 'layers' | 'extractors' | 'blocklist' | 'safelist' | 'preflights' | 'sortLayers'>,
+export interface ResolvedConfig<Theme extends {} = {}> extends Omit<
+RequiredByKey<UserConfig<Theme>, 'mergeSelectors' | 'theme' | 'rules' | 'variants' | 'layers' | 'extractors' | 'blocklist' | 'safelist' | 'preflights' | 'sortLayers'>,
 'rules' | 'shortcuts' | 'autocomplete'
 > {
-  presets: Preset[]
-  shortcuts: Shortcut[]
-  variants: VariantObject[]
+  presets: Preset<Theme>[]
+  shortcuts: Shortcut<Theme>[]
+  variants: VariantObject<Theme>[]
   preprocess: Preprocessor[]
   postprocess: Postprocessor[]
   rulesSize: number
-  rulesDynamic: [number, ...DynamicRule][]
-  rulesStaticMap: Record<string, [number, CSSObject | CSSEntries, RuleMeta | undefined, Rule] | undefined>
+  rulesDynamic: [number, ...DynamicRule<Theme>][]
+  rulesStaticMap: Record<string, [number, CSSObject | CSSEntries, RuleMeta | undefined, Rule<Theme>] | undefined>
   autocomplete: {
     templates: (AutoCompleteFunction | AutoCompleteTemplate)[]
     extractors: AutoCompleteExtractor[]
@@ -642,11 +642,11 @@ export interface GenerateResult {
   matched: Set<string>
 }
 
-export type VariantMatchedResult = readonly [
+export type VariantMatchedResult<Theme extends {} = {}> = readonly [
   raw: string,
   current: string,
   variantHandlers: VariantHandler[],
-  variants: Set<Variant>,
+  variants: Set<Variant<Theme>>,
 ]
 
 export type ParsedUtil = readonly [
@@ -663,13 +663,13 @@ export type RawUtil = readonly [
   meta: RuleMeta | undefined,
 ]
 
-export type StringifiedUtil = readonly [
+export type StringifiedUtil<Theme extends {} = {}> = readonly [
   index: number,
   selector: string | undefined,
   body: string,
   parent: string | undefined,
   meta: RuleMeta | undefined,
-  context: RuleContext | undefined,
+  context: RuleContext<Theme> | undefined,
   noMerge: boolean | undefined,
 ]
 

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -13,7 +13,7 @@ export function isValidSelector(selector = ''): selector is string {
   return validateFilterRE.test(selector)
 }
 
-export function normalizeVariant(variant: Variant): VariantObject {
+export function normalizeVariant(variant: Variant<any>): VariantObject<any> {
   return typeof variant === 'function'
     ? { match: variant }
     : variant

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -98,10 +98,10 @@ export function clone<T>(val: T): T {
   return val
 }
 
-export function isStaticRule(rule: Rule): rule is StaticRule {
+export function isStaticRule(rule: Rule<any>): rule is StaticRule {
   return isString(rule[0])
 }
 
-export function isStaticShortcut(sc: Shortcut): sc is StaticShortcut {
+export function isStaticShortcut(sc: Shortcut<any>): sc is StaticShortcut {
   return isString(sc[0])
 }

--- a/packages/preset-mini/src/_theme/types.ts
+++ b/packages/preset-mini/src/_theme/types.ts
@@ -8,7 +8,7 @@ export interface ThemeAnimation {
   counts?: Record<string, string | number>
 }
 
-interface Colors {
+export interface Colors {
   [key: string]: Colors | string
 }
 

--- a/packages/preset-mini/src/_theme/types.ts
+++ b/packages/preset-mini/src/_theme/types.ts
@@ -8,6 +8,10 @@ export interface ThemeAnimation {
   counts?: Record<string, string | number>
 }
 
+interface Colors {
+  [key: string]: Colors | string
+}
+
 export interface Theme {
   width?: Record<string, string>
   height?: Record<string, string>
@@ -24,9 +28,9 @@ export interface Theme {
   borderRadius?: Record<string, string>
   breakpoints?: Record<string, string>
   verticalBreakpoints?: Record<string, string>
-  colors?: Record<string, string | Record<string, string>>
+  colors?: Colors
   fontFamily?: Record<string, string>
-  fontSize?: Record<string, [string, string]>
+  fontSize?: Record<string, string | [string, string]>
   lineHeight?: Record<string, string>
   letterSpacing?: Record<string, string>
   wordSpacing?: Record<string, string>

--- a/packages/preset-typography/src/index.ts
+++ b/packages/preset-typography/src/index.ts
@@ -1,4 +1,4 @@
-import type { CSSObject, Preset } from '@unocss/core'
+import type { CSSObject, Preset, RuleContext } from '@unocss/core'
 import type { Theme } from '@unocss/preset-mini'
 import { toEscapedSelector } from '@unocss/core'
 import { getPreflights } from './preflights'
@@ -49,7 +49,7 @@ export interface TypographyOptions {
  * @returns typography preset
  * @public
  */
-export function presetTypography(options?: TypographyOptions): Preset<Theme> {
+export function presetTypography(options?: TypographyOptions): Preset {
   if (options?.className) {
     console.warn('[unocss:preset-typography] "className" is deprecated. '
     + 'Use "selectorName" instead.')
@@ -78,7 +78,7 @@ export function presetTypography(options?: TypographyOptions): Preset<Theme> {
       ],
       [
         colorsRE,
-        ([, color], { theme }) => {
+        ([, color], { theme }: RuleContext<Theme>) => {
           const baseColor = theme.colors?.[color] as Record<string, string> | string
           if (baseColor == null)
             return

--- a/packages/preset-typography/src/index.ts
+++ b/packages/preset-typography/src/index.ts
@@ -1,4 +1,4 @@
-import type { CSSObject, Preset, RuleContext } from '@unocss/core'
+import type { CSSObject, Preset } from '@unocss/core'
 import type { Theme } from '@unocss/preset-mini'
 import { toEscapedSelector } from '@unocss/core'
 import { getPreflights } from './preflights'
@@ -49,7 +49,7 @@ export interface TypographyOptions {
  * @returns typography preset
  * @public
  */
-export function presetTypography(options?: TypographyOptions): Preset {
+export function presetTypography(options?: TypographyOptions): Preset<Theme> {
   if (options?.className) {
     console.warn('[unocss:preset-typography] "className" is deprecated. '
     + 'Use "selectorName" instead.')
@@ -78,8 +78,8 @@ export function presetTypography(options?: TypographyOptions): Preset {
       ],
       [
         colorsRE,
-        ([, color], { theme }: RuleContext<Theme>) => {
-          const baseColor = theme.colors?.[color]
+        ([, color], { theme }) => {
+          const baseColor = theme.colors?.[color] as Record<string, string> | string
           if (baseColor == null)
             return
 


### PR DESCRIPTION
### Common improvements
1. Make `createGenerator` support generic. (will use for test

### Theme improvements

> The code is supported, but the type is not

1. The `colors`  support `nested`.
2. The `fontSize` support `string | [string, string]`.


