### PR TITLE
ci: upgrade node to 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18
           cache: pnpm
 
       - name: Setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
https://github.com/nodejs/release#release-schedule

Node.js 18 has been LTS now, and 16 is Maintenance.