### PR TITLE
feat(astro): introduce the `injectExtra` option

### DIFF
--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -16,6 +16,12 @@ export interface AstroIntegrationConfig<Theme extends {} = {}> extends VitePlugi
    * @default true
    */
   injectEntry?: boolean | string
+
+  /**
+   * Inject extra imports for every astro page
+   * @default []
+   */
+  injectExtra?: string[]
 }
 
 export default function UnoCSSAstroIntegration<Theme extends {}>(
@@ -25,6 +31,7 @@ export default function UnoCSSAstroIntegration<Theme extends {}>(
   const {
     injectEntry = true,
     injectReset: includeReset = true,
+    injectExtra = [],
   } = options
 
   return {
@@ -46,6 +53,8 @@ export default function UnoCSSAstroIntegration<Theme extends {}>(
             ? injectEntry
             : 'import "uno.css"')
         }
+        if (injectExtra.length > 0)
+          injects.push(...injectExtra)
         if (injects?.length)
           injectScript('page-ssr', injects.join('\n'))
       },

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -8,22 +8,14 @@ export interface AstroIntegrationConfig<Theme extends {} = {}> extends VitePlugi
    * Include reset styles
    * When passing `true`, `@unocss/reset/tailwind.css` will be used
    * @default true
-   * @deprecated use `injects` instead
    */
   injectReset?: string | boolean
 
   /**
    * Inject UnoCSS entry import for every astro page
    * @default true
-   * @deprecated use `injects` instead
    */
   injectEntry?: boolean | string
-
-  /**
-   * Inject for every astro page, e.g., `['import "uno.css"']`
-   * @default []
-   */
-  injects?: ReadonlyArray<string>
 }
 
 export default function UnoCSSAstroIntegration<Theme extends {}>(
@@ -33,7 +25,6 @@ export default function UnoCSSAstroIntegration<Theme extends {}>(
   const {
     injectEntry = true,
     injectReset: includeReset = true,
-    injects: rawInjects = [],
   } = options
 
   return {
@@ -55,8 +46,6 @@ export default function UnoCSSAstroIntegration<Theme extends {}>(
             ? injectEntry
             : 'import "uno.css"')
         }
-        if (rawInjects.length !== 0)
-          injects.push(...rawInjects)
         if (injects?.length)
           injectScript('page-ssr', injects.join('\n'))
       },

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -8,14 +8,22 @@ export interface AstroIntegrationConfig<Theme extends {} = {}> extends VitePlugi
    * Include reset styles
    * When passing `true`, `@unocss/reset/tailwind.css` will be used
    * @default true
+   * @deprecated use `injects` instead
    */
   injectReset?: string | boolean
 
   /**
    * Inject UnoCSS entry import for every astro page
    * @default true
+   * @deprecated use `injects` instead
    */
   injectEntry?: boolean | string
+
+  /**
+   * Inject for every astro page, e.g., `['import "uno.css"']`
+   * @default []
+   */
+  injects?: ReadonlyArray<string>
 }
 
 export default function UnoCSSAstroIntegration<Theme extends {}>(
@@ -25,6 +33,7 @@ export default function UnoCSSAstroIntegration<Theme extends {}>(
   const {
     injectEntry = true,
     injectReset: includeReset = true,
+    injects: rawInjects = [],
   } = options
 
   return {
@@ -46,6 +55,8 @@ export default function UnoCSSAstroIntegration<Theme extends {}>(
             ? injectEntry
             : 'import "uno.css"')
         }
+        if (rawInjects.length !== 0)
+          injects.push(...rawInjects)
         if (injects?.length)
           injectScript('page-ssr', injects.join('\n'))
       },


### PR DESCRIPTION
This commit also marks the existing `injectReset` & `injectEntry` as deprecated. Users with those options set should have no breaking changes on their existing code, but only receive a warning via the linting tool.

close #1877