### PR TITLE
fix(transformer-directives): enforce `pre` by default

### DIFF
--- a/packages/transformer-directives/src/index.ts
+++ b/packages/transformer-directives/src/index.ts
@@ -37,7 +37,7 @@ export interface TransformerDirectivesContext {
 export default function transformerDirectives(options: TransformerDirectivesOptions = {}): SourceCodeTransformer {
   return {
     name: 'css-directive',
-    enforce: options?.enforce,
+    enforce: options?.enforce || 'pre',
     idFilter: id => !!id.match(cssIdRE),
     transform: (code, id, ctx) => {
       return transformDirectives(code, ctx.uno, options, id)


### PR DESCRIPTION
Fixes #1849

In production builds Nuxt's cssnano plugin applied before unocss plugin. Its mergeRules optimization causes problems with at-rules. My previous solution was disabling `mergeRules` by adding the following lines to @unocss/nuxt module. But that's not ideal since it affects minifying:

```ts
    if (nuxt.options.postcss.plugins.cssnano) {
      const preset = nuxt.options.postcss.plugins.cssnano.preset
      nuxt.options.postcss.plugins.cssnano = {
        preset: [preset?.[0] || 'default', Object.assign(
          preset?.[1] || {}, { mergeRules: false },
        )],
      }
    }
```