### PR TITLE
fix(transformer-directives,nuxt): revert `enforce: 'pre'`, disable `mergeRules`

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,6 @@
 import { dirname, resolve } from 'path'
 import fs from 'fs'
-import type { UserConfig } from '@unocss/core'
+import type { UserConfig, UserConfigDefaults } from '@unocss/core'
 import type { LoadConfigResult, LoadConfigSource } from 'unconfig'
 import { createConfigLoader as createLoader } from 'unconfig'
 
@@ -10,10 +10,11 @@ export async function loadConfig<U extends UserConfig>(
   cwd = process.cwd(),
   configOrPath: string | U = cwd,
   extraConfigSources: LoadConfigSource[] = [],
+  defaults: UserConfigDefaults = {},
 ): Promise<LoadConfigResult<U>> {
   let inlineConfig = {} as U
   if (typeof configOrPath !== 'string') {
-    inlineConfig = configOrPath
+    inlineConfig = Object.assign({}, defaults, configOrPath)
     if (inlineConfig.configFile === false) {
       return {
         config: inlineConfig as U,

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.0.0",
+    "@unocss/config": "workspace:*",
     "@unocss/core": "workspace:*",
     "@unocss/preset-attributify": "workspace:*",
     "@unocss/preset-icons": "workspace:*",

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -58,11 +58,11 @@ export default defineNuxtModule<UnocssNuxtOptions>({
       })
     }
 
-    const { config } = await loadConfig<UserConfig>(process.cwd(), {}, [], options)
+    const { config: unoConfig } = await loadConfig<UserConfig>(process.cwd(), {}, [], options)
 
     if (
       nuxt.options.postcss.plugins.cssnano
-      && config.transformers?.some(t => t.name === 'css-directive' && t.enforce !== 'pre')
+      && unoConfig.transformers?.some(t => t.name === 'css-directive' && t.enforce !== 'pre')
     ) {
       const preset = nuxt.options.postcss.plugins.cssnano.preset
       nuxt.options.postcss.plugins.cssnano = {
@@ -74,7 +74,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
 
     nuxt.hook('vite:extend', ({ config }) => {
       config.plugins = config.plugins || []
-      config.plugins.unshift(...VitePlugin(config))
+      config.plugins.unshift(...VitePlugin(unoConfig))
     })
 
     // Nuxt 2
@@ -90,7 +90,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
 
     extendWebpackConfig((config) => {
       config.plugins = config.plugins || []
-      config.plugins.unshift(WebpackPlugin(config))
+      config.plugins.unshift(WebpackPlugin(unoConfig))
     })
   },
 })

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -4,6 +4,8 @@ import { addComponentsDir, addPluginTemplate, defineNuxtModule, extendWebpackCon
 import WebpackPlugin from '@unocss/webpack'
 import VitePlugin from '@unocss/vite'
 import type { NuxtPlugin } from '@nuxt/schema'
+import { loadConfig } from '@unocss/config'
+import type { UserConfig } from '@unocss/core'
 import { resolveOptions } from './options'
 import type { UnocssNuxtOptions } from './types'
 
@@ -28,7 +30,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
     icons: false,
     wind: false,
   },
-  setup(options, nuxt) {
+  async setup(options, nuxt) {
     // preset shortcuts
     resolveOptions(options)
 
@@ -56,9 +58,23 @@ export default defineNuxtModule<UnocssNuxtOptions>({
       })
     }
 
+    const { config } = await loadConfig<UserConfig>(process.cwd(), {}, [], options)
+
+    if (
+      nuxt.options.postcss.plugins.cssnano
+      && config.transformers?.some(t => t.name === 'css-directive' && t.enforce !== 'pre')
+    ) {
+      const preset = nuxt.options.postcss.plugins.cssnano.preset
+      nuxt.options.postcss.plugins.cssnano = {
+        preset: [preset?.[0] || 'default', Object.assign(
+          preset?.[1] || {}, { mergeRules: false },
+        )],
+      }
+    }
+
     nuxt.hook('vite:extend', ({ config }) => {
       config.plugins = config.plugins || []
-      config.plugins.unshift(...VitePlugin({}, options))
+      config.plugins.unshift(...VitePlugin(config))
     })
 
     // Nuxt 2
@@ -74,7 +90,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
 
     extendWebpackConfig((config) => {
       config.plugins = config.plugins || []
-      config.plugins.unshift(WebpackPlugin({}, options))
+      config.plugins.unshift(WebpackPlugin(config))
     })
   },
 })

--- a/packages/shared-integration/src/context.ts
+++ b/packages/shared-integration/src/context.ts
@@ -28,7 +28,7 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
   let ready = reloadConfig()
 
   async function reloadConfig() {
-    const result = await loadConfig(root, configOrPath, extraConfigSources)
+    const result = await loadConfig(root, configOrPath, extraConfigSources, defaults)
     resolveConfigResult(result)
 
     rawConfig = result.config

--- a/packages/transformer-directives/src/index.ts
+++ b/packages/transformer-directives/src/index.ts
@@ -37,7 +37,7 @@ export interface TransformerDirectivesContext {
 export default function transformerDirectives(options: TransformerDirectivesOptions = {}): SourceCodeTransformer {
   return {
     name: 'css-directive',
-    enforce: options?.enforce || 'pre',
+    enforce: options?.enforce,
     idFilter: id => !!id.match(cssIdRE),
     transform: (code, id, ctx) => {
       return transformDirectives(code, ctx.uno, options, id)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,7 @@ importers:
     specifiers:
       '@nuxt/kit': ^3.0.0
       '@nuxt/schema': ^3.0.0
+      '@unocss/config': workspace:*
       '@unocss/core': workspace:*
       '@unocss/preset-attributify': workspace:*
       '@unocss/preset-icons': workspace:*
@@ -385,6 +386,7 @@ importers:
       unocss: workspace:*
     dependencies:
       '@nuxt/kit': 3.0.0
+      '@unocss/config': link:../config
       '@unocss/core': link:../core
       '@unocss/preset-attributify': link:../preset-attributify
       '@unocss/preset-icons': link:../preset-icons


### PR DESCRIPTION
Reverts #1923
Fixes #1929
Fixes #1849 by disabling cssnano's mergeRules optimization if transformer-directive is detected in nuxt module. esbuild already merges the rules

Also fixes an issue where getConfig always returns an empty object. I discovered it while debugging the issue.
https://github.com/unocss/unocss/blob/9c89d93daaf7085b9060060557259f314c23663d/packages/shared-integration/src/context.ts#L92-L95
