### PR TITLE
fix(nuxt): apply defaults correctly

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -14,7 +14,7 @@ export async function loadConfig<U extends UserConfig>(
 ): Promise<LoadConfigResult<U>> {
   let inlineConfig = {} as U
   if (typeof configOrPath !== 'string') {
-    inlineConfig = Object.assign({}, defaults, configOrPath)
+    inlineConfig = configOrPath
     if (inlineConfig.configFile === false) {
       return {
         config: inlineConfig as U,
@@ -56,7 +56,7 @@ export async function loadConfig<U extends UserConfig>(
   })
 
   const result = await loader.load()
-  result.config = result.config || inlineConfig
+  result.config = Object.assign(defaults, result.config || inlineConfig)
   if (result.config.configDeps) {
     result.sources = [
       ...result.sources,

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -74,7 +74,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
 
     nuxt.hook('vite:extend', ({ config }) => {
       config.plugins = config.plugins || []
-      config.plugins.unshift(...VitePlugin(unoConfig))
+      config.plugins.unshift(...VitePlugin({}, unoConfig))
     })
 
     // Nuxt 2
@@ -90,7 +90,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
 
     extendWebpackConfig((config) => {
       config.plugins = config.plugins || []
-      config.plugins.unshift(WebpackPlugin(unoConfig))
+      config.plugins.unshift(WebpackPlugin({}, unoConfig))
     })
   },
 })


### PR DESCRIPTION
A regression caused by #1930

Fixes duplicate warning in nuxt module when using external config file.

![image](https://user-images.githubusercontent.com/19991745/204686804-665a930e-50ea-48e2-b973-6eb26f87fcd7.png)
