### PR TITLE
feat: add php and phtml to the default includes (#1939)

### DIFF
--- a/packages/shared-integration/src/defaults.ts
+++ b/packages/shared-integration/src/defaults.ts
@@ -1,4 +1,4 @@
 import { cssIdRE } from '@unocss/core'
 
 export const defaultExclude = [cssIdRE]
-export const defaultInclude = [/\.(vue|svelte|[jt]sx|mdx?|astro|elm|html)($|\?)/]
+export const defaultInclude = [/\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/]


### PR DESCRIPTION
transformer-compile-class does not works with classes inside *.phtml and *.php files

this fix might help