### PR TITLE
fix(preset-attributify): apply `prefixedOnly` filter on extractor

### DIFF
--- a/packages/preset-attributify/src/extractor.ts
+++ b/packages/preset-attributify/src/extractor.ts
@@ -52,6 +52,9 @@ export const extractorAttributify = (options?: AttributifyOptions): Extractor =>
               .filter(isValidSelector)
           }
           else {
+            if (options?.prefixedOnly && options.prefix && !name.startsWith(options.prefix))
+              return []
+
             const extractTernary = Array.from(content.matchAll(/(?:[\?:].*?)(["'])([^\1]*?)\1/gms))
               .map(([,,v]) => v.split(splitterRE)).flat()
             return (extractTernary.length ? extractTernary : content.split(splitterRE))

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -33,6 +33,7 @@ Set {
   "[border~=\\"rounded\\"]",
   "[border~=\\"blue-200\\"]",
   "[un-children~=\\"m-auto\\"]",
+  "[x-transition:enter-start~=\\"opacity-0\\"]",
   "[pt2=\\"\\"]",
   "[rounded-sm=\\"\\"]",
   "[inline-block=\\"\\"]",
@@ -325,6 +326,13 @@ exports[`attributify > fixture4 1`] = `
 }"
 `;
 
+exports[`attributify > prefixedOnly 1`] = `
+"/* layer: default */
+.absolute{position:absolute;}
+.fixed{position:fixed;}
+[un-children~=\\"m-auto\\"]>*{margin:auto;}"
+`;
+
 exports[`attributify > variant 1`] = `
 [
   "uno-layer-base-c-white/10",
@@ -358,6 +366,7 @@ exports[`attributify > variant 1`] = `
   "border-rounded",
   "border-blue-200",
   "children-m-auto",
+  "x-transition:enter-start-opacity-0",
   "pt2",
   "rounded-sm",
   "inline-block",

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -23,6 +23,9 @@ describe('attributify', () => {
   v-bind:p="y-2 x-4"
   border="2 rounded blue-200"
   un-children="m-auto"
+  x-transition:enter-start="opacity-0"
+  :x-transition:enter-start="opacity-0"
+  v-bind:x-transition:enter-start="opacity-0"
   pt2 rounded-sm
   inline-block
   transform
@@ -169,6 +172,18 @@ describe('attributify', () => {
         return typeof r === 'string' ? r : r ? r.matcher : r
       }))
       .toMatchSnapshot()
+  })
+
+  test('prefixedOnly', async () => {
+    const uno = createGenerator({
+      presets: [
+        presetAttributify({ strict: true, prefix: 'un-', prefixedOnly: true }),
+        presetUno({ attributifyPseudo: true }),
+      ],
+    })
+
+    const { css } = await uno.generate(fixture1, { preflights: false })
+    expect(css).toMatchSnapshot()
   })
 
   test('fixture1', async () => {


### PR DESCRIPTION
Fixes #1962