### PR TITLE
chore(interactive): reduce search execution

### DIFF
--- a/interactive/components/Search.vue
+++ b/interactive/components/Search.vue
@@ -13,13 +13,14 @@ const vFocus = {
 
 watch(
   () => route.query.s,
-  async () => {
-    input.value = String(route.query.s || '')
-    await excuteSearch()
+  async (val) => {
+    if (input.value === val) return
+    input.value = String(val || '')
+    await executeSearch()
   },
 )
 
-async function excuteSearch() {
+async function executeSearch() {
   if (input.value)
     isSearching.value = true
   try {
@@ -45,7 +46,7 @@ async function excuteSearch() {
 
 throttledWatch(
   input,
-  excuteSearch,
+  executeSearch,
   { throttle: 100, immediate: true },
 )
 

--- a/interactive/components/Search.vue
+++ b/interactive/components/Search.vue
@@ -14,7 +14,8 @@ const vFocus = {
 watch(
   () => route.query.s,
   async (val) => {
-    if (input.value === val) return
+    if (input.value === val)
+      return
     input.value = String(val || '')
     await executeSearch()
   },


### PR DESCRIPTION
- fix spell checker
- fix search duplicate execution

After performing the search, the `router.replace` operation triggers watch, causing each search to be performed twice.

``` ts
watch(
  () => route.query.s,
  async () => {
    input.value = String(route.query.s || '')
    await excuteSearch()
  },
)

async function executeSearch() {
  ...
  await router.replace({
    path: '/',
    query: input.value
      ? {
          s: input.value,
        }
      : undefined,
  })
}
```