### PR TITLE
feat(preset): add px to rem preset

### DIFF
--- a/packages/preset-px-to-rem/LICENSE
+++ b/packages/preset-px-to-rem/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Xc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preset-px-to-rem/README.md
+++ b/packages/preset-px-to-rem/README.md
@@ -1,0 +1,80 @@
+# @unocss/preset-px-to-rem
+
+Coverts px to rem for utils.
+
+## Installation
+
+```bash
+npm i -D @unocss/preset-px-to-rem
+```
+
+```ts
+import presetUno from '@unocss/preset-uno'
+import presetPxToRem from '@unocss/preset-px-to-rem'
+
+Unocss({
+  presets: [
+    presetUno(),
+    presetPxToRem()
+  ],
+})
+```
+
+## Config
+```ts
+remToPxPreset(options: PxToRemOptions = {})
+
+interface PxToRemOptions {
+  /**
+   * 75px = 1 rem
+   * @default 75
+   */
+  rootValue?: number
+  /**
+   * precision
+   * @default 5
+   */
+   unitPrecision?: number
+}
+
+```
+
+## Usage
+
+```html
+<div class="m-75px" w-35px></div>
+```
+
+<table><tr><td width="500px" valign="top">
+
+### without
+
+```css
+.m-75px {
+  margin: 75px;
+}
+
+.w-35px{
+  width: 35px;
+}
+```
+
+</td><td width="500px" valign="top">
+
+### with
+
+```css
+.m-75px {
+  margin: 1rem;
+}
+
+.w-35px{
+  width: 0.46667rem;
+}
+```
+
+</td></tr></table>
+
+## License
+
+MIT License &copy; 2022-PRESENT [Xc](https://github.com/chenxch)

--- a/packages/preset-px-to-rem/README.md
+++ b/packages/preset-px-to-rem/README.md
@@ -9,12 +9,10 @@ npm i -D @unocss/preset-px-to-rem
 ```
 
 ```ts
-import presetUno from '@unocss/preset-uno'
 import presetPxToRem from '@unocss/preset-px-to-rem'
 
 Unocss({
   presets: [
-    presetUno(),
     presetPxToRem()
   ],
 })
@@ -22,7 +20,7 @@ Unocss({
 
 ## Config
 ```ts
-remToPxPreset(options: PxToRemOptions = {})
+presetPxToRem(options: PxToRemOptions = {})
 
 interface PxToRemOptions {
   /**

--- a/packages/preset-px-to-rem/build.config.ts
+++ b/packages/preset-px-to-rem/build.config.ts
@@ -1,0 +1,12 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  entries: [
+    'src/index',
+  ],
+  clean: true,
+  declaration: true,
+  rollup: {
+    emitCJS: true,
+  },
+})

--- a/packages/preset-px-to-rem/package.json
+++ b/packages/preset-px-to-rem/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@unocss/preset-px-to-rem",
+  "version": "0.47.5",
+  "description": "Convert all px to rem in utils",
+  "author": "Xc <124118265@qq.com>",
+  "license": "MIT",
+  "homepage": "https://github.com/unocss/unocss/tree/main/packages/preset-px-to-rem#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unocss/unocss.git",
+    "directory": "packages/preset-px-to-rem"
+  },
+  "bugs": {
+    "url": "https://github.com/unocss/unocss/issues"
+  },
+  "keywords": [
+    "unocss",
+    "unocss-preset"
+  ],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "unbuild",
+    "stub": "unbuild --stub"
+  },
+  "dependencies": {
+    "@unocss/core": "workspace:*"
+  }
+}

--- a/packages/preset-px-to-rem/src/index.ts
+++ b/packages/preset-px-to-rem/src/index.ts
@@ -1,0 +1,34 @@
+import type { Preset } from '@unocss/core'
+
+const pxRE = /(-?[\.\d]+)px/g
+
+export interface PxToRemOptions {
+  /**
+   * 75px = 1 rem
+   * @default 75
+   */
+  rootValue?: number
+  /**
+   * precision
+   * @default 5
+   */
+   unitPrecision?: number
+}
+
+export default function remToPxPreset(options: PxToRemOptions = {}): Preset {
+  const {
+    rootValue = 75,
+    unitPrecision = 5,
+  } = options
+
+  return {
+    name: '@unocss/preset-px-to-rem',
+    postprocess: (util) => {
+      util.entries.forEach((i) => {
+        const value = i[1]
+        if (value && typeof value === 'string' && pxRE.test(value))
+          i[1] = value.replace(pxRE, (_, p1) => `${(p1 / rootValue).toFixed(unitPrecision)}rem`)
+      })
+    },
+  }
+}

--- a/packages/preset-px-to-rem/src/index.ts
+++ b/packages/preset-px-to-rem/src/index.ts
@@ -15,7 +15,7 @@ export interface PxToRemOptions {
    unitPrecision?: number
 }
 
-export default function remToPxPreset(options: PxToRemOptions = {}): Preset {
+export default function pxToRemPreset(options: PxToRemOptions = {}): Preset {
   const {
     rootValue = 75,
     unitPrecision = 5,


### PR DESCRIPTION
## reason
I personally like the unocss design very much, so I applied it to a recently developed mobile project. In addition to using `unocss`, the project also used `vant4` components. Since the design draft is `750px`, `postcss-pxtorem` was used for conversion during compilation. It is normal in the development mode. In the production mode, it is necessary to judge `vant` to return different rootValues. I don’t know if it is because of asynchronous processing that the unocss conversion has a cardinality error.

```ts
// vite.config.ts
import postCssPxToRem from 'postcss-pxtorem'

{
css: {
    postcss: {
      plugins: [
        postCssPxToRem({
          rootValue({ file }) {
            return file.includes('vant') ? 37.5 : 75
          },
          propList: ['*'],
        }),
      ],
    },
  },
}
```

## Why submit this plugin?
I found a rem-to-px conversion in the issue, why is there no px-to-rem? Maybe you can use `postcss-pxtorem`, but when developing in parallel with vant, this problem occurs, you can weigh whether to add this plugin.
