### PR TITLE
chore(interactive): search optimization

### DIFF
--- a/interactive/components/Search.vue
+++ b/interactive/components/Search.vue
@@ -4,22 +4,11 @@ import { onBeforeRouteUpdate } from 'vue-router'
 import type { ResultItem } from '~/types'
 import { input, isSearching, searchResult, selectIndex, userConfigLoading } from '~/composables/state'
 
-const route = useRoute()
 const router = useRouter()
 const inputEl = $ref<HTMLInputElement>()
 const vFocus = {
   mounted: (el: HTMLElement) => el.focus(),
 }
-
-watch(
-  () => route.query.s,
-  async (val) => {
-    if (input.value === val)
-      return
-    input.value = String(val || '')
-    await executeSearch()
-  },
-)
 
 async function executeSearch() {
   if (input.value)
@@ -45,10 +34,10 @@ async function executeSearch() {
   })
 }
 
-throttledWatch(
+watchDebounced(
   input,
   executeSearch,
-  { throttle: 100, immediate: true },
+  { debounce: 200, immediate: true },
 )
 
 useEventListener('keydown', (e) => {


### PR DESCRIPTION
## Delete watch

The role of watch is to call a search when entering through the address bar.

This is already implemented in state's `initParams` and watchDebounced's `immediate`.

``` ts
// interactive/composables/state.ts
const initParams = new URLSearchParams(location.search)

export const input = ref(initParams.get('s')?.toString() || '')
```

``` ts
// interactive/components/Search.vue
watchDebounced(
  input,
  executeSearch,
  { debounce: 200, immediate: true },
)
```

## `throttledWatch` -> `watchDebounced`

