### PR TITLE
feat(preset-web-fonts): add customFetch option

### DIFF
--- a/packages/preset-web-fonts/README.md
+++ b/packages/preset-web-fonts/README.md
@@ -111,6 +111,7 @@ Unocss({
   ],
 })
 ```
+
 PR welcome to add more providers 🙌
 
 ## Configuration

--- a/packages/preset-web-fonts/README.md
+++ b/packages/preset-web-fonts/README.md
@@ -73,9 +73,11 @@ Currently supported Providers:
 - `bunny` - [Privacy-Friendly Google Fonts](https://fonts.bunny.net/)
 - `fontshare` - [Quality Font Service by ITF](https://www.fontshare.com/)
 
-### Custom request function
+PR welcome to add more providers 🙌
 
-Use your own request to fetch font source
+### Custom fetch function
+
+Use your own function to fetch font source.
 
 ```ts
 import presetWebFonts from '@unocss/preset-web-fonts'
@@ -88,31 +90,16 @@ Unocss({
     presetUno(),
     presetWebFonts({
       // use axios with an https proxy
-      customRequest: (url: string) => axios.get(url, { httpsAgent: new ProxyAgent('https://localhost:7890') }),
+      customFetch: (url: string) => axios.get(url, { httpsAgent: new ProxyAgent('https://localhost:7890') }),
       provider: 'google',
       fonts: {
         sans: 'Roboto',
         mono: ['Fira Code', 'Fira Mono:400,700'],
-        // custom ones
-        lobster: 'Lobster',
-        lato: [
-          {
-            name: 'Lato',
-            weights: ['400', '700'],
-            italic: true,
-          },
-          {
-            name: 'sans-serif',
-            provider: 'none',
-          },
-        ],
       },
     }),
   ],
 })
 ```
-
-PR welcome to add more providers 🙌
 
 ## Configuration
 

--- a/packages/preset-web-fonts/README.md
+++ b/packages/preset-web-fonts/README.md
@@ -74,6 +74,7 @@ Currently supported Providers:
 - `fontshare` - [Quality Font Service by ITF](https://www.fontshare.com/)
 
 ### Custom request function
+
 Use your own request to fetch font source
 
 ```ts
@@ -110,7 +111,6 @@ Unocss({
   ],
 })
 ```
-
 PR welcome to add more providers 🙌
 
 

--- a/packages/preset-web-fonts/README.md
+++ b/packages/preset-web-fonts/README.md
@@ -113,7 +113,6 @@ Unocss({
 ```
 PR welcome to add more providers 🙌
 
-
 ## Configuration
 
 Refer to the [type definition](https://github.com/unocss/unocss/blob/main/packages/preset-web-fonts/src/types.ts#L4) for all configurations available.

--- a/packages/preset-web-fonts/README.md
+++ b/packages/preset-web-fonts/README.md
@@ -73,7 +73,46 @@ Currently supported Providers:
 - `bunny` - [Privacy-Friendly Google Fonts](https://fonts.bunny.net/)
 - `fontshare` - [Quality Font Service by ITF](https://www.fontshare.com/)
 
+### Custom request function
+Use your own request to fetch font source
+
+```ts
+import presetWebFonts from '@unocss/preset-web-fonts'
+import presetUno from '@unocss/preset-uno'
+import axios from 'axios'
+import ProxyAgent from 'proxy-agent'
+
+Unocss({
+  presets: [
+    presetUno(),
+    presetWebFonts({
+      // use axios with an https proxy
+      customRequest: (url: string) => axios.get(url, { httpsAgent: new ProxyAgent('https://localhost:7890') }),
+      provider: 'google',
+      fonts: {
+        sans: 'Roboto',
+        mono: ['Fira Code', 'Fira Mono:400,700'],
+        // custom ones
+        lobster: 'Lobster',
+        lato: [
+          {
+            name: 'Lato',
+            weights: ['400', '700'],
+            italic: true,
+          },
+          {
+            name: 'sans-serif',
+            provider: 'none',
+          },
+        ],
+      },
+    }),
+  ],
+})
+```
+
 PR welcome to add more providers 🙌
+
 
 ## Configuration
 

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -35,7 +35,7 @@ const preset = (options: WebFontsOptions = {}): Preset<any> => {
     extendTheme = true,
     inlineImports = true,
     themeKey = 'fontFamily',
-    customRequest,
+    customFetch,
   } = options
 
   const fontObject = Object.fromEntries(
@@ -49,16 +49,15 @@ const preset = (options: WebFontsOptions = {}): Preset<any> => {
   async function importUrl(url: string) {
     if (inlineImports) {
       if (!importCache[url]) {
-        const { $fetch } = await import('ohmyfetch')
-        importCache[url] = (customRequest
-          ? customRequest(url)
-          : $fetch(url, { headers: {}, retry: 3 }))
-          .catch((e) => {
-            console.error('Failed to fetch web fonts')
-            console.error(e)
-            if (typeof process !== 'undefined' && process.env.CI)
-              throw e
-          })
+        const promise = customFetch
+          ? customFetch(url)
+          : (await import('ohmyfetch')).$fetch(url, { headers: {}, retry: 3 })
+        importCache[url] = promise.catch((e) => {
+          console.error('Failed to fetch web fonts')
+          console.error(e)
+          if (typeof process !== 'undefined' && process.env.CI)
+            throw e
+        })
       }
       return await importCache[url]
     }

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -35,6 +35,7 @@ const preset = (options: WebFontsOptions = {}): Preset<any> => {
     extendTheme = true,
     inlineImports = true,
     themeKey = 'fontFamily',
+    customRequest,
   } = options
 
   const fontObject = Object.fromEntries(
@@ -49,7 +50,9 @@ const preset = (options: WebFontsOptions = {}): Preset<any> => {
     if (inlineImports) {
       if (!importCache[url]) {
         const { $fetch } = await import('ohmyfetch')
-        importCache[url] = $fetch(url, { headers: {}, retry: 3 })
+        importCache[url] = (customRequest
+          ? customRequest(url)
+          : $fetch(url, { headers: {}, retry: 3 }))
           .catch((e) => {
             console.error('Failed to fetch web fonts')
             console.error(e)

--- a/packages/preset-web-fonts/src/types.ts
+++ b/packages/preset-web-fonts/src/types.ts
@@ -44,11 +44,11 @@ export interface WebFontsOptions {
   inlineImports?: boolean
 
   /**
-   * Inline CSS @import()
+   * Custom fetch function
    *
    * @default undefined
    */
-  customRequest?: (url: string) => Promise<any>
+  customFetch?: (url: string) => Promise<any>
 }
 
 export interface Provider {

--- a/packages/preset-web-fonts/src/types.ts
+++ b/packages/preset-web-fonts/src/types.ts
@@ -42,6 +42,13 @@ export interface WebFontsOptions {
    * @default true
    */
   inlineImports?: boolean
+
+  /**
+   * Inline CSS @import()
+   *
+   * @default undefined
+   */
+  customRequest?: (url: string) => Promise<any>
 }
 
 export interface Provider {


### PR DESCRIPTION
Fucked by GFW because of default provider `google`.
So add an option to custom request to fetch web font source to enable something like proxy agent.
