### PR TITLE
feat: remove un-cloak to html node as well as body

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -172,6 +172,7 @@ export default function init(inlineConfig: RuntimeOptions = {}) {
     const html = body && body.outerHTML
     if (html) {
       await extract(`${html} ${decodeHtml(html)}`)
+      removeCloak(defaultDocument.documentElement)
       removeCloak(body)
     }
   }


### PR DESCRIPTION
For one use case, I have an "un-cloak" attribute added automatically to the html tag dynamically before the body exist.
Plus I find this intuitive to have the attribute on the html tag, the fact that both work seems better to me.
Thanks for your work !


You can try here the following 2 links (to copy paste in URL):

data:text/html,<html un-cloak>
  <style>[un-cloak]{display:none}</style>
  <script type="module">
    import initUnocssRuntime from "https://patch.deno.dev/@unocss/runtime?dev";
    initUnocssRuntime();
  </script>
  <div>will show</div>
</html>

data:text/html,<html un-cloak>
  <style>[un-cloak]{display:none}</style>
  <script type="module">
    import initUnocssRuntime from "https://esm.sh/@unocss/runtime?dev";
    initUnocssRuntime();
  </script>
  <div>will not show</div>
</html>

The patch is available here: https://dash.deno.com/playground/patch