### PR TITLE
feat: add mdsvex extensions to SvelteScopedPlugin filters fix #1936

### DIFF
--- a/packages/vite/src/modes/svelte-scoped/index.ts
+++ b/packages/vite/src/modes/svelte-scoped/index.ts
@@ -17,7 +17,7 @@ export function SvelteScopedPlugin({ ready, uno }: UnocssPluginContext): Plugin 
       viteConfig = _viteConfig
       const { config } = await ready
       filter = createFilter(
-        config.include || [/\.svelte$/],
+        config.include || [/\.svelte$/, /\.svelte\.md$/, /\.svx$/],
         config.exclude || defaultExclude,
       )
     },

--- a/packages/vite/src/modes/svelte-scoped/index.ts
+++ b/packages/vite/src/modes/svelte-scoped/index.ts
@@ -8,7 +8,7 @@ export * from './transform'
 
 export function SvelteScopedPlugin({ ready, uno }: UnocssPluginContext): Plugin {
   let viteConfig: ResolvedConfig
-  let filter = createFilter([/\.svelte$/], defaultExclude)
+  let filter = createFilter([/\.svelte$/, /\.svelte\.md$/, /\.svx$/], defaultExclude)
 
   return {
     name: 'unocss:svelte-scoped',


### PR DESCRIPTION
This PR adds .svelte.md and .svx file extensions to the SvelteScopedPlugin filters so UnoCSS works out of the box for users of mdsvex+UnoCSS who use those file extensions.

At least that's what I think it does, I got an npm error trying to install from my branch in my fork so no idea if this actually works. 😨 

If it does work it should also fix https://github.com/unocss/unocss/issues/1936 