### PR TITLE
chore: fix failed tests

### DIFF
--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -88,7 +88,7 @@ describe.concurrent('fixtures', () => {
     const css = await getGlobContent(root, 'dist/**/*.css')
 
     expect(css).contains('.w-200px')
-    expect(css).contains('[font~="mono"]')
+    expect(css).contains('[font~=mono]')
   }, 60_000)
 
   it('vue cli 5', async () => {
@@ -99,6 +99,6 @@ describe.concurrent('fixtures', () => {
     const css = await getGlobContent(root, 'dist/**/*.css')
 
     expect(css).contains('.w-200px')
-    expect(css).contains('[font~="mono"]')
+    expect(css).contains('[font~=mono]')
   }, 60_000)
 })


### PR DESCRIPTION
After the css file generated by build is compressed, `[font~="mono"]` has no quotation marks.

<img width="327" alt="image" src="https://user-images.githubusercontent.com/53554371/210943988-c9f8f377-5e28-4f8b-9944-48af2544558c.png">
