### PR TITLE
doc(preset-attributify): update docs with svelteHTML instead of svelte.JSX

### DIFF
--- a/packages/preset-attributify/README.md
+++ b/packages/preset-attributify/README.md
@@ -177,12 +177,10 @@ declare module 'solid-js' {
 ### Svelte & SvelteKit
 
 ```ts
-import type { AttributifyAttributes } from '@unocss/preset-attributify'
+declare namespace svelteHTML {
+  import type { AttributifyAttributes } from '@unocss/preset-attributify'
 
-declare global {
-  namespace svelte.JSX {
-    interface HTMLAttributes<T> extends AttributifyAttributes {}
-  }
+  type HTMLAttributes = AttributifyAttributes
 }
 ```
 


### PR DESCRIPTION
Update documentation to match upstream changes in Svelte's language tools: https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md#im-getting-deprecation-warnings-for-sveltejsx--i-want-to-migrate-to-the-new-typings

It seems to be working well like this, if I type it as an interface instead I get errors