### PR TITLE
feat(core): make generator can timeout

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -121,6 +121,29 @@ export class UnoGenerator<Theme extends {} = {}> {
     options: GenerateOptions = {},
   ): Promise<GenerateResult> {
     const {
+      timeout = 0,
+    } = options
+
+    if (timeout === 0)
+      return this.generateRaced(input, options)
+
+    return await Promise.race([
+      this.generateRaced(input, options),
+      new Promise(resolve => setTimeout(() => resolve({
+        css: '',
+        layers: [],
+        getLayer: () => undefined,
+        getLayers: () => '',
+        matched: new Set<string>(),
+      }), timeout)) as Promise<GenerateResult>,
+    ])
+  }
+
+  private async generateRaced(
+    input: string | Set<string> | string[],
+    options: GenerateOptions = {},
+  ): Promise<GenerateResult> {
+    const {
       id,
       scope,
       preflights = true,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -743,6 +743,12 @@ export interface GenerateOptions {
   minify?: boolean
 
   /**
+   * Set generator timeout duration
+   * @default 0
+   */
+  timeout?: number
+
+  /**
    * @experimental
    */
   scope?: string

--- a/test/generate-async.test.ts
+++ b/test/generate-async.test.ts
@@ -46,3 +46,25 @@ describe('generate-async', () => {
     expect(order).eql([1, 2])
   })
 })
+
+describe('generator timeout', () => {
+  test('awaitable generator can timed-out', async () => {
+    const order: number[] = []
+
+    setTimeout(() => {
+      order.push(1)
+    }, 10)
+
+    const uno = createGenerator({
+      rules: [
+        [/^rule$/, () => new Promise(resolve => setTimeout(() => {
+          order.push(2)
+          resolve('/* rule */')
+        }, 20))],
+      ],
+    })
+
+    await uno.generate('rule', { timeout: 15 })
+    expect(order).eql([1])
+  })
+})


### PR DESCRIPTION
As touched in #2067, due to the nature of the usage of regex in the presets, I'd like to propose to add timeout option to the ```uno.generator()```

I'm still not sure what happend to the function calling the regex when a catastrophic backtrack happened but for now the generator will just exit early.

There are 3 possible sections to apply the detection independently: extractor, token parsing and preflights. But, as a proof of concept, for now it will be just as a global wrapper to the main generator function.