### PR TITLE
fix(core): replace scope placeholder globally

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -637,11 +637,10 @@ export function createGenerator<Theme extends {} = {}>(config?: UserConfig<Theme
   return new UnoGenerator<Theme>(config, defaults)
 }
 
-export const regexScopePlaceholder = / \$\$ /
-export const hasScopePlaceholder = (css: string) => css.match(regexScopePlaceholder)
-
+const regexScopeCheck = / \$\$ /
+export const regexScopePlaceholder = / +\$\$ +/g
 function applyScope(css: string, scope?: string) {
-  if (hasScopePlaceholder(css))
+  if (css.match(regexScopeCheck))
     return css.replace(regexScopePlaceholder, scope ? ` ${scope} ` : ' ')
   else
     return scope ? `${scope} ${css}` : css

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -637,10 +637,11 @@ export function createGenerator<Theme extends {} = {}>(config?: UserConfig<Theme
   return new UnoGenerator<Theme>(config, defaults)
 }
 
-const regexScopeCheck = / \$\$ /
-export const regexScopePlaceholder = / +\$\$ +/g
+export const regexScopePlaceholder = /\s\$\$\s+/g
+export const hasScopePlaceholder = (css: string) => css.match(/\s\$\$\s/)
+
 function applyScope(css: string, scope?: string) {
-  if (css.match(regexScopeCheck))
+  if (hasScopePlaceholder(css))
     return css.replace(regexScopePlaceholder, scope ? ` ${scope} ` : ' ')
   else
     return scope ? `${scope} ${css}` : css

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -7,6 +7,12 @@ exports[`preset-mini > custom var prefix 1`] = `
 .scale-100{--hi-scale-x:1;--hi-scale-y:1;transform:translateX(var(--hi-translate-x)) translateY(var(--hi-translate-y)) translateZ(var(--hi-translate-z)) rotate(var(--hi-rotate)) rotateX(var(--hi-rotate-x)) rotateY(var(--hi-rotate-y)) rotateZ(var(--hi-rotate-z)) skewX(var(--hi-skew-x)) skewY(var(--hi-skew-y)) scaleX(var(--hi-scale-x)) scaleY(var(--hi-scale-y)) scaleZ(var(--hi-scale-z));}"
 `;
 
+exports[`preset-mini > dark class 1`] = `
+"/* layer: default */
+.dark .hello .dark\\\\:scope-\\\\[\\\\.hello\\\\]\\\\:text-1\\\\/2{font-size:0.25rem;line-height:0.5rem;}
+.light [world] .scope-\\\\[\\\\[world\\\\]\\\\]\\\\:light\\\\:text-1\\\\/3{font-size:0.25rem;line-height:0.75rem;}"
+`;
+
 exports[`preset-mini > dark customizing selector 1`] = `
 "/* layer: default */
 [data-mode=\\"dark\\"] .dark\\\\:bg-white{--un-bg-opacity:1;background-color:rgba(255,255,255,var(--un-bg-opacity));}

--- a/test/preset-mini.test.ts
+++ b/test/preset-mini.test.ts
@@ -141,4 +141,21 @@ describe('preset-mini', () => {
     expect(uno.config.theme.fontSize.lg).toEqual(['3rem', '1.5em'])
     expect(css).toMatchSnapshot()
   })
+
+  test('dark class', async () => {
+    const uno = createGenerator({
+      presets: [
+        presetMini(),
+      ],
+    })
+
+    const { css } = await uno.generate([
+      'dark:scope-[.hello]:text-1/2',
+      'scope-[[world]]:light:text-1/3',
+    ].join(' '), {
+      preflights: false,
+    })
+
+    expect(css).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Fix #2068 

I'd tag this as breaking since the replacement is now global while exported and being used in 2 other places:

https://github.com/unocss/unocss/blob/badcf8666a43bcb640d1a2d1f8f8318b2ec27047/packages/vscode/src/selectionStyle.ts#L54

https://github.com/unocss/unocss/blob/badcf8666a43bcb640d1a2d1f8f8318b2ec27047/packages/transformer-directives/src/apply.ts#L66

