### PR TITLE
feat(runtime): add alternate variant with its own <style> element

### DIFF
--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -1,4 +1,5 @@
-import type { Postprocessor } from '@unocss/core'
+import type { Postprocessor, Variant } from '@unocss/core'
+import { escapeRegExp } from '@unocss/core'
 
 const camelize = (str: string) => str.replace(/-(\w)/g, (_, c) => c ? c.toUpperCase() : '')
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
@@ -35,4 +36,19 @@ export function decodeHtml(html: string): string {
     .replace(/&amp;/g, '&')
     .replace(/&gt;/g, '>')
     .replace(/&lt;/g, '<')
+}
+
+export function alternateLayerVariant(prefix: string, layer: string): Variant {
+  const regex = new RegExp(`^${escapeRegExp(prefix)}(.+)$`)
+  return {
+    match(matcher) {
+      const match = matcher.match(regex)
+      if (match) {
+        return {
+          matcher: match[1],
+          layer,
+        }
+      }
+    },
+  }
 }

--- a/test/__snapshots__/runtime.test.ts.snap
+++ b/test/__snapshots__/runtime.test.ts.snap
@@ -12,6 +12,18 @@ text-green5\\\\:10{color:rgba(34,197,94,0.1);}
 shadow-xl{--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px var(--un-shadow-color, rgba(0,0,0,0.1)),var(--un-shadow-inset) 0 8px 10px -6px var(--un-shadow-color, rgba(0,0,0,0.1));box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}"
 `;
 
+exports[`runtime auto prefixer > test using configured alternate layer 1`] = `
+"/* layer: default */
+.text-red{--un-text-opacity:1;color:rgba(248,113,113,var(--un-text-opacity));}"
+`;
+
+exports[`runtime auto prefixer > test using configured alternate layer 2`] = `
+"/* layer: split */
+.\\\\[\\\\&\\\\:hover\\\\]\\\\:\\\\^text-blue:hover{--un-text-opacity:1;color:rgba(96,165,250,var(--un-text-opacity));}
+.\\\\^\\\\[\\\\&\\\\:active\\\\]\\\\:text-yellow:active{--un-text-opacity:1;color:rgba(250,204,21,var(--un-text-opacity));}
+.\\\\^text-green{--un-text-opacity:1;color:rgba(74,222,128,var(--un-text-opacity));}"
+`;
+
 exports[`runtime auto prefixer > using autoprefixer 1`] = `
 "/* layer: default */
 .\\\\[--vars\\\\:value\\\\]{--vars:value;}

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -2,7 +2,7 @@ import { createGenerator } from '@unocss/core'
 import presetUno from '@unocss/preset-uno'
 import presetTagify from '@unocss/preset-tagify'
 import { describe, expect, test } from 'vitest'
-import { autoPrefixer, decodeHtml } from '../packages/runtime/src/utils'
+import { alternateLayerVariant, autoPrefixer, decodeHtml } from '../packages/runtime/src/utils'
 
 function mockElementWithStyle() {
   const store: any = {}
@@ -82,6 +82,27 @@ describe('runtime auto prefixer', () => {
       </flex>
     `, { preflights: false })
     expect(css).toMatchSnapshot()
+  })
+
+  test('test using configured alternate layer', async () => {
+    const altLayerName = 'split'
+    const uno = createGenerator({
+      presets: [
+        presetUno(),
+      ],
+      variants: [
+        alternateLayerVariant('^', altLayerName),
+      ],
+    })
+
+    const result = await uno.generate([
+      'text-red',
+      '^text-green',
+      '[&:hover]:^text-blue',
+      '^[&:active]:text-yellow',
+    ].join(' '), { preflights: false })
+    expect(result.getLayers(undefined, [altLayerName])).toMatchSnapshot()
+    expect(result.getLayer(altLayerName)).toMatchSnapshot()
   })
 })
 


### PR DESCRIPTION
Add a separate layer with its own variant & style element to enable css override without adding important modifier.

The exsiting `<style>` element is intentionally appended early (before `<head>`) so as to make unocss act as base styling. This in turn making overriding style difficult and may resort to selector manipulation or using the important keyword/modifier. In userspace, developer can move the style element around, but considering the preflights & reset styles are here, moving the style element around may not be optimal.

This PR make unocss runtime produce 2 `<style>` elements and split the generator output into two parts. One with a configurable layer variant will be on the new `<style>` element, placed after `</body>`. The rest assume the previous behavior having the css before the `<head>`.