### PR TITLE
feat: allow to return generated css inline

### DIFF
--- a/packages/shared-integration/src/layers.ts
+++ b/packages/shared-integration/src/layers.ts
@@ -4,7 +4,7 @@ export const VIRTUAL_ENTRY_ALIAS = [
 export const LAYER_MARK_ALL = '__ALL__'
 
 export const RESOLVED_ID_WITH_QUERY_RE = /[\/\\]__uno(?:(_.*?))?\.css(\?.*)?$/
-export const RESOLVED_ID_RE = /[\/\\]__uno(?:(_.*?))?\.css$/
+export const RESOLVED_ID_RE = /[\/\\]__uno(?:(_.*?))?\.css(?:\?.*)?$/
 
 export function resolveId(id: string) {
   if (id.match(RESOLVED_ID_WITH_QUERY_RE))
@@ -12,11 +12,8 @@ export function resolveId(id: string) {
 
   for (const alias of VIRTUAL_ENTRY_ALIAS) {
     const match = id.match(alias)
-    if (match) {
-      return match[1]
-        ? `/__uno_${match[1]}.css`
-        : '/__uno.css'
-    }
+    if (match)
+      return ['/__uno', match[1] ? `_${match[1]}` : '', '.css', match[2] ?? ''].join('')
   }
 }
 


### PR DESCRIPTION
See https://github.com/unocss/unocss/pull/2098#issuecomment-1401844999

Vite seems to need `?inline` at the resolved id.
- [ ] docs?
- [ ] test
- [ ] get this actually to work lol