### PR TITLE
fix: `vite build --watch` not emitting anything

### DIFF
--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -93,8 +93,10 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
       },
       load(id) {
         const layer = resolveLayer(getPath(id))
-        if (layer)
+        if (layer) {
+          vfsLayers.add(layer)
           return getLayerPlaceholder(layer)
+        }
       },
       moduleParsed({ id, importedIds }) {
         if (!layerImporterMap.has(id))


### PR DESCRIPTION
There was a regression introduced in b7a6687d218827f1dc70e7aa61aa67bfbff838d9 where vite projects built using `vite build --watch` will only generate once. Subsequent generations will just leave the placeholder.

My solution here was to add the layers as they're loaded, rather than removing the `clear`.

Re-fixes #963
See #1963 - it's unclear why this reintroduced the issue, I'm not familiar enough with nuxt or astro.