### PR TITLE
fix(attributify)!: add `fill` and `opacity` to default ignore attrs, close #2104

### DIFF
--- a/packages/preset-attributify/src/extractor.ts
+++ b/packages/preset-attributify/src/extractor.ts
@@ -11,7 +11,7 @@ const splitterRE = /[\s'"`;]+/g
 const elementRE = /<\w(?=.*>)[\w:\.$-]*\s((?:['"`\{].*?['"`\}]|.*?)*?)>/gs
 const valuedAttributeRE = /([?]|(?!\d|-{2}|-\d)[a-zA-Z0-9\u00A0-\uFFFF-_:!%-.]+)=?(?:["]([^"]*)["]|[']([^']*)[']|[{]([^}]*)[}])?/gms
 
-export const defaultIgnoreAttributes = ['placeholder']
+export const defaultIgnoreAttributes = ['placeholder', 'fill', 'opacity']
 
 export const extractorAttributify = (options?: AttributifyOptions): Extractor => {
   const ignoreAttributes = options?.ignoreAttributes ?? defaultIgnoreAttributes


### PR DESCRIPTION
close #2104

This is a breaking change if you are using:

```html
<div opacity="10" fill="red" />
```

They won't be captured by unocss anymore.

### Migration

You can either prefix them with `un-`

```html
<div un-opacity="10" un-fill="red" />
```

Or use `op` as the shorthand for `opacity`:

```html
<div op="10"/>
```

Or update the config to change it back:

```ts
presetAttributify({
  ignoreAttributes: ['placeholder'] // previous default
})
```