### PR TITLE
fix(preset-mini): don't generate arbitrary property if it starts with colon

### DIFF
--- a/packages/preset-mini/src/_rules/variables.ts
+++ b/packages/preset-mini/src/_rules/variables.ts
@@ -26,7 +26,7 @@ export const cssVariables: Rule[] = [
 ]
 
 export const cssProperty: Rule[] = [
-  [/^\[(--(\w|\\\W)+|[\w-]+):(.+)\]$/, ([match, prop,, value]) => {
+  [/^\[(--(\w|\\\W)+|[\w-]+):([^:].*)\]$/, ([match, prop,, value]) => {
     if (!isURI(match.slice(1, -1)))
       return { [prop]: h.bracket(`[${value}]`) }
   }],

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -1067,6 +1067,7 @@ export const presetMiniNonTargets = [
   '[name].[hash:9]',
   '["update:modelValue"]',
   '[https://en.wikipedia.org/wiki]',
+  '[Baz::class]',
   // escaped arbitrary css properties only allowed in css variables
   '[cant\~escape:me]',
 ]


### PR DESCRIPTION
Fixes #2106