### PR TITLE
docs(playground): content missing on editor resize

### DIFF
--- a/playground/src/components/Editor.vue
+++ b/playground/src/components/Editor.vue
@@ -52,8 +52,15 @@ function handleReset() {
   }
 }
 
+const handleEditorResize = useThrottleFn(() => {
+  // manually refresh when resizing, ensure content display completely
+  Array.from(document.querySelectorAll('.CodeMirror') ?? []).forEach((el) => {
+    (el as any).CodeMirror?.refresh()
+  })
+}, 200)
 function handleResize(event: ({ size: number })[]) {
   panelSizes.value = event.map(({ size }) => size)
+  handleEditorResize()
 }
 function isCollapsed(index: number) {
   return panelSizes.value[index] <= titleHeightPercent.value + 3


### PR DESCRIPTION
https://user-images.githubusercontent.com/35442047/215271430-14fdbbf4-f5fa-471d-84a7-d3284f53eb86.mp4

Currently, the content in the editor is not displaying correctly after being resized. It requires interaction, such as clicking or scrolling, or manual refreshing to display correctly.