### PR TITLE
feat(core,preset-attributify)!: allow matching bracket-only last value

### DIFF
--- a/packages/autocomplete/src/create.ts
+++ b/packages/autocomplete/src/create.ts
@@ -63,7 +63,7 @@ export function createAutocomplete(uno: UnoGenerator): UnocssAutocomplete {
       return cache.get(input)!
 
     // match and ignore existing variants
-    const [, processed, , variants] = uno.matchVariants(input)
+    const [, processed, , variants] = await uno.matchVariants(input)
     let idx = processed ? input.search(escapeRegExp(processed)) : input.length
     // This input contains variants that modifies the processed part,
     // autocomplete will need to reverse it which is not possible

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -87,7 +87,7 @@ export class UnoGenerator<Theme extends {} = {}> {
       return
     }
 
-    const applied = this.matchVariants(raw, current)
+    const applied = await this.matchVariants(raw, current)
 
     if (!applied || this.isBlocked(applied[1])) {
       this.blocked.add(raw)
@@ -101,7 +101,7 @@ export class UnoGenerator<Theme extends {} = {}> {
       context.variants = [...applied[3]]
 
     // expand shortcuts
-    const expanded = this.expandShortcut(context.currentSelector, context)
+    const expanded = await this.expandShortcut(context.currentSelector, context)
     const utils = expanded
       ? await this.stringifyShortcuts(context.variantMatch, context, expanded[0], expanded[1])
       // no shortcuts
@@ -292,7 +292,7 @@ export class UnoGenerator<Theme extends {} = {}> {
     }
   }
 
-  matchVariants(raw: string, current?: string): VariantMatchedResult<Theme> {
+  async matchVariants(raw: string, current?: string): Promise<VariantMatchedResult<Theme>> {
     // process variants
     const variants = new Set<Variant<Theme>>()
     const handlers: VariantHandler[] = []
@@ -310,7 +310,7 @@ export class UnoGenerator<Theme extends {} = {}> {
       for (const v of this.config.variants) {
         if (!v.multiPass && variants.has(v))
           continue
-        let handler = v.match(processed, context)
+        let handler = await v.match(processed, context)
         if (!handler)
           continue
         if (isString(handler))
@@ -401,7 +401,7 @@ export class UnoGenerator<Theme extends {} = {}> {
     shortcutPrefix?: string | string[] | undefined,
   ): Promise<(ParsedUtil | RawUtil)[] | undefined> {
     const [raw, processed, variantHandlers] = isString(input)
-      ? this.matchVariants(input)
+      ? await this.matchVariants(input)
       : input
 
     if (this.config.details)
@@ -496,7 +496,7 @@ export class UnoGenerator<Theme extends {} = {}> {
     return [parsed[0], selector, body, parent, ruleMeta, this.config.details ? context : undefined, noMerge]
   }
 
-  expandShortcut(input: string, context: RuleContext<Theme>, depth = 5): [ShortcutValue[], RuleMeta | undefined] | undefined {
+  async expandShortcut(input: string, context: RuleContext<Theme>, depth = 5): Promise<[ShortcutValue[], RuleMeta | undefined] | undefined> {
     if (depth === 0)
       return
 
@@ -544,9 +544,9 @@ export class UnoGenerator<Theme extends {} = {}> {
 
     // expand nested shortcuts with variants
     if (!result) {
-      const [raw, inputWithoutVariant] = isString(input) ? this.matchVariants(input) : input
+      const [raw, inputWithoutVariant] = isString(input) ? await this.matchVariants(input) : input
       if (raw !== inputWithoutVariant) {
-        const expanded = this.expandShortcut(inputWithoutVariant, context, depth - 1)
+        const expanded = await this.expandShortcut(inputWithoutVariant, context, depth - 1)
         if (expanded)
           result = expanded[0].map(item => isString(item) ? raw.replace(inputWithoutVariant, item) : item)
       }
@@ -555,10 +555,10 @@ export class UnoGenerator<Theme extends {} = {}> {
     if (!result)
       return
 
+    const mapResult = result.map(async r => (isString(r) ? (await this.expandShortcut(r, context, depth - 1))?.[0] : undefined) || [r])
+
     return [
-      result
-        .flatMap(r => (isString(r) ? this.expandShortcut(r, context, depth - 1)?.[0] : undefined) || [r])
-        .filter(Boolean),
+      (await Promise.all(mapResult)).flat(1).filter(Boolean),
       meta,
     ]
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -270,7 +270,7 @@ export interface VariantHandler {
   layer?: string | undefined
 }
 
-export type VariantFunction<Theme extends {} = {}> = (matcher: string, context: Readonly<VariantContext<Theme>>) => string | VariantHandler | undefined
+export type VariantFunction<Theme extends {} = {}> = (matcher: string, context: Readonly<VariantContext<Theme>>) => Awaitable<string | VariantHandler | undefined>
 
 export interface VariantObject<Theme extends {} = {}> {
   /**

--- a/packages/preset-attributify/package.json
+++ b/packages/preset-attributify/package.json
@@ -37,6 +37,7 @@
     "stub": "unbuild --stub"
   },
   "dependencies": {
-    "@unocss/core": "workspace:*"
+    "@unocss/core": "workspace:*",
+    "@unocss/preset-mini": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,8 +433,10 @@ importers:
   packages/preset-attributify:
     specifiers:
       '@unocss/core': workspace:*
+      '@unocss/preset-mini': workspace:*
     dependencies:
       '@unocss/core': link:../core
+      '@unocss/preset-mini': link:../preset-mini
 
   packages/preset-icons:
     specifiers:
@@ -4436,7 +4438,7 @@ packages:
       '@babel/core': 7.20.2
       '@babel/plugin-transform-typescript': 7.20.2_@babel+core@7.20.2
       '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.20.2
-      vite: 3.2.5_qfz55zahqkp66vn23sxaaw3yfe
+      vite: 3.2.5
       vue: 3.2.45
     transitivePeerDependencies:
       - supports-color
@@ -4449,7 +4451,7 @@ packages:
       vite: ^3.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 3.2.5_qfz55zahqkp66vn23sxaaw3yfe
+      vite: 3.2.5
       vue: 3.2.45
     dev: true
 
@@ -10819,6 +10821,7 @@ packages:
 
   /file-uri-to-path/1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
 
   /filesize/3.6.1:
@@ -14311,6 +14314,7 @@ packages:
 
   /nan/2.16.0:
     resolution: {integrity: sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==}
+    requiresBuild: true
     dev: true
     optional: true
 

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -335,6 +335,11 @@ exports[`attributify > fixture4 1`] = `
 }"
 `;
 
+exports[`attributify > merge attribute name and value-only 1`] = `
+"/* layer: default */
+[bg~=\\"\\\\[\\\\&\\\\.foo\\\\]\\\\:\\\\[\\\\&\\\\:nth-child\\\\(3\\\\)\\\\]\\\\:\\\\[\\\\#123\\\\]\\"]{background-color:&.foo;}"
+`;
+
 exports[`attributify > prefixedOnly 1`] = `
 "/* layer: default */
 .absolute{position:absolute;}

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -337,7 +337,8 @@ exports[`attributify > fixture4 1`] = `
 
 exports[`attributify > merge attribute name and value-only 1`] = `
 "/* layer: default */
-[bg~=\\"\\\\[\\\\&\\\\.foo\\\\]\\\\:\\\\[\\\\&\\\\:nth-child\\\\(3\\\\)\\\\]\\\\:\\\\[\\\\#123\\\\]\\"]{background-color:&.foo;}"
+[bg~=\\"\\\\[\\\\&\\\\:nth-child\\\\(3\\\\)\\\\]\\\\:\\\\[\\\\#123456\\\\]\\"]:nth-child(3){--un-bg-opacity:1;background-color:rgba(18,52,86,var(--un-bg-opacity));}
+[bg~=\\"\\\\[\\\\&\\\\.foo\\\\]\\\\:\\\\[\\\\&\\\\:nth-child\\\\(3\\\\)\\\\]\\\\:\\\\[\\\\#123\\\\]\\"]:nth-child(3).foo{--un-bg-opacity:1;background-color:rgba(17,34,51,var(--un-bg-opacity));}"
 `;
 
 exports[`attributify > prefixedOnly 1`] = `

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -170,11 +170,13 @@ describe('attributify', () => {
       strict: true,
     })
 
-    expect(Array.from(await uno.applyExtractors(fixture1) || [])
-      .map((i) => {
-        const r = variant.match(i, {} as any)
+    const promises = Array.from(await uno.applyExtractors(fixture1) || [])
+      .map(async (i) => {
+        const r = await variant.match(i, {} as any)
         return typeof r === 'string' ? r : r ? r.matcher : r
-      }))
+      })
+
+    expect(await Promise.all(promises))
       .toMatchSnapshot()
   })
 

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -257,4 +257,12 @@ describe('attributify', () => {
       await uno.generate('<div class="w-fullllllllllllll"')
     }, 20)
   })
+
+  test('merge attribute name and value-only', async () => {
+    const { css } = await uno.generate(`
+      <div bg="[&:nth-child(3)]:[#123456]"></div>
+      <div class="foo" bg="[&.foo]:[&:nth-child(3)]:[#123]"></div>
+    `, { preflights: false })
+    expect(css).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Closes #2147

This PR addresses the issue in part by making `VariantFunction` as awaitable, as the attributify variant will need to await 2 generator functions to check if the token is parseable or not.
