### PR TITLE
fix(preset-mini): fix non-existent `font-size`, still return `line-height`.

### DIFF
--- a/packages/preset-mini/src/_rules/typography.ts
+++ b/packages/preset-mini/src/_rules/typography.ts
@@ -44,9 +44,10 @@ export const fonts: Rule<Theme>[] = [
         }
       }
 
-      if (lineHeight) {
+      const fontSize = h.bracketOfLength.rem(size)
+      if (lineHeight && fontSize) {
         return {
-          'font-size': h.bracketOfLength.rem(size),
+          'font-size': fontSize,
           'line-height': lineHeight,
         }
       }

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -1092,4 +1092,7 @@ export const presetMiniNonTargets = [
   '[Baz::class]',
   // escaped arbitrary css properties only allowed in css variables
   '[cant\~escape:me]',
+
+  // not exists
+  'text-main/50',
 ]


### PR DESCRIPTION
fix: 
<img width="1036" alt="image" src="https://user-images.githubusercontent.com/29533304/217050944-c5f492ce-7bf9-4e30-914c-a9eeeed5c240.png">
