### PR TITLE
feat(core)!: make select pseudo elements not to be moved around

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,7 +1,7 @@
 import type { Postprocessor, Preprocessor, Preset, ResolvedConfig, Rule, Shortcut, ThemeExtender, UserConfig, UserConfigDefaults, UserShortcuts } from './types'
 import { clone, isStaticRule, mergeDeep, normalizeVariant, toArray, uniq } from './utils'
 import { extractorSplit } from './extractors'
-import { DEFAULT_LAYERS } from './constants'
+import { DEFAULT_LAYERS, DEFAULT_SEPARATORS, DEFAULT_UNSORTED_PSEUDO_ELEMENTS } from './constants'
 
 export function resolveShortcuts<Theme extends {} = {}>(shortcuts: UserShortcuts<Theme>): Shortcut<Theme>[] {
   return toArray(shortcuts).flatMap((s) => {
@@ -49,7 +49,7 @@ export function resolveConfig<Theme extends {} = {}>(
 
   const layers = Object.assign(DEFAULT_LAYERS, ...rawPresets.map(i => i.layers), userConfig.layers)
 
-  function mergePresets<T extends 'rules' | 'variants' | 'extractors' | 'shortcuts' | 'preflights' | 'preprocess' | 'postprocess' | 'extendTheme' | 'safelist' | 'separators'>(key: T): Required<UserConfig<Theme>>[T] {
+  function mergePresets<T extends 'rules' | 'variants' | 'extractors' | 'shortcuts' | 'preflights' | 'preprocess' | 'postprocess' | 'extendTheme' | 'safelist' | 'separators' | 'unsortedPseudoElements'>(key: T): Required<UserConfig<Theme>>[T] {
     return uniq([
       ...sortedPresets.flatMap(p => toArray(p[key] || []) as any[]),
       ...toArray(config[key] || []) as any[],
@@ -97,7 +97,11 @@ export function resolveConfig<Theme extends {} = {}>(
 
   let separators = toArray(mergePresets('separators'))
   if (!separators.length)
-    separators = [':', '-']
+    separators = [...DEFAULT_SEPARATORS]
+
+  let unsortedPseudoElements = mergePresets('unsortedPseudoElements')
+  if (unsortedPseudoElements == null)
+    unsortedPseudoElements = [...DEFAULT_UNSORTED_PSEUDO_ELEMENTS]
 
   return {
     mergeSelectors: true,
@@ -122,5 +126,6 @@ export function resolveConfig<Theme extends {} = {}>(
     extractors,
     safelist: mergePresets('safelist'),
     separators,
+    unsortedPseudoElements,
   }
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -7,3 +7,7 @@ export const DEFAULT_LAYERS = {
   [LAYER_SHORTCUTS]: -10,
   [LAYER_DEFAULT]: 0,
 }
+
+export const DEFAULT_SEPARATORS = [':', '-']
+
+export const DEFAULT_UNSORTED_PSEUDO_ELEMENTS = []

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -10,4 +10,13 @@ export const DEFAULT_LAYERS = {
 
 export const DEFAULT_SEPARATORS = [':', '-']
 
-export const DEFAULT_UNSORTED_PSEUDO_ELEMENTS = []
+export const DEFAULT_UNSORTED_PSEUDO_ELEMENTS = [
+  '::-webkit-resizer',
+  '::-webkit-scrollbar',
+  '::-webkit-scrollbar-button',
+  '::-webkit-scrollbar-corner',
+  '::-webkit-scrollbar-thumb',
+  '::-webkit-scrollbar-track',
+  '::-webkit-scrollbar-track-piece',
+  '::file-selector-button',
+]

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -368,7 +368,7 @@ export class UnoGenerator<Theme extends {} = {}> {
         variantContextResult.prefix,
         variantContextResult.selector,
         variantContextResult.pseudo,
-      ].join('')),
+      ].join(''), this.config.unsortedPseudoElements ?? []),
       entries: variantContextResult.entries,
       parent,
       layer: variantContextResult.layer,
@@ -647,11 +647,17 @@ function applyScope(css: string, scope?: string) {
     return scope ? `${scope} ${css}` : css
 }
 
-export function movePseudoElementsEnd(selector: string) {
+export function movePseudoElementsEnd(selector: string, excludedPseudo: string[] = []) {
   const pseudoElements = selector.match(/::[\w-]+(\([\w-]+\))?/g)
   if (pseudoElements) {
-    for (const e of pseudoElements)
+    for (let i = pseudoElements.length - 1; i >= 0; --i) {
+      const e = pseudoElements[i]
+      if (excludedPseudo.includes(e)) {
+        pseudoElements.splice(i, 1)
+        continue
+      }
       selector = selector.replace(e, '')
+    }
     selector += pseudoElements.join('')
   }
   return selector

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -407,6 +407,11 @@ export interface ConfigBase<Theme extends {} = {}> {
    * @default false
    */
   details?: boolean
+
+  /**
+   * Excluded pseudo elements when moving to the end of selector
+   */
+  unsortedPseudoElements?: string[]
 }
 
 export type AutoCompleteTemplate = string

--- a/test/__snapshots__/order.test.ts.snap
+++ b/test/__snapshots__/order.test.ts.snap
@@ -12,6 +12,8 @@ exports[`order > fully controlled rules merged and sorted by body 1`] = `
 
 exports[`order > movePseudoElementsEnd 1`] = `".part-\\\\[hello-2\\\\]\\\\:marker\\\\:file\\\\:hover\\\\:selection\\\\:mb-4:hover::part(hello-2)::marker::file-selector-button::selection"`;
 
+exports[`order > movePseudoElementsEnd with exception 1`] = `".part-\\\\[hello-2\\\\]\\\\:marker\\\\:file\\\\:hover\\\\:selection\\\\:mb-4::file-selector-button:hover::part(hello-2)::marker::selection"`;
+
 exports[`order > multiple variant sorting 1`] = `
 "/* layer: default */
 .dark .group:hover:focus-within .dark\\\\:group-hover\\\\:group-focus-within\\\\:bg-blue-600{--un-bg-opacity:1;background-color:rgba(37,99,235,var(--un-bg-opacity));}

--- a/test/order.test.ts
+++ b/test/order.test.ts
@@ -114,6 +114,13 @@ describe('order', () => {
       .toMatchSnapshot()
   })
 
+  test('movePseudoElementsEnd with exception', () => {
+    expect(movePseudoElementsEnd('.part-\\[hello-2\\]\\:marker\\:file\\:hover\\:selection\\:mb-4::part(hello-2)::marker::file-selector-button:hover::selection', [
+      '::file-selector-button',
+    ]))
+      .toMatchSnapshot()
+  })
+
   test('variant sorting', async () => {
     const uno = createGenerator({
       rules: [


### PR DESCRIPTION
Preventive addition as in https://github.com/tailwindlabs/tailwindcss/issues/9977

The list of pseudo is pseudo elements (PE) that can be styled with pseudo classes (PC). 

By moving the PE at the end, the PE could not be styled via PC. This PR add support for specifying which PE that should not be moved around.

Tagged as breaking due to the default values added, which may shuffle the listed pseudo elements around

Edit: alternative to #2190