### PR TITLE
feat(preset-mini): add backdrop-element-x pseudo for attributify use

### DIFF
--- a/packages/preset-mini/src/_variants/pseudo.ts
+++ b/packages/preset-mini/src/_variants/pseudo.ts
@@ -54,6 +54,7 @@ const PseudoClasses: Record<string, string> = Object.fromEntries([
   'only-of-type',
 
   // pseudo elements part 2
+  ['backdrop-element', '::backdrop'],
   ['placeholder', '::placeholder'],
   ['before', '::before'],
   ['after', '::after'],

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -96,6 +96,7 @@ Set {
   "[px-4=\\"\\"]",
   "[text-true-gray-800=\\"\\"]",
   "[un-placeholder~=\\"text-red\\"]",
+  "[backdrop-element~=\\"filter\\"]",
   "[absolute=\\"\\"]",
   "[leading-1rem=\\"\\"]",
   "[left-4=\\"\\"]",
@@ -271,6 +272,7 @@ exports[`attributify > fixture2 1`] = `
 [un-placeholder~=\\"text-red\\"]::placeholder{--un-text-opacity:1;color:rgba(248,113,113,var(--un-text-opacity));}
 [group=\\"\\"]:hover [group-hover~=\\"op-50\\"]{opacity:0.5;}
 [op-20=\\"\\"]{opacity:0.2;}
+[backdrop-element~=\\"filter\\"]::backdrop{filter:var(--un-blur) var(--un-brightness) var(--un-contrast) var(--un-drop-shadow) var(--un-grayscale) var(--un-hue-rotate) var(--un-invert) var(--un-saturate) var(--un-sepia);}
 [all\\\\:transition-400=\\"\\"] *{transition-property:color,background-color,border-color,outline-color,text-decoration-color,fill,stroke,opacity,box-shadow,transform,filter,backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:400ms;}
 [transition~=\\"\\\\32 00\\"]{transition-property:color,background-color,border-color,outline-color,text-decoration-color,fill,stroke,opacity,box-shadow,transform,filter,backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:200ms;}
 [after~=\\"content-\\\\[string\\\\:\\\\!\\\\]\\"]::after{content:!;}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -533,6 +533,7 @@ unocss .scope-\\\\[unocss\\\\]\\\\:block{display:block;}
 .font-oblique,
 .oblique{font-style:oblique;}
 .antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-smoothing:grayscale;}
+.backdrop-element\\\\:shadow-green-100::backdrop{--un-shadow-opacity:1;--un-shadow-color:rgba(220,252,231,var(--un-shadow-opacity));}
 .backdrop\\\\:shadow-green::backdrop{--un-shadow-opacity:1;--un-shadow-color:rgba(74,222,128,var(--un-shadow-opacity));}
 .shadow{--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 var(--un-shadow-color, rgba(0,0,0,0.1)),var(--un-shadow-inset) 0 1px 2px -1px var(--un-shadow-color, rgba(0,0,0,0.1));box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}
 .shadow-\\\\[0px_4px_4px_0px_rgba\\\\(237\\\\,_0\\\\,_0\\\\,_1\\\\)\\\\]{--un-shadow:0px 4px 4px 0px var(--un-shadow-color, rgba(237,0,0,1));box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -984,6 +984,7 @@ export const presetMiniTargets: string[] = [
   'file:bg-violet-50',
   'hover:file:bg-violet-100',
   'backdrop:shadow-green',
+  'backdrop-element:shadow-green-100',
 
   // variants - pseudo classes
   'rtl:text-right',

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -67,7 +67,7 @@ describe('attributify', () => {
   </div>
   <div flex>
     <div ma inline-flex relative h-14>
-      <input type="text" m-0 pt-4 px-4 text-true-gray-800 peer placeholder="unocss" un-placeholder="text-red">
+      <input type="text" m-0 pt-4 px-4 text-true-gray-800 peer placeholder="unocss" un-placeholder="text-red" backdrop-element="filter">
       <label absolute leading-1rem left-4 pointer-events-none text-gray-7 top="1/3" transition="200 linear"
         peer-not-placeholder-shown="-translate-y-4 scale-75 origin-top-left text-green-500"
         peer-focus="-translate-y-4 scale-75 origin-top-left text-green-500"


### PR DESCRIPTION
Since `backdrop-x` pseudo variant is by default colon-only to prevent clashes with `backdrop-x` rule, this PR introduces `backdrop-element-x` with (default) support for colon and dashses separator, thus enabling the variant to be used in attributify mode.

The syntax is choosen due the nature of backdrop as pseudo element. The thinking was if some pseudo class were to be introduced with clashing rule name, it would then be added as `<pseudo>-class-x` to accompany `<pseudo>-element-x`