### PR TITLE
fix(unocss): `perset-wind` => `preset-wind` typo fix

### DIFF
--- a/packages/unocss/preset-wind.d.ts
+++ b/packages/unocss/preset-wind.d.ts
@@ -1,2 +1,2 @@
-export * from './dist/perset-wind'
-export { default } from './dist/perset-wind'
+export * from './dist/preset-wind'
+export { default } from './dist/preset-wind'


### PR DESCRIPTION
To fix type definitions when importing `preset-wind` like:

```ts
import PresetWind from "unocss/preset-wind";
```