### PR TITLE
fix(vscode): properly highlight attributify value

### DIFF
--- a/packages/shared-common/src/index.ts
+++ b/packages/shared-common/src/index.ts
@@ -148,7 +148,9 @@ export function getMatchedPositions(code: string, matched: string[], hasVariantG
       .forEach((match) => {
         const escaped = match[1]
         const body = match[0].slice(escaped.length)
-        const bodyIndex = body.indexOf(value)
+        let bodyIndex = body.match(`[\\b\\s'"]${escapeRegExp(value)}[\\b\\s'"]`)?.index ?? -1
+        if (body[bodyIndex].match(/[\s'"]/))
+          bodyIndex++
         if (bodyIndex < 0)
           return
         const start = match.index! + escaped.length + bodyIndex

--- a/test/pos.test.ts
+++ b/test/pos.test.ts
@@ -45,6 +45,36 @@ describe('matched-positions', async () => {
       `)
   })
 
+  test('attributify position', async () => {
+    const uno = createGenerator({
+      presets: [
+        presetAttributify({ strict: true }),
+        presetUno({ attributifyPseudo: true }),
+      ],
+      theme: {
+        colors: {
+          bb: 'black',
+        },
+      },
+    })
+
+    expect(await match(uno, '<div border="bb b"></div>'))
+      .toMatchInlineSnapshot(`
+        [
+          [
+            13,
+            15,
+            "[border=\\"bb\\"]",
+          ],
+          [
+            16,
+            17,
+            "[border=\\"b\\"]",
+          ],
+        ]
+      `)
+  })
+
   test('css-directive', async () => {
     const uno = createGenerator({
       presets: [


### PR DESCRIPTION
`base`'s `b` is highlighted twice. Also visible in [playground](https://uno.antfu.me/play/?html=DwEwlgbgBARg9gJxAUwQXgEQxrDA%2BIA&config=JYWwDg9gTgLgBAbzgEwKYDNgDtUGEJaYDmANHGFKgM6owCCMMUwARgK4zDoCeZF1tAJIBjAlT6UaMAKpYIcAL5x0UCCDgByNnOFUqGgFAHUAD0iwUGAIZsANvDSYc%2BQsCIAKBAbhwYAC1QQVAAuRG8fOFFbaCpQrwiIlhZQjRZbK2EAaw0ScJ8FXPzCuCg7alCAbQqNYTYqGDUAWlLbVBzESIhoqBTKZA1FAF1B4v4pWLgKvPJJWlkIdwBKYp8x2gYmVg4ubiWVmYEYETFPaZ8qYStW0IBGADoAJn2fYWQsFL9GMFiAeh-qEB3Kh%2BH45aYKZbhEYGCEGIA&options=N4IgLgTghgdgzgMwPYQLYgFwKgGzgUwBoQJ84AHJeASwDd9NIBXIkAd2oBMwALTAdgAcARmI981AOY8wAgEwA2AL5A)

![image](https://user-images.githubusercontent.com/19991745/218284933-b99628c5-2f6b-4b64-be03-d8cf2ac9d1b3.png)
