### PR TITLE
refactor(preset-attributify): improve element extractor

### DIFF
--- a/packages/preset-attributify/src/extractor.ts
+++ b/packages/preset-attributify/src/extractor.ts
@@ -8,7 +8,7 @@ const strippedPrefixes = [
 ]
 
 const splitterRE = /[\s'"`;]+/g
-const elementRE = /<\w(?=.*>)[\w:\.$-]*\s((?:['"`\{].*?['"`\}]|.*?)*?)(?:>|\Z)/gs
+const elementRE = /<[^>\s]*\s((?:'.*?'|".*?"|`.*?`|\{.*?\}|[^>]*?)*)/gs
 const valuedAttributeRE = /([?]|(?!\d|-{2}|-\d)[a-zA-Z0-9\u00A0-\uFFFF-_:!%-.]+)=?(?:["]([^"]*)["]|[']([^']*)[']|[{]([^}]*)[}])?/gms
 
 export const defaultIgnoreAttributes = ['placeholder', 'fill', 'opacity']
@@ -22,7 +22,6 @@ export const extractorAttributify = (options?: AttributifyOptions): Extractor =>
     name: 'attributify',
     extract({ code }) {
       const result = Array.from(code.matchAll(elementRE))
-        .filter(match => match[0].endsWith('>'))
         .flatMap(match => Array.from((match[1] || '').matchAll(valuedAttributeRE)))
         .flatMap(([, name, ...contents]) => {
           const content = contents.filter(Boolean).join('')

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -66,6 +66,7 @@ Set {
   "[all:transition-400=\\"\\"]",
   "[type~=\\"checkbox\\"]",
   "[peer=\\"\\"]",
+  "<md:color-red",
   "[mt-a=\\"\\"]",
   "[mb-a=\\"\\"]",
   "[group=\\"\\"]",

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -49,7 +49,7 @@ describe('attributify', () => {
   const fixture2 = `
 <template>
   <div h-80 text-center flex flex-col align-center select-none all:transition-400>
-    <input type="checkbox" peer mt-a>
+    <input type="checkbox" peer placeholder=">" class="<md:color-red" mt-a>
     <div mb-a group peer-checked="text-4xl">
       <div
         font-100 text-4xl mb--3 p-10


### PR DESCRIPTION
Fixes #1584
Fixes #2112
Supersedes #2134

@chu121su12 I tried pasting [your code](https://github.com/unocss/unocss/issues/2067#issuecomment-1396298585) on playground and it was slowing down the editor. Every key store was taking 3-4 seconds on my machine. With this PR it seems instant as it should be. 

I also tested this PR with the provided repro in #2067, and it successfully builds.