### PR TITLE
fix(vite): misplaced semicolon

### DIFF
--- a/packages/vite/src/modes/global/dev.ts
+++ b/packages/vite/src/modes/global/dev.ts
@@ -153,7 +153,7 @@ export function GlobalModeDevPlugin({ uno, tokens, tasks, flushTasks, affectedMo
 
         const { hash, css } = await generateCSS(layer)
         // add hash to the chunk of CSS that it will send back to client to check if there is new CSS generated
-        return `__uno_hash_${hash}{--:''};${css}`
+        return `__uno_hash_${hash}{--:'';}${css}`
       },
     },
     {


### PR DESCRIPTION
A misplaced semicolon has been introduced somewhere between 0.49.1 and 0.49.6, which produces invalid `<style>` and breaks whatever selector comes first in the CSS (in my case it breaks a preflight).

This PR moves the semicolon inside `{}` where it probably was supposed to be.