### PR TITLE
fix(nuxt): disable cssnano `normalizeWhitespace` optimization

### DIFF
--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -68,7 +68,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
       const preset = nuxt.options.postcss.plugins.cssnano.preset
       nuxt.options.postcss.plugins.cssnano = {
         preset: [preset?.[0] || 'default', Object.assign(
-          preset?.[1] || {}, { mergeRules: false },
+          preset?.[1] || {}, { mergeRules: false, normalizeWhitespace: false },
         )],
       }
     }


### PR DESCRIPTION
Related #2227

Fixes this case:

```vue
<template>
  <div class="flex flex-col gap-4">
    <div class="test1">
      .test1
    </div>
    <div class="test2">
      .test2
    </div>
  </div>
</template>

<style>
.test1 {
  @apply bg-slate-200;
  @apply text-center;
}

.test2 {
  @apply text-center;
  @apply bg-slate-200;
}
</style>

```