### PR TITLE
fix(vite): resolve relative path in rollupOptions

### DIFF
--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path'
+import { isAbsolute, resolve } from 'path'
 import type { Plugin, ResolvedConfig } from 'vite'
 import type { GenerateResult, UnocssPluginContext } from '@unocss/core'
 import type { PluginContext } from 'rollup'
@@ -116,20 +116,12 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
         // for Vite lib more with rollupOptions.output, #2231
         if (config.build.rollupOptions.output) {
           const outputOptions = config.build.rollupOptions.output
-          if (Array.isArray(outputOptions)) {
-            distDirs.push(
-              ...outputOptions.map(option => option.dir).filter(Boolean) as string[],
-            )
-            distDirs.push(
-              ...outputOptions.map(option => option.dir ? resolve(config.root, option.dir) : '').filter(Boolean) as string[],
-            )
-          }
-          else {
-            if (outputOptions.dir) {
-              distDirs.push(outputOptions.dir)
-              distDirs.push(resolve(config.root, outputOptions.dir))
-            }
-          }
+          const outputDirs = Array.isArray(outputOptions)
+            ? outputOptions.map(option => option.dir).filter(Boolean) as string[]
+            : outputOptions.dir
+              ? [outputOptions.dir]
+              : []
+          distDirs.push(...outputDirs.map(dir => isAbsolute(dir) ? dir : resolve(config.root, dir)))
         }
 
         const cssPostPlugin = config.plugins.find(i => i.name === 'vite:css-post')

--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -120,10 +120,15 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
             distDirs.push(
               ...outputOptions.map(option => option.dir).filter(Boolean) as string[],
             )
+            distDirs.push(
+              ...outputOptions.map(option => option.dir ? resolve(config.root, option.dir) : '').filter(Boolean) as string[],
+            )
           }
           else {
-            if (outputOptions.dir)
+            if (outputOptions.dir) {
               distDirs.push(outputOptions.dir)
+              distDirs.push(resolve(config.root, outputOptions.dir))
+            }
           }
         }
 


### PR DESCRIPTION
When i specify relative dir for rollupOptions output
```
rollupOptions: {
  output: [
    {
        dir: "dist/es"
     }
  ]
}
```
In one project with only .ts files, it resolved to "dist/es".  However, in vue project, it resolved to absolute path "/home/xxx/project/dist/es".

This fix will handle absolute path postcss-plugin matching
