### PR TITLE
fix(vite): resolve relative path in rollupOptions

### DIFF
--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -121,7 +121,13 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
             : outputOptions.dir
               ? [outputOptions.dir]
               : []
-          distDirs.push(...outputDirs.map(dir => isAbsolute(dir) ? dir : resolve(config.root, dir)))
+
+          outputDirs.forEach((dir) => {
+            distDirs.push(dir)
+
+            if (!isAbsolute(dir))
+              distDirs.push(resolve(config.root, dir))
+          })
         }
 
         const cssPostPlugin = config.plugins.find(i => i.name === 'vite:css-post')


### PR DESCRIPTION
`options.dir` passed to `renderChunk()` function is inconsistent, sometimes it's relative, sometimes it's absolute, so needs to put both relative and absolute paths in plugins map.  eg.

```
dir: 'dist/es'
```
becomes
```
cssPlugins: Map(2){
  'dist/es' => vite:css-post plugin,
  '/home/xxx/project/dist/es' => vite:css-post plugin
}
```