### PR TITLE
refactor(postcss): perf and stability improvements

### DIFF
--- a/packages/postcss/src/apply.ts
+++ b/packages/postcss/src/apply.ts
@@ -7,7 +7,7 @@ import { expandVariantGroup, notNull, regexScopePlaceholder } from '@unocss/core
 
 type Writeable<T> = { -readonly [P in keyof T]: T[P] }
 
-export function parseApply(root: Root, uno: UnoGenerator, directiveName: string) {
+export async function parseApply(root: Root, uno: UnoGenerator, directiveName: string) {
   // @ts-expect-error types doesn't allow async callback but it seems work
   root.walkAtRules(directiveName, async (rule) => {
     if (!rule.parent)

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -91,9 +91,9 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
           uno = createGenerator(cfg.config)
           last_config_mtime = config_mtime
         }
-        else {
+
+        if (!uno)
           uno = createGenerator((await loadConfig(cwd, configOrPath)).config)
-        }
 
         if (!Object.keys(cfg.config).length)
           throw new Error('UnoCSS config file not found.')

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -40,7 +40,7 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
   let promises: Promise<void>[] = []
 
   return {
-    postcssPlugin: unocss,
+    postcssPlugin: directiveMap.unocss,
     plugins: [
       async function (root: Root, result: Result) {
         if (!result.opts.from?.split('?')[0].endsWith('.css'))

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -89,7 +89,7 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
           if (!uno) {
             uno = createGenerator(cfg.config)
           }
-          else {
+          else if (cfg.sources.length) {
             const config_mtime = (await stat(cfg.sources[0])).mtimeMs
             if (config_mtime > last_config_mtime) {
               uno = createGenerator((await loadConfig(cwd, configOrPath)).config)

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -102,7 +102,7 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
         promises.push(
           ...rawContent.map(async (v) => {
             const { matched } = await uno.generate(v.raw, {
-              id: `unocss${v.extension}`,
+              id: `unocss.${v.extension}`,
             })
 
             for (const candidate of matched)

--- a/packages/postcss/src/screen.ts
+++ b/packages/postcss/src/screen.ts
@@ -3,7 +3,7 @@ import type { Root } from 'postcss'
 
 import type { Theme } from '@unocss/preset-mini'
 
-export function parseScreen(root: Root, uno: UnoGenerator, directiveName: string) {
+export async function parseScreen(root: Root, uno: UnoGenerator, directiveName: string) {
   // @ts-expect-error types
   root.walkAtRules(directiveName, async (rule) => {
     let breakpointName = ''

--- a/packages/postcss/src/theme.ts
+++ b/packages/postcss/src/theme.ts
@@ -2,10 +2,10 @@ import type { UnoGenerator } from '@unocss/core'
 import type { Root } from 'postcss'
 import MagicString from 'magic-string'
 
-export function parseTheme(root: Root, uno: UnoGenerator, directiveName: string) {
-  const themeFnRE = new RegExp(`${directiveName}\\((.*?)\\)`, 'g')
+export const themeFnRE = (directiveName: string) => new RegExp(`${directiveName}\\((.*?)\\)`, 'g')
+export async function parseTheme(root: Root, uno: UnoGenerator, directiveName: string) {
   root.walkDecls((decl) => {
-    const matches = Array.from(decl.value.matchAll(themeFnRE))
+    const matches = Array.from(decl.value.matchAll(themeFnRE(directiveName)))
 
     if (!matches.length)
       return

--- a/packages/postcss/src/types.ts
+++ b/packages/postcss/src/types.ts
@@ -9,6 +9,7 @@ export interface UnoPostcssPluginOptions {
     apply: string
     screen: string
     theme: string
+    unocss: string
   }
   cwd?: string
   configOrPath?: string | UserConfig


### PR DESCRIPTION
- fixes an issue that sometimes caused new styles to not appear
- prevents running on unrelated CSS files
- allows customizing `unocss` at-rule and plugin name. this is useful if you want to have separate CSS files and uno configs for different routes, for example, marketing site and dashboard.