### PR TITLE
fix(cli): config path is different with unconfig path

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,6 @@
     "consola": "^2.15.3",
     "fast-glob": "^3.2.12",
     "magic-string": "^0.30.0",
-    "pathe": "^1.1.0",
     "perfect-debounce": "^0.1.3"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,6 +54,7 @@
     "consola": "^2.15.3",
     "fast-glob": "^3.2.12",
     "magic-string": "^0.30.0",
+    "pathe": "^1.1.0",
     "perfect-debounce": "^0.1.3"
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 import { existsSync, promises as fs } from 'fs'
-import { basename, dirname, relative, resolve } from 'path'
+import { basename, dirname, normalize, relative, resolve } from 'pathe'
 import fg from 'fast-glob'
 import consola from 'consola'
 import { cyan, dim, green } from 'colorette'
@@ -74,7 +74,7 @@ export async function build(_options: CliOptions) {
       watcher.add(configSources)
 
     watcher.on('all', async (type, file) => {
-      const absolutePath = resolve(cwd, file)
+      const absolutePath = normalize(resolve(cwd, file))
 
       if (configSources.includes(absolutePath)) {
         await ctx.reloadConfig()

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,7 +33,7 @@ export async function build(_options: CliOptions) {
 
   async function loadConfig() {
     const ctx = createContext<UserConfig>(options.config, defaultConfig)
-    const configSources = (await ctx.updateRoot(cwd)).sources
+    const configSources = (await ctx.updateRoot(cwd)).sources.map(i => normalize(i))
     return { ctx, configSources }
   }
 
@@ -76,7 +76,7 @@ export async function build(_options: CliOptions) {
     watcher.on('all', async (type, file) => {
       const absolutePath = resolve(cwd, file)
 
-      if (configSources.includes(normalize(absolutePath))) {
+      if (configSources.includes(absolutePath)) {
         await ctx.reloadConfig()
         consola.info(`${cyan(basename(file))} changed, setting new config`)
       }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 import { existsSync, promises as fs } from 'fs'
-import { basename, dirname, relative, resolve } from 'pathe'
+import { basename, dirname, relative, resolve } from 'path'
 import fg from 'fast-glob'
 import consola from 'consola'
 import { cyan, dim, green } from 'colorette'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -74,9 +74,9 @@ export async function build(_options: CliOptions) {
       watcher.add(configSources)
 
     watcher.on('all', async (type, file) => {
-      const absolutePath = normalize(resolve(cwd, file))
+      const absolutePath = resolve(cwd, file)
 
-      if (configSources.includes(absolutePath)) {
+      if (configSources.includes(normalize(absolutePath))) {
         await ctx.reloadConfig()
         consola.info(`${cyan(basename(file))} changed, setting new config`)
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,7 @@ importers:
       consola: ^2.15.3
       fast-glob: ^3.2.12
       magic-string: ^0.27.0
+      pathe: ^1.1.0
       perfect-debounce: ^0.1.3
     dependencies:
       '@ampproject/remapping': 2.2.0
@@ -343,6 +344,7 @@ importers:
       consola: 2.15.3
       fast-glob: 3.2.12
       magic-string: 0.27.0
+      pathe: 1.1.0
       perfect-debounce: 0.1.3
 
   packages/config:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,7 @@ importers:
       simple-git-hooks: 2.8.1
       splitpanes: 3.1.5
       terser: 5.16.4
-      tsup: 6.6.3_typescript@4.9.5
+      tsup: 6.6.3_uujdqti2krmttzhqvubwnsmcci
       typescript: 4.9.5
       unbuild: 0.8.11
       unocss: link:packages/unocss
@@ -330,7 +330,6 @@ importers:
       consola: ^2.15.3
       fast-glob: ^3.2.12
       magic-string: ^0.27.0
-      pathe: ^1.1.0
       perfect-debounce: ^0.1.3
     dependencies:
       '@ampproject/remapping': 2.2.0
@@ -344,7 +343,6 @@ importers:
       consola: 2.15.3
       fast-glob: 3.2.12
       magic-string: 0.27.0
-      pathe: 1.1.0
       perfect-debounce: 0.1.3
 
   packages/config:
@@ -4424,7 +4422,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/plugin-transform-typescript': 7.20.2_@babel+core@7.20.12
       '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.20.12
-      vite: 4.1.4
+      vite: 4.1.4_afytg7t7cxnbgu4qby33jri5ia
       vue: 3.2.47
     transitivePeerDependencies:
       - supports-color
@@ -4437,7 +4435,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.1.4
+      vite: 4.1.4_afytg7t7cxnbgu4qby33jri5ia
       vue: 3.2.47
     dev: true
 
@@ -18063,7 +18061,7 @@ packages:
       - ts-node
     dev: true
 
-  /tsup/6.6.3_typescript@4.9.5:
+  /tsup/6.6.3_uujdqti2krmttzhqvubwnsmcci:
     resolution: {integrity: sha512-OLx/jFllYlVeZQ7sCHBuRVEQBBa1tFbouoc/gbYakyipjVQdWy/iQOvmExUA/ewap9iQ7tbJf9pW0PgcEFfJcQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -18087,7 +18085,8 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 3.1.4
+      postcss: 8.4.21
+      postcss-load-config: 3.1.4_postcss@8.4.21
       resolve-from: 5.0.0
       rollup: 3.15.0
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
fixed: #2275 
In `@unocss/cli`, the configuration path using `pathe.resolve`, which results is `c:\\xxx\\xxx\\unocss.config.ts` on windows

https://github.com/unocss/unocss/blob/217998afa71bba40a2d38aefb12158643c3776c7/packages/cli/src/index.ts#L2
https://github.com/unocss/unocss/blob/217998afa71bba40a2d38aefb12158643c3776c7/packages/cli/src/index.ts#L76-L83

But In `unconfig`, the configuration path using `path.resolve`, which result does not contain the escape character——`\` on windows
https://github.com/antfu/unconfig/blob/fd0baca5f39b8feb087339dfc6d65918550bdc61/src/fs.ts#L2
https://github.com/antfu/unconfig/blob/fd0baca5f39b8feb087339dfc6d65918550bdc61/src/fs.ts#L49-L53