### PR TITLE
fix(nuxt): disable cssnano `discardComments` optimization

### DIFF
--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -64,13 +64,14 @@ export default defineNuxtModule<UnocssNuxtOptions>({
 
     if (
       isNuxt3()
+      && nuxt.options.builder === '@nuxt/vite-builder'
       && nuxt.options.postcss.plugins.cssnano
       && unoConfig.transformers?.some(t => t.name === '@unocss/transformer-directives' && t.enforce !== 'pre')
     ) {
       const preset = nuxt.options.postcss.plugins.cssnano.preset
       nuxt.options.postcss.plugins.cssnano = {
         preset: [preset?.[0] || 'default', Object.assign(
-          preset?.[1] || {}, { mergeRules: false, normalizeWhitespace: false },
+          preset?.[1] || {}, { mergeRules: false, normalizeWhitespace: false, discardComments: false },
         )],
       }
     }


### PR DESCRIPTION
Fixes #2279

### Context
In modern browsers there is no difference between `--foo:;` and `--foo: ;`. But on older browsers [this is an issue.](https://github.com/sveltejs/svelte/issues/7288#issuecomment-1046039821)

### About solution
In Vite, comments will be discarded by esbuild anyway. On Webpack, `transformerDirectives` is only supported with `enforce: pre`, so we will never hit this line.

### Alternative solutions
- Fix cssnano: https://github.com/cssnano/cssnano/tree/master/packages/postcss-discard-comments

- Rerun [postcss-normalize-whitespace](https://github.com/cssnano/cssnano/tree/master/packages/postcss-normalize-whitespace) after `cssnano`. Requires changes on Nuxt repo. We will only add the following code on our nuxt module. Then update [this file](https://github.com/nuxt/nuxt/blob/main/packages/vite/src/css.ts) on Nuxt side. All we need to sure `postcss-normalize-whitespace` runs after `cssnano`.
```ts
Object.assign(nuxt.options.postcss.plugins, { 'postcss-normalize-whitespace': {} })
```



