### PR TITLE
fix(postcss): add a `default` reference to itself

### DIFF
--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -199,5 +199,6 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
 }
 
 unocss.postcss = true
+unocss.default = unocss
 
 export default unocss


### PR DESCRIPTION
For some reason Typescript doesn't pick up the default type when importing like that:

```ts
const unocss = require("@unocss/postcss")
//         ^ any 
```

Typescript inference works right with that but this is undefined:
```ts
const unocss = require("@unocss/postcss").default
```

Fixing that by adding a circular reference to itself. 

### Why we can't drop `default` export and just use named exports?

Because PostCSS plugins can be provided with the package name, and this will do `require(package-name)` internally.
```ts
  plugins: {
    '@unocss/postcss': {},
  },
```