### PR TITLE
fix(webpack): resolve path from id with decodeURIComponent

### DIFF
--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -144,7 +144,7 @@ export default function WebpackPlugin<Theme extends {}>(
       lastTokenSize = tokens.size
       Array.from(plugin.__vfsModules)
         .forEach((id) => {
-          const path = id.slice(plugin.__virtualModulePrefix.length).replace(/\\/g, '/')
+          const path = decodeURIComponent(id.slice(plugin.__virtualModulePrefix.length))
           const layer = resolveLayer(path)
           if (!layer)
             return


### PR DESCRIPTION
Unplugin will encode resolved path since [0.9.0](https://github.com/unjs/unplugin/commit/335f403bfba35bee4e251493824786ae1689a9e7).