### PR TITLE
fix(playground): display the right panel size

### DIFF
--- a/playground/src/composables/panel.ts
+++ b/playground/src/composables/panel.ts
@@ -63,6 +63,7 @@ export function normalizePanels() {
 watch(
   titleHeightPercent,
   (value: number) => {
-    panelSizes.value = getInitialPanelSizes(value)
+    if (panelSizes.value.includes(100))
+      panelSizes.value = getInitialPanelSizes(value)
   },
 )

--- a/playground/src/composables/panel.ts
+++ b/playground/src/composables/panel.ts
@@ -16,7 +16,7 @@ export const panelSizes = useLocalStorage<number[]>(
 
 export function getInitialPanelSizes(percent: number): number[] {
   return [
-    percent,
+    100 - percent * 3,
     percent,
     percent,
     percent,


### PR DESCRIPTION
Fixed not open any panel when first open, and use storage cache sizes.