### PR TITLE
feat(vscode): support `rust` as a language id

### DIFF
--- a/packages/vscode/src/autocomplete.ts
+++ b/packages/vscode/src/autocomplete.ts
@@ -30,6 +30,7 @@ const languageIds = [
   'less',
   'stylus',
   'astro',
+  'rust',
 ]
 const delimiters = ['-', ':']
 


### PR DESCRIPTION
This will allow `unocss` to be used in frameworks like `yew` and [`leptos`](https://github.com/leptos-rs/leptos).