### PR TITLE
fix(postcss): normalize dependency paths

### DIFF
--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -1,4 +1,5 @@
 import { readFile, stat } from 'node:fs/promises'
+import { normalize } from 'node:path'
 import type { UnoGenerator } from '@unocss/core'
 import fg from 'fast-glob'
 import type { Result, Root } from 'postcss'
@@ -140,7 +141,7 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
             result.messages.push({
               type: 'dependency',
               plugin: directiveMap.unocss,
-              file,
+              file: normalize(file),
               parent: result.opts.from,
             })
 


### PR DESCRIPTION
Webpack considers Windows paths with forward slashes as invalid:

https://github.com/webpack/webpack/blob/4ba225225b1348c8776ca5b5fe53468519413bc0/lib/NormalModule.js#L93