### PR TITLE
feat(core): support candidates ending with `:`

### DIFF
--- a/packages/core/src/extractors/split.ts
+++ b/packages/core/src/extractors/split.ts
@@ -20,6 +20,7 @@ export const splitCode = (code: string) => {
     result.add(match[0])
 
   code.split(defaultSplitRE).forEach((match) => {
+    match = match.replace(/:$/, '')
     isValidSelector(match) && !arbitraryPropertyCandidateRE.test(match) && result.add(match)
   })
 

--- a/packages/shared-common/src/index.ts
+++ b/packages/shared-common/src/index.ts
@@ -113,6 +113,7 @@ export function getMatchedPositions(code: string, matched: string[], hasVariantG
   // highlight for plain classes
   let start = 0
   code.split(/([\s"'`;<>*]|:\(|\)"|\)\s)/g).forEach((i) => {
+    i = i.replace(/:$/, '')
     const end = start + i.length
     if (isPug) {
       result.push(...getPlainClassMatchedPositionsForPug(i, plain, start))

--- a/test/__snapshots__/custom-raw.test.ts.snap
+++ b/test/__snapshots__/custom-raw.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`custom-raw > basic 1`] = `
 "/* layer: default */

--- a/test/__snapshots__/emojis.test.ts.snap
+++ b/test/__snapshots__/emojis.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`emojis > extractor1 1`] = `
 Set {

--- a/test/__snapshots__/layer.test.ts.snap
+++ b/test/__snapshots__/layer.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`layers > static 1`] = `
 "/* layer: shortcuts */

--- a/test/__snapshots__/order.test.ts.snap
+++ b/test/__snapshots__/order.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`order > fully controlled rules merged and sorted by body 1`] = `
 "/* layer: default */

--- a/test/__snapshots__/parser.test.ts.snap
+++ b/test/__snapshots__/parser.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`split string with custom separator 1`] = `
 "/* layer: default */

--- a/test/__snapshots__/postcss.test.ts.snap
+++ b/test/__snapshots__/postcss.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`postcss > @apply 1`] = `"div{--un-bg-opacity:1;background-color:rgba(248,113,113,var(--un-bg-opacity));}div:hover{--un-text-opacity:1;color:rgba(255,255,255,var(--un-text-opacity));}.dark div>:focus:hover{font-size:20px;}"`;
 

--- a/test/__snapshots__/postprocess.test.ts.snap
+++ b/test/__snapshots__/postprocess.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`postprocess 1`] = `
 "/* layer: default */

--- a/test/__snapshots__/preflights.test.ts.snap
+++ b/test/__snapshots__/preflights.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`preflights > basic 1`] = `
 "/* layer: preflights */

--- a/test/__snapshots__/scope.test.ts.snap
+++ b/test/__snapshots__/scope.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`scope 1`] = `
 "/* layer: default */

--- a/test/__snapshots__/selector-no-merge.test.ts.snap
+++ b/test/__snapshots__/selector-no-merge.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`selector > rules split selector 1`] = `
 "/* layer: default */

--- a/test/__snapshots__/transformer-variant-group.test.ts.snap
+++ b/test/__snapshots__/transformer-variant-group.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`transformer-variant-group > basic > "!hover:(m-2 p-2)" 1`] = `"!hover:m-2 !hover:p-2"`;
 

--- a/test/__snapshots__/variant-handler.test.ts.snap
+++ b/test/__snapshots__/variant-handler.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`variants > noMerge on variant 1`] = `
 "/* layer: default */

--- a/test/extractor.test.ts
+++ b/test/extractor.test.ts
@@ -10,6 +10,7 @@ it('extractorSplit', async () => {
   expect(await extract('<div class="text-red border">foo</div>')).toContain('text-red')
   expect(await extract('<div class="<sm:text-lg">foo</div>')).toContain('<sm:text-lg')
   expect(await extract('"class=\"bg-white\""')).toContain('bg-white')
+  expect(await extract('<div :class="{ fixed: isMobile }">')).toContain('fixed')
 })
 
 it('extractorSvelte uses regular split with non .svelte files', async () => {


### PR DESCRIPTION
Fixes #2320

@antfu This is not a regression. We never supported this use case. As you may guess, it will come with some false positives.

Also, can you update snapshots on `main` for cleaner Git history? Thanks.