### PR TITLE
fix(astro): respect Astro's `srcDir` config

### DIFF
--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -43,7 +43,7 @@ export default function UnoCSSAstroIntegration<Theme extends {}>(
         // Adding components to UnoCSS's extra content
         options.extraContent ||= {}
         options.extraContent.filesystem ||= []
-        options.extraContent.filesystem.push(resolve(fileURLToPath(config.root), 'src/components/**/*').replace(/\\/g, '/'))
+        options.extraContent.filesystem.push(resolve(fileURLToPath(config.srcDir), 'components/**/*').replace(/\\/g, '/'))
 
         config.vite.plugins ||= []
         config.vite.plugins.push(...VitePlugin(options, defaults) as any)


### PR DESCRIPTION
This pull request makes UnoCSS's Astro integration respect Astro's [`srcDir`](https://docs.astro.build/en/reference/configuration-reference/#srcdir) option, instead of hard-coded `src`.