### PR TITLE
docs: add note about Astro `client:only` components

### DIFF
--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -46,6 +46,10 @@ export default {
 
 for more details, please refer to the [Vite plugin](../vite).
 
+## Notes
+
+[`client:only`](https://docs.astro.build/en/reference/directives-reference/#clientonly) components must be placed in [`components`](https://docs.astro.build/en/core-concepts/project-structure/#srccomponents) folder or added to UnoCSS's `extraContent` config in order to be processed.
+
 ## License
 
 MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)


### PR DESCRIPTION
I assume my issue in #2325 is a common one, and it's worth a place in the readme.

Help with wording is welcomed.