### PR TITLE
feat(runtime): export built-in presets

### DIFF
--- a/packages/preset-icons/src/core.ts
+++ b/packages/preset-icons/src/core.ts
@@ -6,10 +6,12 @@ import type {
 } from '@iconify/utils/lib/loader/types'
 import { encodeSvgForCss } from '@iconify/utils/lib/svg/encode-svg-for-css'
 import type { IconsOptions } from './types'
+import supportedCollection from './collections.json'
 
 const COLLECTION_NAME_PARTS_MAX = 3
 
 export { IconsOptions }
+export { supportedCollection }
 
 export function createPresetIcons(lookupIconLoader: (options: IconsOptions) => Promise<UniversalIconLoader>) {
   return function presetIcons(options: IconsOptions = {}): Preset {

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -22,7 +22,7 @@ export function normalizedFontMeta(meta: WebFontMeta | string, defaultProvider: 
   }
 }
 
-const providers = {
+export const providers = {
   google: GoogleFontsProvider,
   bunny: BunnyFontsProvider,
   fontshare: FontshareProvider,

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -71,6 +71,25 @@ With `@unocss/preset-mini` and `@unocss/preset-attributify` preset:
 <script src="https://cdn.jsdelivr.net/npm/@unocss/runtime/mini.global.js"></script>
 ```
 
+### Individual Presets
+
+All the official presets from UnoCSS are available and must be loaded before initializing the runtime.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@unocss/runtime/preset-icons.global.js"></script>
+<script>
+  window.__unocss = {
+    presets: [
+      window.__unocss_presets.presetIcons({
+        scale: 1.2,
+        cdn: 'https://esm.sh/'
+      }),
+    ],
+  }
+</script>
+<script src="https://cdn.jsdelivr.net/npm/@unocss/runtime/core.global.js"></script>
+```
+
 ## Bundler Usage
 
 ```bash

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -35,9 +35,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "pnpm run build:node && pnpm run build:cdn",
+    "build": "pnpm run build:node && pnpm run build:cdn && pnpm run build:presets",
     "build:cdn": "tsup src/cdn/*.ts --format iife --minify --out-dir .",
     "build:node": "tsup src/index.ts --format esm,cjs --dts",
+    "build:presets": "tsup src/presets/*.ts --format iife --minify --out-dir .",
     "watch": "tsup src/cdn/*.ts --format iife --watch src --out-dir .",
     "dev": "nr watch & live-server --open=/play"
   },

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -93,6 +93,7 @@ declare global {
   interface Window {
     __unocss?: UserConfig & { runtime?: RuntimeOptions }
     __unocss_runtime?: RuntimeContext
+    __unocss_presets?: Record<string, Function>
   }
 }
 

--- a/packages/runtime/src/presets/preset-attributify.ts
+++ b/packages/runtime/src/presets/preset-attributify.ts
@@ -1,0 +1,8 @@
+import type { AttributifyOptions } from '@unocss/preset-attributify'
+import presetAttributify from '@unocss/preset-attributify'
+
+(() => {
+  window.__unocss_presets = Object.assign(window.__unocss_presets ?? {}, {
+    presetAttributify: (options: AttributifyOptions) => presetAttributify(options),
+  })
+})()

--- a/packages/runtime/src/presets/preset-icons.ts
+++ b/packages/runtime/src/presets/preset-icons.ts
@@ -1,0 +1,58 @@
+import type { IconifyJSON } from '@iconify/types'
+import type { IconsOptions } from '@unocss/preset-icons'
+import type { UniversalIconLoader } from '@iconify/utils'
+import { searchForIcon } from '@iconify/utils/lib/loader/modern'
+import { combineLoaders, createPresetIcons, supportedCollection } from '@unocss/preset-icons'
+import { loadIcon } from '@iconify/utils'
+
+(() => {
+  const $fetch = (url: string) => fetch(url).then(data => data.json())
+
+  function createRuntimeLoader(cdnBase: string): UniversalIconLoader {
+    const cache = new Map<string, Promise<IconifyJSON>>()
+
+    function fetchCollection(name: string) {
+      if (!supportedCollection.includes(name))
+        return undefined
+      if (!cache.has(name))
+        cache.set(name, $fetch(`${cdnBase}@iconify-json/${name}/icons.json`))
+      return cache.get(name)!
+    }
+
+    return async (collection, icon, options) => {
+      let result = await loadIcon(collection, icon, options)
+      if (result)
+        return result
+
+      const iconSet = await fetchCollection(collection)
+      if (iconSet) {
+        // possible icon names
+        const ids = [
+          icon,
+          icon.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase(),
+          icon.replace(/([a-z])(\d+)/g, '$1-$2'),
+        ]
+        result = await searchForIcon(iconSet, collection, ids, options)
+      }
+
+      return result
+    }
+  }
+
+  window.__unocss_presets = Object.assign(window.__unocss_presets ?? {}, {
+    presetIcons: (options: IconsOptions) => createPresetIcons(async (options) => {
+      const {
+        cdn,
+      } = options
+
+      const loaders: UniversalIconLoader[] = []
+
+      if (cdn)
+        loaders.push(createRuntimeLoader(cdn))
+
+      loaders.push(loadIcon)
+
+      return combineLoaders(loaders)
+    })(options),
+  })
+})()

--- a/packages/runtime/src/presets/preset-mini.ts
+++ b/packages/runtime/src/presets/preset-mini.ts
@@ -1,0 +1,8 @@
+import type { PresetMiniOptions } from '@unocss/preset-mini'
+import presetMini from '@unocss/preset-mini'
+
+(() => {
+  window.__unocss_presets = Object.assign(window.__unocss_presets ?? {}, {
+    presetMini: (options: PresetMiniOptions) => presetMini(options),
+  })
+})()

--- a/packages/runtime/src/presets/preset-tagify.ts
+++ b/packages/runtime/src/presets/preset-tagify.ts
@@ -1,0 +1,8 @@
+import type { TagifyOptions } from '@unocss/preset-tagify'
+import presetTagify from '@unocss/preset-tagify'
+
+(() => {
+  window.__unocss_presets = Object.assign(window.__unocss_presets ?? {}, {
+    presetTagify: (options: TagifyOptions) => presetTagify(options),
+  })
+})()

--- a/packages/runtime/src/presets/preset-typography.ts
+++ b/packages/runtime/src/presets/preset-typography.ts
@@ -1,0 +1,8 @@
+import type { TypographyOptions } from '@unocss/preset-typography'
+import presetTypography from '@unocss/preset-typography'
+
+(() => {
+  window.__unocss_presets = Object.assign(window.__unocss_presets ?? {}, {
+    presetTypography: (options: TypographyOptions) => presetTypography(options),
+  })
+})()

--- a/packages/runtime/src/presets/preset-uno.ts
+++ b/packages/runtime/src/presets/preset-uno.ts
@@ -1,0 +1,8 @@
+import type { PresetUnoOptions } from '@unocss/preset-uno'
+import presetUno from '@unocss/preset-uno'
+
+(() => {
+  window.__unocss_presets = Object.assign(window.__unocss_presets ?? {}, {
+    presetUno: (options: PresetUnoOptions) => presetUno(options),
+  })
+})()

--- a/packages/runtime/src/presets/preset-web-fonts.ts
+++ b/packages/runtime/src/presets/preset-web-fonts.ts
@@ -4,7 +4,7 @@ import type { WebFontsOptions } from '@unocss/preset-web-fonts'
 import { normalizedFontMeta, providers } from '@unocss/preset-web-fonts'
 
 (() => {
-  const $fetch = (url: string) => fetch(url).then(data => data.json())
+  const $fetch = (url: string) => fetch(url).then(data => data.text())
 
   const presetWebFonts = (options: WebFontsOptions = {}): Preset<any> => {
     const {

--- a/packages/runtime/src/presets/preset-web-fonts.ts
+++ b/packages/runtime/src/presets/preset-web-fonts.ts
@@ -1,0 +1,94 @@
+import type { Preset } from '@unocss/core'
+import { toArray } from '@unocss/core'
+import type { WebFontsOptions } from '@unocss/preset-web-fonts'
+import { normalizedFontMeta, providers } from '@unocss/preset-web-fonts'
+
+(() => {
+  const $fetch = (url: string) => fetch(url).then(data => data.json())
+
+  const presetWebFonts = (options: WebFontsOptions = {}): Preset<any> => {
+    const {
+      provider: defaultProvider = 'google',
+      extendTheme = true,
+      inlineImports = true,
+      themeKey = 'fontFamily',
+      customFetch,
+    } = options
+
+    const fontObject = Object.fromEntries(
+      Object.entries(options.fonts || {})
+        .map(([name, meta]) => [name, toArray(meta).map(m => normalizedFontMeta(m, defaultProvider))]),
+    )
+    const fonts = Object.values(fontObject).flatMap(i => i)
+
+    const importCache: Record<string, Promise<string>> = {}
+
+    async function importUrl(url: string) {
+      if (inlineImports) {
+        if (!importCache[url]) {
+          const promise = (customFetch || $fetch)(url)
+          importCache[url] = promise.catch((e) => {
+            console.error('Failed to fetch web fonts')
+            console.error(e)
+            if (typeof process !== 'undefined' && process.env.CI)
+              throw e
+          })
+        }
+        return await importCache[url]
+      }
+      else {
+        return `@import url('${url}')`
+      }
+    }
+
+    const preset: Preset<any> = {
+      name: '@unocss/preset-web-fonts',
+      preflights: [
+        {
+          async getCSS() {
+            const names = new Set(fonts.map(i => i.provider || defaultProvider))
+            const preflights: (string | undefined)[] = []
+
+            for (const name of names) {
+              const fontsForProvider = fonts.filter(i => i.provider === name)
+              const provider = providers[name]
+
+              if (provider.getImportUrl) {
+                const url = provider.getImportUrl(fontsForProvider)
+                if (url)
+                  preflights.push(await importUrl(url))
+              }
+
+              preflights.push(provider.getPreflight?.(fontsForProvider))
+            }
+
+            return preflights.filter(Boolean).join('\n')
+          },
+        },
+      ],
+    }
+
+    if (extendTheme) {
+      preset.extendTheme = (theme) => {
+        if (!theme[themeKey])
+          theme[themeKey] = {}
+        const obj = Object.fromEntries(
+          Object.entries(fontObject)
+            .map(([name, fonts]) => [name, fonts.map(f => providers[f.provider || defaultProvider].getFontName(f))]),
+        )
+        for (const key of Object.keys(obj)) {
+          if (typeof theme[themeKey][key] === 'string')
+            theme[themeKey][key] = obj[key].map(i => `${i},`).join('') + theme[themeKey][key]
+          else
+            theme[themeKey][key] = obj[key].join(',')
+        }
+      }
+    }
+
+    return preset
+  }
+
+  window.__unocss_presets = Object.assign(window.__unocss_presets ?? {}, {
+    presetWebFonts: (options: WebFontsOptions) => presetWebFonts(options),
+  })
+})()

--- a/packages/runtime/src/presets/preset-wind.ts
+++ b/packages/runtime/src/presets/preset-wind.ts
@@ -1,0 +1,8 @@
+import type { PresetWindOptions } from '@unocss/preset-wind'
+import presetWind from '@unocss/preset-wind'
+
+(() => {
+  window.__unocss_presets = Object.assign(window.__unocss_presets ?? {}, {
+    presetWind: (options: PresetWindOptions) => presetWind(options),
+  })
+})()


### PR DESCRIPTION
Export all built-in presets as individual preset key/function pair. The main purpose of this is to be able to use `presetIcons` online without needing to use bundler. With separate presets, each of them can be used with their respective options.

As for the existing cdns, we can consider deprecating all but `core` and `full`. `core` is the recommended one to be used for integration, while `full` is for showcase shortcut.