### PR TITLE
fix(vite): avoid hanging warning timer

### DIFF
--- a/packages/vite/src/modes/global/dev.ts
+++ b/packages/vite/src/modes/global/dev.ts
@@ -104,6 +104,13 @@ export function GlobalModeDevPlugin({ uno, tokens, tasks, flushTasks, affectedMo
     }
   }
 
+  function clearWarnTimer() {
+    if (resolvedWarnTimer) {
+      clearTimeout(resolvedWarnTimer)
+      resolvedWarnTimer = undefined
+    }
+  }
+
   onInvalidate(() => {
     invalidate(10, new Set([...entries, ...affectedModules]))
   })
@@ -143,6 +150,7 @@ export function GlobalModeDevPlugin({ uno, tokens, tasks, flushTasks, affectedMo
         const entry = resolveId(id)
         if (entry) {
           resolved = true
+          clearWarnTimer()
           entries.add(entry)
           return entry
         }
@@ -158,6 +166,9 @@ export function GlobalModeDevPlugin({ uno, tokens, tasks, flushTasks, affectedMo
           code: `__uno_hash_${hash}{--:'';}${css}`,
           map: { mappings: '' },
         }
+      },
+      closeBundle() {
+        clearWarnTimer()
       },
     },
     {


### PR DESCRIPTION
Ran into an issue where my dev server processes wouldn't shut down for some time due to an open handle.

I eventually traced it to a timer in UnoCSS which is set when the build starts and then runs for 20 seconds no matter what.

This pull request makes it so the timer is automatically cleared once it's fulfilled its purpose or the build server is closed so it won't keep the Node process alive.