### PR TITLE
docs: update vite server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ If you are seaking for the true dynamic generation at the runtime, you may check
 
 ### Inspector
 
-From v0.7.0, our Vite plugin now ships with a dev inspector ([@unocss/inspector](https://github.com/unocss/unocss/tree/main/packages/inspector)) for you to view, play and analyse your custom rules and setup. Visit `http://localhost:3000/__unocss` in your Vite dev server to see it.
+From v0.7.0, our Vite plugin now ships with a dev inspector ([@unocss/inspector](https://github.com/unocss/unocss/tree/main/packages/inspector)) for you to view, play and analyse your custom rules and setup. Visit `http://localhost:5173/__unocss` in your Vite dev server to see it.
 
 <img src="https://user-images.githubusercontent.com/11247099/140885990-1827f5ce-f12a-4ed4-9d63-e5145a65fb4a.png">
 

--- a/packages/inspector/README.md
+++ b/packages/inspector/README.md
@@ -2,7 +2,7 @@
 
 The inspector UI for UnoCSS. Ships with `unocss` and `@unocss/vite`.
 
-Visit `http://localhost:3000/__unocss` in your Vite dev server to see the inspector.
+Visit `http://localhost:5173/__unocss` in your Vite dev server to see the inspector.
 
 <img src="https://user-images.githubusercontent.com/11247099/140885990-1827f5ce-f12a-4ed4-9d63-e5145a65fb4a.png">
 <img src="https://user-images.githubusercontent.com/11247099/140886020-7014f412-f020-4aed-a169-d025cc1bbcd3.png">


### PR DESCRIPTION
Vite has changed the default `server.port` config to 5173.

Refs:

- [https://vitejs.dev/config/server-options.html#server-port](https://vitejs.dev/config/server-options.html#server-port)