### PR TITLE
feat(preset-mini): add webkit vendor prefix to `user-select`

### DIFF
--- a/packages/preset-mini/src/_rules/static.ts
+++ b/packages/preset-mini/src/_rules/static.ts
@@ -58,10 +58,10 @@ export const resizes: Rule[] = [
 ]
 
 export const userSelects: Rule[] = [
-  ['select-auto', { 'user-select': 'auto' }],
-  ['select-all', { 'user-select': 'all' }],
-  ['select-text', { 'user-select': 'text' }],
-  ['select-none', { 'user-select': 'none' }],
+  ['select-auto', { '-webkit-user-select': 'auto', 'user-select': 'auto' }],
+  ['select-all', { '-webkit-user-select': 'all', 'user-select': 'all' }],
+  ['select-text', { '-webkit-user-select': 'text', 'user-select': 'text' }],
+  ['select-none', { '-webkit-user-select': 'none', 'user-select': 'none' }],
   ...makeGlobalStaticRules('select', 'user-select'),
 ]
 

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -15,11 +15,6 @@ exports[`cli > supports unocss.config.js 1`] = `
 .box{margin-left:auto;margin-right:auto;max-width:80rem;border-radius:0.375rem;--un-bg-opacity:1;background-color:rgba(243,244,246,var(--un-bg-opacity));padding:1rem;--un-shadow:var(--un-shadow-inset) 0 1px 2px 0 var(--un-shadow-color, rgba(0,0,0,0.05));box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}"
 `;
 
-exports[`cli > supports unocss.config.ts changed rebuild 1`] = `
-"/* layer: shortcuts */
-.box{margin-left:auto;margin-right:auto;max-width:80rem;border-radius:0.375rem;--un-bg-opacity:1;background-color:rgba(243,244,246,var(--un-bg-opacity));padding:1rem;--un-shadow:var(--un-shadow-inset) 0 1px 2px 0 var(--un-shadow-color, rgba(0,0,0,0.05));box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}"
-`;
-
 exports[`cli > supports variantGroup transformer 1`] = `
 "/* layer: default */
 .border-red{--un-border-opacity:1;border-color:rgba(248,113,113,var(--un-border-opacity));}

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -249,7 +249,7 @@ exports[`attributify > fixture2 1`] = `
 [peer=\\"\\"]:not(:placeholder-shown)~[peer-not-placeholder-shown~=\\"-translate-y-4\\"]{--un-translate-y:-1rem;transform:translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z)) rotate(var(--un-rotate)) rotateX(var(--un-rotate-x)) rotateY(var(--un-rotate-y)) rotateZ(var(--un-rotate-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z));}
 [peer=\\"\\"]:focus~[peer-focus~=\\"scale-75\\"],
 [peer=\\"\\"]:not(:placeholder-shown)~[peer-not-placeholder-shown~=\\"scale-75\\"]{--un-scale-x:0.75;--un-scale-y:0.75;transform:translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z)) rotate(var(--un-rotate)) rotateX(var(--un-rotate-x)) rotateY(var(--un-rotate-y)) rotateZ(var(--un-rotate-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z));}
-[select-none=\\"\\"]{user-select:none;}
+[select-none=\\"\\"]{-webkit-user-select:none;user-select:none;}
 [bg-gradient~=\\"from-yellow-400\\"]{--un-gradient-from:rgba(250,204,21,var(--un-from-opacity, 1));--un-gradient-to:rgba(250,204,21,0);--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to);}
 [bg-gradient~=\\"via-red-500\\"]{--un-gradient-to:rgba(239,68,68,0);--un-gradient-stops:var(--un-gradient-from), rgba(239,68,68,var(--un-via-opacity, 1)), var(--un-gradient-to);}
 [bg-gradient~=\\"to-pink-500\\"]{--un-gradient-to:rgba(236,72,153,var(--un-to-opacity, 1));}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -778,8 +778,8 @@ unocss .scope-\\\\[unocss\\\\]\\\\:block{display:block;}
 .vertical-baseline{vertical-align:baseline;}
 .vertical-inherit{vertical-align:inherit;}
 .vertical-super{vertical-align:super;}
-.select-all{user-select:all;}
-.select-none{user-select:none;}
+.select-all{-webkit-user-select:all;user-select:all;}
+.select-none{-webkit-user-select:none;user-select:none;}
 .select-inherit{user-select:inherit;}
 .whitespace-pre-wrap{white-space:pre-wrap;}
 .whitespace-unset{white-space:unset;}

--- a/test/__snapshots__/transformer-directives.test.ts.snap
+++ b/test/__snapshots__/transformer-directives.test.ts.snap
@@ -117,6 +117,7 @@ html.dark {
 .icon-btn {
   display: inline-block;
   cursor: pointer;
+  -webkit-user-select: none;
   user-select: none;
   font-size: 1.5rem;
   line-height: 2rem;


### PR DESCRIPTION
[Safari requires `-webkit-` vendor prefix for `user-select`](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select#browser_compatibility).

This PR was created in past (https://github.com/unocss/unocss/pull/1411) and was declined but given that

- this comment: https://github.com/unocss/unocss/issues/12#:~:text=Providing%20them%20in%20the%20first%20place%20could%20be%20the%20most%20well%20behaved%20and%20performant%20solution%20IMO
- other rules handles vendor prefixes
  - examples
    - https://github.com/unocss/unocss/blob/339f2b2c9be41a5505e7f4509eea1cf00a87a8d1/packages/preset-wind/src/rules/filters.ts#L48-L50
    - https://github.com/unocss/unocss/blob/339f2b2c9be41a5505e7f4509eea1cf00a87a8d1/packages/preset-mini/src/_rules/behaviors.ts#L22-L25

, I think it makes sense to add this.

