### PR TITLE
fix(preset-mini): order `-webkit-appearance` before

### DIFF
--- a/packages/preset-mini/src/_rules/behaviors.ts
+++ b/packages/preset-mini/src/_rules/behaviors.ts
@@ -20,8 +20,8 @@ export const outline: Rule<Theme>[] = [
 
 export const appearance: Rule[] = [
   ['appearance-none', {
-    'appearance': 'none',
     '-webkit-appearance': 'none',
+    'appearance': 'none',
   }],
 ]
 

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -823,7 +823,7 @@ unocss .scope-\\\\[unocss\\\\]\\\\:block{display:block;}
 .outline-revert-layer{outline-style:revert-layer;}
 .outline-unset{outline-style:unset;}
 .outline-none{outline:2px solid transparent;outline-offset:2px;}
-.appearance-none{appearance:none;-webkit-appearance:none;}
+.appearance-none{-webkit-appearance:none;appearance:none;}
 .order-\\\\$variable{order:var(--variable);}
 .order-first{order:-9999;}
 .order-none{order:0;}

--- a/test/__snapshots__/transformer-directives.test.ts.snap
+++ b/test/__snapshots__/transformer-directives.test.ts.snap
@@ -79,8 +79,8 @@ html.dark {
 .select-dark {
   display: block;
   width: 100%;
-  appearance: none;
   -webkit-appearance: none;
+  appearance: none;
   border-radius: 0.25rem;
   --un-bg-opacity: 1;
   background-color: rgba(55, 65, 81, var(--un-bg-opacity));


### PR DESCRIPTION
Vendor prefixed properties should come before the non-prefixed ones in general.
https://css-tricks.com/ordering-css3-properties/

As far as I searched all rules was following that in this repository except this `appearance` rule.

This PR moves `-webkit-appearance` before `appearance`.
