### PR TITLE
feat(eslint-plugin): add svelte support

### DIFF
--- a/packages/eslint-plugin/fixtures/src/+page.svelte
+++ b/packages/eslint-plugin/fixtures/src/+page.svelte
@@ -1,0 +1,1 @@
+<h1 class="text-3xl hover:text-red m1 font-bold underline">Hello world!</h1>

--- a/packages/eslint-plugin/src/constants.ts
+++ b/packages/eslint-plugin/src/constants.ts
@@ -1,1 +1,2 @@
 export const CLASS_FIELDS = ['class', 'classname']
+export const AST_NODES_WITH_QUOTES = ['Literal', 'VLiteral']


### PR DESCRIPTION
Currently `@unocss/eslint-plugin` only supports React and Vue by visiting `JSXAttribute` and `VAttribute` nodes.

This patch adds support for Svelte by visiting `SvelteAttribute` which comes from [svelte-eslint-parser](https://github.com/ota-meshi/svelte-eslint-parser/blob/main/docs/AST.md#svelteattribute) community package.

## Why not [sveltejs/eslint-plugin-svelte3](https://github.com/sveltejs/eslint-plugin-svelte3)?
While they are the official (and recommended) eslint plugin for Svelte, they uses some hack-ish preprocess/postprocess mechanisms to traverse the code and does not provide any ASTs. Thus it is impossible to use their implementation.

## What is with `AST_NODES_WITH_QUOTES` and `fixer.replaceTextRange`?
This comes from the difference between React/Vue and Svelte's AST structure. As there are no concrete standard in the eslint AST specification, each framework's AST and how their properties are calculated is _slightly_ different. 

**TL;DR**: `Literal` and `VLiteral` nodes are having their `range` contains its encapsulating quotes, but `SvelteLiteral`'s counterpart does not contain the encapsulatings.

Having the same following attribute in the code,
```
class='w-32'
```

* `Literal` (from React): `{ "type": "Literal", "value": "w-32", "raw": "'w-32'", "range": [6, 11]  }`
* `VLiteral` (from Vue): `{ "type": "VLiteral", "value": "w-32", "range": [6, 11] }`
* `SvelteLiteral` (from Svelte): `{ "type": "SvelteLiteral", "value": "w-32", "range": [7, 10] }`

While they have the same value for `value`, the `range` they provide are different.
To keep the code simple, I've made the list of literal nodes which its range contains the encapsulating quotes themselves.
By checking the list, we can decide should the fixer replaces the whole range of the node or just the content of the node of interest.

By using this approach, not only being able to support various ASTs, we can also keep the original quotes from the code no matter it was `"` or `'`. The original implementation was to simply replace with `"` regardless of the original context.