### PR TITLE
docs(config): split config file into smaller files

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -1,6 +1,7 @@
-import { defineConfig } from 'vitepress'
-import type { DefaultTheme } from 'vitepress/types'
-import { version } from '../../package.json'
+import type { DefaultTheme, LocaleSpecificConfig } from 'vitepress/types'
+import { version } from '../../../package.json'
+
+const description = 'The instant on-demand Atomic CSS engine'
 
 const Guides: DefaultTheme.NavItemWithLink[] = [
   { text: 'Getting Started', link: '/guide/' },
@@ -210,50 +211,17 @@ const SidebarConfig: DefaultTheme.SidebarItem[] = [
   },
 ]
 
-// TODO: verify this is the correct url
-const ogUrl = 'https://unocss.dev/'
-const ogImage = `${ogUrl}og-image.png`
-const title = 'UnoCSS'
-const description = 'The instant on-demand Atomic CSS engine'
-
-export default defineConfig({
-  lang: 'en-US',
-  title,
-  titleTemplate: title,
+export const enConfig: LocaleSpecificConfig<DefaultTheme.Config> = ({
   description,
-  outDir: './dist',
   head: [
-    ['link', { rel: 'icon', href: '/logo.svg', type: 'image/svg+xml' }],
-    ['link', { rel: 'alternate icon', href: '/favicon.ico', type: 'image/png', sizes: '16x16' }],
-    ['meta', { name: 'author', content: 'Anthony Fu' }],
-    ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { name: 'og:title', content: title }],
     ['meta', { name: 'og:description', content: description }],
-    ['meta', { property: 'og:image', content: ogImage }],
-    ['meta', { name: 'twitter:title', content: title }],
-    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
-    ['meta', { name: 'twitter:image', content: ogImage }],
-    ['meta', { name: 'twitter:site', content: '@antfu7' }],
-    ['meta', { name: 'twitter:url', content: ogUrl }],
   ],
-  lastUpdated: true,
-  cleanUrls: true,
-  ignoreDeadLinks: [
-    /^\/play/,
-    /^\/interactive/,
-    /:\/\/localhost/,
-  ],
-
-  markdown: {
-    theme: {
-      light: 'vitesse-light',
-      dark: 'vitesse-dark',
-    },
-  },
-
   themeConfig: {
-    logo: '/logo.svg',
     nav: Nav,
+    editLink: {
+      pattern: 'https://github.com/unocss/unocss/docs/edit/main/docs/:path',
+      text: 'Suggest changes to this page',
+    },
     sidebar: {
       '/guide/': SidebarGuide,
       '/integrations/': SidebarGuide,
@@ -264,18 +232,6 @@ export default defineConfig({
       '/extractors/': SidebarPresets,
 
       '/config/': SidebarConfig,
-    },
-    editLink: {
-      pattern: 'https://github.com/unocss/unocss/docs/edit/main/docs/:path',
-      text: 'Suggest changes to this page',
-    },
-    socialLinks: [
-      { icon: 'github', link: 'https://github.com/unocss/unocss' },
-      { icon: 'discord', link: 'http://chat.antfu.me' },
-    ],
-    footer: {
-      message: 'Released under the MIT License.',
-      copyright: 'Copyright © 2021-PRESENT Anthony Fu',
     },
   },
 })

--- a/docs/.vitepress/config/index.ts
+++ b/docs/.vitepress/config/index.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitepress'
+import { enConfig } from './en'
+import { sharedConfig } from './shared'
+
+export default defineConfig({
+  ...sharedConfig,
+
+  locales: {
+    root: { label: 'English', lang: 'en-US', link: '/', ...enConfig },
+  },
+})

--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -1,0 +1,52 @@
+import { defineConfig } from 'vitepress'
+
+// TODO: verify this is the correct url
+const ogUrl = 'https://unocss.dev/'
+const ogImage = `${ogUrl}og-image.png`
+const title = 'UnoCSS'
+
+export const sharedConfig = defineConfig({
+  lang: 'en-US',
+  title,
+  titleTemplate: title,
+  outDir: './dist',
+  head: [
+    ['link', { rel: 'icon', href: '/logo.svg', type: 'image/svg+xml' }],
+    ['link', { rel: 'alternate icon', href: '/favicon.ico', type: 'image/png', sizes: '16x16' }],
+    ['meta', { name: 'author', content: 'Anthony Fu' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { name: 'og:title', content: title }],
+    ['meta', { property: 'og:image', content: ogImage }],
+    ['meta', { name: 'twitter:title', content: title }],
+    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    ['meta', { name: 'twitter:image', content: ogImage }],
+    ['meta', { name: 'twitter:site', content: '@antfu7' }],
+    ['meta', { name: 'twitter:url', content: ogUrl }],
+  ],
+  lastUpdated: true,
+  cleanUrls: true,
+  ignoreDeadLinks: [
+    /^\/play/,
+    /^\/interactive/,
+    /:\/\/localhost/,
+  ],
+
+  markdown: {
+    theme: {
+      light: 'vitesse-light',
+      dark: 'vitesse-dark',
+    },
+  },
+
+  themeConfig: {
+    logo: '/logo.svg',
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/unocss/unocss' },
+      { icon: 'discord', link: 'http://chat.antfu.me' },
+    ],
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Copyright © 2021-PRESENT Anthony Fu',
+    },
+  },
+})


### PR DESCRIPTION
Splitting the `config` file into smaller files, could be convenient for future internationalization efforts. Separating the files in advance can help avoid potential conflicts that may arise if changes are made to the files later.

Will start translating docs to `zh-CN` after this PR is merged.