### PR TITLE
docs: add icons examples on icons.md

### DIFF
--- a/docs/presets/icons.md
+++ b/docs/presets/icons.md
@@ -4,6 +4,36 @@ description: Use any icon with Pure CSS for UnoCSS (@unocss/preset-icons).
 outline: deep
 ---
 
+<script setup>
+const toggleDark = () => {
+  const preference = localStorage.getItem('vitepress-theme-appearance') || '';
+  localStorage.setItem('vitepress-theme-appearance', preference === 'dark' ? '' : 'dark');
+  const css = document.createElement('style');
+    css.type = 'text/css';
+    css.appendChild(
+      document.createTextNode(
+        `:not(.VPSwitchAppearance):not(.VPSwitchAppearance *) {
+  -webkit-transition: none !important;
+  -moz-transition: none !important;
+  -o-transition: none !important;
+  -ms-transition: none !important;
+  transition: none !important;
+}`
+      )
+    );
+  document.head.appendChild(css);
+
+  if (preference === 'dark') {
+    document.documentElement.classList.remove('dark');
+  } else {
+    document.documentElement.classList.add('dark');
+  }
+
+  const _ = window.getComputedStyle(css).opacity;
+  document.head.removeChild(css);
+}
+</script>
+
 # Icons preset
 
 Use any icon with Pure CSS for UnoCSS.
@@ -34,7 +64,14 @@ For examples:
 <div class="i-twemoji-grinning-face-with-smiling-eyes hover:i-twemoji-face-with-tears-of-joy" />
 ```
 
-<img src="https://user-images.githubusercontent.com/11247099/136709053-31b4db79-eddc-4dc6-aa2d-388086332630.gif" height="100">
+<div class="w-full flex items-center justify-center gap-x-4 text-4xl p-2 mt-4">
+  <div class="i-ph:anchor-simple-thin" />
+  <div class="i-mdi:alarm text-orange-400 hover:text-teal-400" />
+  <div class="w-2em h-2em i-logos:vue transform transition-800 hover:rotate-180" />
+  <button class="i-carbon:sun dark:i-carbon:moon !w-2em !h-2em" @click="toggleDark()" title="toggle dark mode"/>
+  <div class="i-twemoji:grinning-face-with-smiling-eyes hover:i-twemoji:face-with-tears-of-joy" /> 
+  <div class="text-base my-auto flex"><div class="i-carbon:arrow-left my-auto mr-1" /> Hover it</div>
+</div>
 
 ## Install
 
@@ -97,6 +134,18 @@ By default, this preset will choose the rendering modes automatically for each i
 - `?mask` for `mask` - renders the icon as a mask image
 
 For example, `vscode-icons:file-type-light-pnpm`, an icon with colors (the `svg` doesn't contain `currentColor`) that will be rendered as a background image. Use `vscode-icons:file-type-light-pnpm?mask` to render it as a mask image and bypass it's colors.
+
+```html
+<div class="w-full flex items-center justify-center gap-x-4 text-4xl p-2 mt-4">
+  <div class="i-vscode-icons:file-type-light-pnpm" />
+  <div class="i-vscode-icons:file-type-light-pnpm?mask text-red-300" />
+</div>
+```
+
+<div class="w-full flex items-center justify-center gap-x-4 text-4xl p-2 mt-4">
+  <div class="i-vscode-icons:file-type-light-pnpm" />
+  <div class="i-vscode-icons:file-type-light-pnpm?mask text-red-300" />
+</div>
 
 ## Configuring collections and icons resolvers
 

--- a/docs/presets/icons.md
+++ b/docs/presets/icons.md
@@ -6,31 +6,7 @@ outline: deep
 
 <script setup>
 const toggleDark = () => {
-  const preference = localStorage.getItem('vitepress-theme-appearance') || '';
-  localStorage.setItem('vitepress-theme-appearance', preference === 'dark' ? '' : 'dark');
-  const css = document.createElement('style');
-    css.type = 'text/css';
-    css.appendChild(
-      document.createTextNode(
-        `:not(.VPSwitchAppearance):not(.VPSwitchAppearance *) {
-  -webkit-transition: none !important;
-  -moz-transition: none !important;
-  -o-transition: none !important;
-  -ms-transition: none !important;
-  transition: none !important;
-}`
-      )
-    );
-  document.head.appendChild(css);
-
-  if (preference === 'dark') {
-    document.documentElement.classList.remove('dark');
-  } else {
-    document.documentElement.classList.add('dark');
-  }
-
-  const _ = window.getComputedStyle(css).opacity;
-  document.head.removeChild(css);
+  document.querySelector('.VPSwitchAppearance')?.click()
 }
 </script>
 
@@ -72,6 +48,8 @@ For examples:
   <div class="i-twemoji:grinning-face-with-smiling-eyes hover:i-twemoji:face-with-tears-of-joy" /> 
   <div class="text-base my-auto flex"><div class="i-carbon:arrow-left my-auto mr-1" /> Hover it</div>
 </div>
+
+Check [all available icons](https://icones.js.org/).
 
 ## Install
 


### PR DESCRIPTION
Filed an issue on VP: https://github.com/vuejs/vitepress/issues/2192

Toggle dark mode from icons.md icon and from VP switcher can result in phantom clicks, VP switcher not reactive to local storage.

This PR also includes icon examples for `Modes Overriding`.

https://streamable.com/36lpf7 