### PR TITLE
docs: link rich integrations to vite

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ features:
   - icon: <span class="i-carbon-ibm-cloud-transit-gateway"></span>
     title: Rich Integrations
     details: "First class support of Vite, Webpack, PostCSS, CLI, VS Code, ESLint, etc."
-    link: /integrations/
+    link: /integrations/vite
     linkText: "Learn more"
   - icon: <span class="i-carbon-asset"></span>
     title: Shortcuts


### PR DESCRIPTION
Link rich integrations to vite, otherwise page navigation will result in a 404 error.