### PR TITLE
docs: disable rainbow animation on reduce motion

### DIFF
--- a/docs/.vitepress/theme/rainbow.css
+++ b/docs/.vitepress/theme/rainbow.css
@@ -89,6 +89,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   :root {
-    animation: none;
+    animation: none !important;
   }
 }

--- a/docs/.vitepress/theme/rainbow.css
+++ b/docs/.vitepress/theme/rainbow.css
@@ -86,3 +86,9 @@
   --vp-c-brand: #00a98e; --vp-c-brand-light: #4ad1b4; --vp-c-brand-lighter: #78fadc; --vp-c-brand-dark: #008269; --vp-c-brand-darker: #005d47; --vp-c-brand-next: #009ff7;
   animation: rainbow 40s linear infinite;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    animation: none;
+  }
+}


### PR DESCRIPTION
It's very distracting, even if it's been turned to over 40 seconds for non-landing pages.

It would be best to completely turn it off instead if the user explicitly requests for reduced motion.
