### PR TITLE
docs: fix navbar style

### DIFF
--- a/docs/.vitepress/theme/overrides.css
+++ b/docs/.vitepress/theme/overrides.css
@@ -20,3 +20,7 @@ table {
 .VPHero .image-container:hover .image-bg {
   opacity: 0.2;
 }
+
+.VPNavBar {
+  white-space: nowrap;
+}


### PR DESCRIPTION
When window innerWidth is not enough but greater than `768px`, there is the problem in navbar.

|  before  |  after  |
|  ------  |  -----  |
| ![unocss1](https://user-images.githubusercontent.com/30711792/230731193-fff562a1-3582-46c4-982d-869bc3d77024.png) |![unocss2](https://user-images.githubusercontent.com/30711792/230731209-4909d5a1-6668-4352-946e-7a9e9fadab5b.png)|
