### PR TITLE
feat(interactive): migrate `cs.github.com` to `github.com/search`

### DIFF
--- a/interactive/components/details/Rule.vue
+++ b/interactive/components/details/Rule.vue
@@ -58,8 +58,10 @@ function getRegexperLink(regex: RegExp) {
   return `https://regexper.com/#${encodeURIComponent(regex.source)}`
 }
 
-function getCsGitHubLink(key: RegExp | string, repo = 'unocss/unocss') {
-  return `https://cs.github.com/?scope=${encodeURI(`repo:${repo}`)}&q="${encodeURIComponent(String(key))}"`
+function getGitHubCodeSearchLink(key: RegExp | string, repo = 'unocss/unocss') {
+  // https://docs.github.com/en/search-github/searching-on-github/searching-code#search-within-a-users-or-organizations-repositories
+  const separator = ' '
+  return `https://github.com/search?type=code&q=${encodeURI(`repo:${repo}`)}${separator}"${encodeURIComponent(String(key))}"`
 }
 </script>
 
@@ -131,7 +133,7 @@ function getCsGitHubLink(key: RegExp | string, repo = 'unocss/unocss') {
                 <a text-sm link :href="getRegex101Link(r[0], item.class)" target="_blank">Regex101</a>
                 <a text-sm link :href="getRegexperLink(r[0])" target="_blank">Regexper</a>
               </template>
-              <a text-sm link :href="getCsGitHubLink(r[0])" target="_blank">GitHub</a>
+              <a text-sm link :href="getGitHubCodeSearchLink(r[0])" target="_blank">GitHub</a>
             </div>
           </template>
         </div>


### PR DESCRIPTION
`cs.github.com` is being retired