### PR TITLE
chore(playground): update interactive docs link

### DIFF
--- a/playground/src/components/HeaderBar.vue
+++ b/playground/src/components/HeaderBar.vue
@@ -57,7 +57,7 @@ function handleReset() {
       />
       <a
         i-ri-search-line icon-btn
-        href="https://unocss.dev/play/"
+        href="https://unocss.dev/interactive/"
         target="_blank"
         title="Interactive Docs"
       />


### PR DESCRIPTION
Currently it links to the playground instead of the interactive docs.