### PR TITLE
Add section to notify devs on how to use astro's add for integrations.

### DIFF
--- a/docs/integrations/astro.md
+++ b/docs/integrations/astro.md
@@ -9,6 +9,23 @@ The UnoCSS integration for [Astro](https://astro.build/): `@unocss/astro`. Check
 
 ## Installation
 
+
+**Using astro add **
+
+::: code-group
+  ```bash [pnpm]
+  pnpm  astro add -D @unocss/astro
+  ```
+  ```bash [yarn]
+  yarn astro add -D @unocss/astro
+  ```
+  ```bash [npm]
+  npx astro add -D @unocss/astro
+  ```
+:::
+
+**Individually **
+
 ::: code-group
   ```bash [pnpm]
   pnpm add -D unocss
@@ -32,6 +49,7 @@ export default defineConfig({
   ],
 })
 ```
+
 
 Create a `uno.config.ts` file:
 


### PR DESCRIPTION
The changes below are a way of telling people how to install unocss as an integration. I'm doing this so that people will know this and do things correctly. The next time you want to do an integration remember this https://docs.astro.build/en/reference/integrations-reference/#allow-installation-with-astro-add.