### PR TITLE
Update astro.md

### DIFF
--- a/docs/integrations/astro.md
+++ b/docs/integrations/astro.md
@@ -9,6 +9,23 @@ The UnoCSS integration for [Astro](https://astro.build/): `@unocss/astro`. Check
 
 ## Installation
 
+
+**Using astro add **
+
+::: code-group
+  ```bash [pnpm]
+  pnpm  astro add -D @unocss/astro
+  ```
+  ```bash [yarn]
+  yarn astro add -D @unocss/astro
+  ```
+  ```bash [npm]
+  npx astro add -D @unocss/astro
+  ```
+:::
+
+**Individually **
+
 ::: code-group
   ```bash [pnpm]
   pnpm add -D unocss
@@ -32,6 +49,7 @@ export default defineConfig({
   ],
 })
 ```
+
 
 Create a `uno.config.ts` file:
 

--- a/docs/integrations/astro.md
+++ b/docs/integrations/astro.md
@@ -10,7 +10,7 @@ The UnoCSS integration for [Astro](https://astro.build/): `@unocss/astro`. Check
 ## Installation
 
 
-**Using astro add **
+**Using astro add**
 
 ::: code-group
   ```bash [pnpm]
@@ -24,7 +24,7 @@ The UnoCSS integration for [Astro](https://astro.build/): `@unocss/astro`. Check
   ```
 :::
 
-**Individually **
+**Individually**
 
 ::: code-group
   ```bash [pnpm]


### PR DESCRIPTION
I'm doing this again because I don't think you understand the point of the previous pull request. 
The point of it is to inform developers that they can install unocss by using `astro add`. 
They do this properly by using `astro add @unocss/astro -D`. 
I wrote all of the code that is necessary for you to do just that.

Integrations automatically setup the importing of the file and places it at the right place making life easier for developers. 
If this is not documented time will not be saved people will struggle to type the right name for `astro add` and assume it's just `astro add unocss`.  

The last sentence was to tell you how to do it again if you needed to do another integration.   