### PR TITLE
fix(postcss): ignore dot folders

### DIFF
--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -118,7 +118,7 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
           cwd,
           dot: true,
           absolute: true,
-          ignore: ['**/{.git,node_modules}/**'],
+          ignore: ['**/{.*,node_modules}/**'],
           stats: true,
         }) as unknown as { path: string; mtimeMs: number }[]
 

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -116,9 +116,8 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
 
         const entries = await fg(isScanTarget ? globs : from, {
           cwd,
-          dot: true,
           absolute: true,
-          ignore: ['**/{.*,node_modules}/**'],
+          ignore: ['**/node_modules/**'],
           stats: true,
         }) as unknown as { path: string; mtimeMs: number }[]
 


### PR DESCRIPTION
Fixes #2473

In this case, the `.next` folder had a few large `js` files causing the slowdown. IMO ignoring all dot folders by default is fine.