### PR TITLE
chore(cli): upgrade consola to v3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
     "cac": "^6.7.14",
     "chokidar": "^3.5.3",
     "colorette": "^2.0.19",
-    "consola": "^2.15.3",
+    "consola": "^3.0.0",
     "fast-glob": "^3.2.12",
     "magic-string": "^0.30.0",
     "pathe": "^1.1.0",

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,4 +1,4 @@
-import consola from 'consola'
+import { consola } from 'consola'
 
 export class PrettyError extends Error {
   constructor(message: string) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,18 +1,18 @@
 import { existsSync, promises as fs } from 'node:fs'
 import { basename, dirname, normalize, relative, resolve } from 'pathe'
 import fg from 'fast-glob'
-import consola from 'consola'
+import { consola } from 'consola'
 import { cyan, dim, green } from 'colorette'
 import { debounce } from 'perfect-debounce'
 import { toArray } from '@unocss/core'
 import type { SourceCodeTransformerEnforce, UserConfig } from '@unocss/core'
-import { version } from '../package.json'
 import { createContext } from '../../shared-integration/src/context'
 import { applyTransformers } from '../../shared-integration/src/transformers'
-import { PrettyError, handleError } from './errors'
+import { version } from '../package.json'
 import { defaultConfig } from './config'
-import type { CliOptions, ResolvedCliOptions } from './types'
+import { PrettyError, handleError } from './errors'
 import { getWatcher } from './watcher'
+import type { CliOptions, ResolvedCliOptions } from './types'
 
 const name = 'unocss'
 
@@ -118,7 +118,8 @@ export async function build(_options: CliOptions) {
 
     // update source file
     await Promise.all(
-      postTransform.filter(({ transformedCode }) => !!transformedCode)
+      postTransform
+        .filter(({ transformedCode }) => !!transformedCode)
         .map(({ transformedCode, id }) => new Promise<void>((resolve) => {
           if (existsSync(id))
             fs.writeFile(id, transformedCode as string, 'utf-8').then(resolve)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,8 +509,8 @@ importers:
         specifier: ^2.0.19
         version: 2.0.19
       consola:
-        specifier: ^2.15.3
-        version: 2.15.3
+        specifier: ^3.0.0
+        version: 3.0.0
       fast-glob:
         specifier: ^3.2.12
         version: 3.2.12
@@ -8531,6 +8531,10 @@ packages:
 
   /consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
+
+  /consola@3.0.0:
+    resolution: {integrity: sha512-ed10+SGP/dL3u7fEDxDPb+68vS4JckVjivIMq2wg5to8od2Rki5AyetFivjuC3cE49+azquEVDSgHZ8qYrUxdQ==}
+    dev: false
 
   /console-browserify@1.2.0:
     resolution: {integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==}


### PR DESCRIPTION
- Updated from default to named export, as changed in [Consola v3](https://github.com/unjs/consola/releases/tag/v3.0.0).