### PR TITLE
feat(core)!: add `content` option

### DIFF
--- a/docs/integrations/postcss.md
+++ b/docs/integrations/postcss.md
@@ -23,10 +23,7 @@ npm i -D @unocss/postcss
 // postcss.config.cjs
 module.exports = {
   plugins: {
-    '@unocss/postcss': {
-      // Optional
-      content: ['**/*.{html,js,ts,jsx,tsx,vue,svelte,astro}'],
-    },
+    '@unocss/postcss': {},
   },
 }
 ```

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -40,10 +40,11 @@ export default function UnoCSSAstroIntegration<Theme extends {}>(
     name: 'unocss',
     hooks: {
       'astro:config:setup': async ({ config, injectScript }) => {
+        const scan = resolve(fileURLToPath(config.srcDir), 'components/**/*').replace(/\\/g, '/')
         // Adding components to UnoCSS's extra content
-        options.extraContent ||= {}
-        options.extraContent.filesystem ||= []
-        options.extraContent.filesystem.push(resolve(fileURLToPath(config.srcDir), 'components/**/*').replace(/\\/g, '/'))
+        options.content ||= {}
+        options.content.filesystem ||= []
+        options.content.filesystem.push(scan)
 
         config.vite.plugins ||= []
         config.vite.plugins.push(...VitePlugin(options, defaults) as any)

--- a/packages/core/src/utils/defaults.ts
+++ b/packages/core/src/utils/defaults.ts
@@ -1,0 +1,9 @@
+import type { FilterPattern } from '../types'
+import { cssIdRE } from './helpers'
+
+// regex patterns, used with rollup's createFilter
+export const defaultExclude: Exclude<FilterPattern, null> = [cssIdRE]
+export const defaultInclude: Exclude<FilterPattern, null> = [/\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/]
+
+// micromatch patterns, used in postcss plugin and createFilter
+export const defaultIncludeGlobs = ['./**/*.{html,js,ts,jsx,tsx,vue,svelte,astro,elm,php,phtml,mdx,md}']

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './defaults'
 export * from './escape'
 export * from './object'
 export * from './basic'

--- a/packages/nuxt/src/options.ts
+++ b/packages/nuxt/src/options.ts
@@ -5,7 +5,6 @@ import presetWebFonts from '@unocss/preset-web-fonts'
 import presetTypography from '@unocss/preset-typography'
 import presetTagify from '@unocss/preset-tagify'
 import presetWind from '@unocss/preset-wind'
-import { defaultExclude } from '../../shared-integration/src/defaults'
 import type { UnocssNuxtOptions } from './types'
 
 export function resolveOptions(options: UnocssNuxtOptions) {
@@ -26,8 +25,19 @@ export function resolveOptions(options: UnocssNuxtOptions) {
         options.presets.push(preset(typeof option === 'boolean' ? {} : option))
     }
   }
-  options.exclude = options.exclude || defaultExclude
-  // ignore macro files created by Nuxt
-  if (Array.isArray(options.exclude))
-    options.exclude.push(/\?macro=true/)
+  // if (Array.isArray(options.content)) {
+  //   const files = options.content
+  //   options.content = {
+  //     files,
+  //     exclude: defaultExclude,
+  //   }
+  // }
+
+  // if (typeof options.content === 'object') {
+  //   options.content.exclude = options.content.exclude || defaultExclude
+
+  //   // ignore macro files created by Nuxt
+  //   if (Array.isArray(options.content.exclude))
+  //     options.content.exclude.push(/\?macro=true/)
+  // }
 }

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -1,5 +1,5 @@
 import { readFile, stat } from 'node:fs/promises'
-import { normalize, resolve } from 'node:path'
+import { normalize } from 'node:path'
 import type { UnoGenerator } from '@unocss/core'
 import fg from 'fast-glob'
 import type { Result, Root } from 'postcss'
@@ -127,7 +127,7 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
             const { matched } = typeof v === 'string'
               ? await uno.generate(v)
               : await uno.generate(v.content, {
-                id: resolve(cwd, `unocss.${v.extension}`),
+                id: `unocss.${v.extension}`,
               })
 
             for (const candidate of matched)

--- a/packages/shared-integration/src/defaults.ts
+++ b/packages/shared-integration/src/defaults.ts
@@ -1,8 +1,0 @@
-import { cssIdRE } from '@unocss/core'
-
-// picomatch patterns, used with rollup's createFilter
-export const defaultExclude = [cssIdRE]
-export const defaultInclude = [/\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/]
-
-// micromatch patterns, used in postcss plugin
-export const defaultIncludeGlobs = ['**/*.{html,js,ts,jsx,tsx,vue,svelte,astro,elm,php,phtml,mdx,md}']

--- a/packages/shared-integration/src/extra-content.ts
+++ b/packages/shared-integration/src/extra-content.ts
@@ -5,21 +5,21 @@ import type { UnocssPluginContext } from '@unocss/core'
 import { applyTransformers } from './transformers'
 
 export async function setupExtraContent(ctx: UnocssPluginContext, shouldWatch = false) {
-  const { extraContent } = await ctx.getConfig()
+  const { content } = await ctx.getConfig()
   const { extract, tasks, root, filter } = ctx
 
   // plain text
-  if (extraContent?.plain) {
+  if (content?.plain) {
     await Promise.all(
-      extraContent.plain.map((code, idx) => {
-        return extract(code, `__extra_content_${idx}__`)
+      content.plain.map((plain) => {
+        return typeof plain === 'string' ? extract(plain) : extract(plain.content, plain.extension)
       }),
     )
   }
 
   // filesystem
-  if (extraContent?.filesystem) {
-    const files = await fg(extraContent.filesystem, { cwd: root })
+  if (content?.filesystem) {
+    const files = await fg(content.filesystem, { cwd: root })
 
     async function extractFile(file: string) {
       const code = await fs.readFile(file, 'utf-8')

--- a/packages/shared-integration/src/index.ts
+++ b/packages/shared-integration/src/index.ts
@@ -1,4 +1,3 @@
-export * from './defaults'
 export * from './layers'
 export * from './constants'
 export * from './context'

--- a/packages/vite/src/modes/svelte-scoped/index.ts
+++ b/packages/vite/src/modes/svelte-scoped/index.ts
@@ -1,14 +1,13 @@
 import type { Plugin, ResolvedConfig } from 'vite'
 import { createFilter } from '@rollup/pluginutils'
 import type { UnocssPluginContext } from '@unocss/core'
-import { defaultExclude } from '../../integration'
 import { transformSvelteSFC } from './transform'
 
 export * from './transform'
 
 export function SvelteScopedPlugin({ ready, uno }: UnocssPluginContext): Plugin {
   let viteConfig: ResolvedConfig
-  let filter = createFilter([/\.svelte$/, /\.svelte\.md$/, /\.svx$/], defaultExclude)
+  let filter = createFilter([/\.svelte$/, /\.svelte\.md$/, /\.svx$/], uno.config.content.pipeline.exclude)
 
   return {
     name: 'unocss:svelte-scoped',
@@ -17,8 +16,8 @@ export function SvelteScopedPlugin({ ready, uno }: UnocssPluginContext): Plugin 
       viteConfig = _viteConfig
       const { config } = await ready
       filter = createFilter(
-        config.include || [/\.svelte$/, /\.svelte\.md$/, /\.svx$/],
-        config.exclude || defaultExclude,
+        config.content.pipeline.include || [/\.svelte$/, /\.svelte\.md$/, /\.svx$/],
+        config.content.pipeline.exclude,
       )
     },
     transform(code, id) {

--- a/packages/vite/src/modes/vue-scoped.ts
+++ b/packages/vite/src/modes/vue-scoped.ts
@@ -1,10 +1,9 @@
 import type { Plugin } from 'vite'
 import { createFilter } from '@rollup/pluginutils'
 import type { UnocssPluginContext } from '@unocss/core'
-import { defaultExclude } from '../integration'
 
 export function VueScopedPlugin({ uno, ready }: UnocssPluginContext): Plugin {
-  let filter = createFilter([/\.vue$/], defaultExclude)
+  let filter = createFilter([/\.vue$/], uno.config.content.pipeline.exclude)
 
   async function transformSFC(code: string) {
     const { css } = await uno.generate(code)
@@ -19,8 +18,8 @@ export function VueScopedPlugin({ uno, ready }: UnocssPluginContext): Plugin {
     async configResolved() {
       const { config } = await ready
       filter = createFilter(
-        config.include || [/\.vue$/],
-        config.exclude || defaultExclude,
+        config.content.pipeline.include || [/\.vue$/],
+        config.content.pipeline.exclude,
       )
     },
     transform(code, id) {

--- a/test/__snapshots__/postcss.test.ts.snap
+++ b/test/__snapshots__/postcss.test.ts.snap
@@ -9,13 +9,6 @@ exports[`postcss > @screen 1`] = `
     }"
 `;
 
-exports[`postcss > @screen 2`] = `
-"@media (min-width: 768px) and (max-width: 1023.9px) {
-      div{--un-bg-opacity:1;background-color:rgba(248,113,113,var(--un-bg-opacity));}div:hover{--un-text-opacity:1;color:rgba(255,255,255,var(--un-text-opacity));}.dark div>:focus:hover{font-size:20px;}
-      div{color:#dc2626}
-    }"
-`;
-
 exports[`postcss > @unocss 1`] = `
 "/* layer: preflights */
 *,::before,::after{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgba(0,0,0,0);--un-ring-shadow:0 0 rgba(0,0,0,0);--un-shadow-inset: ;--un-shadow:0 0 rgba(0,0,0,0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgba(147,197,253,0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}::backdrop{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgba(0,0,0,0);--un-ring-shadow:0 0 rgba(0,0,0,0);--un-shadow-inset: ;--un-shadow:0 0 rgba(0,0,0,0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgba(147,197,253,0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}
@@ -431,5 +424,3 @@ exports[`postcss > @unocss layers 1`] = `
 `;
 
 exports[`postcss > theme() 1`] = `"div{color:#dc2626}"`;
-
-exports[`postcss > theme() 2`] = `"div{color:#dc2626}"`;

--- a/test/__snapshots__/postcss.test.ts.snap
+++ b/test/__snapshots__/postcss.test.ts.snap
@@ -9,6 +9,13 @@ exports[`postcss > @screen 1`] = `
     }"
 `;
 
+exports[`postcss > @screen 2`] = `
+"@media (min-width: 768px) and (max-width: 1023.9px) {
+      div{--un-bg-opacity:1;background-color:rgba(248,113,113,var(--un-bg-opacity));}div:hover{--un-text-opacity:1;color:rgba(255,255,255,var(--un-text-opacity));}.dark div>:focus:hover{font-size:20px;}
+      div{color:#dc2626}
+    }"
+`;
+
 exports[`postcss > @unocss 1`] = `
 "/* layer: preflights */
 *,::before,::after{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgba(0,0,0,0);--un-ring-shadow:0 0 rgba(0,0,0,0);--un-shadow-inset: ;--un-shadow:0 0 rgba(0,0,0,0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgba(147,197,253,0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}::backdrop{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgba(0,0,0,0);--un-ring-shadow:0 0 rgba(0,0,0,0);--un-shadow-inset: ;--un-shadow:0 0 rgba(0,0,0,0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgba(147,197,253,0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}
@@ -424,3 +431,5 @@ exports[`postcss > @unocss layers 1`] = `
 `;
 
 exports[`postcss > theme() 1`] = `"div{color:#dc2626}"`;
+
+exports[`postcss > theme() 2`] = `"div{color:#dc2626}"`;

--- a/test/postcss.test.ts
+++ b/test/postcss.test.ts
@@ -8,6 +8,14 @@ import postcss from 'postcss'
 import { presetWindTargets } from './assets/preset-wind-targets'
 
 const config: UserConfig = {
+  content: {
+    filesystem: [
+      './test/assets/preset-wind-targets.ts',
+    ],
+    plain: [{
+      content: presetWindTargets.join(' '), extension: 'html',
+    }],
+  },
   presets: [
     presetWind({
       dark: 'media',
@@ -39,12 +47,6 @@ const config: UserConfig = {
 function pcss() {
   return postcss(
     postcssPlugin({
-      content: [
-        './test/assets/preset-wind-targets.ts',
-        {
-          raw: presetWindTargets.join(' '), extension: 'html',
-        },
-      ],
       configOrPath: config,
     }))
 }
@@ -52,12 +54,15 @@ function pcss() {
 function pcssLite() {
   return postcss(
     postcssPlugin({
-      content: [
-        {
-          raw: '<div class="relative p4 test example">', extension: 'html',
-        },
-      ],
       configOrPath: <UserConfig>{
+        content: {
+          filesystem: ['./*.html'],
+          plain: [
+            {
+              content: '<div class="relative p4 test example">', extension: 'html',
+            },
+          ],
+        },
         presets: [
           presetWind(),
           {

--- a/test/postcss.test.ts
+++ b/test/postcss.test.ts
@@ -56,7 +56,7 @@ function pcssLite() {
     postcssPlugin({
       configOrPath: <UserConfig>{
         content: {
-          filesystem: ['./*.html'],
+          filesystem: [],
           plain: [
             {
               content: '<div class="relative p4 test example">', extension: 'html',


### PR DESCRIPTION
TODO: 
- explain the motivation
- add tests

Breaking changes:
- postcss!: `content` option removed
- core: `content` option added (similar to https://tailwindcss.com/docs/content-configuration)
- core!: `include` and `exclude` options moved to content option
- core!: `extraContent` removed, functionality moved to `content` option