### PR TITLE
docs: add nav config activeMatch

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -81,6 +81,7 @@ const Nav: DefaultTheme.NavItem[] = [
         items: Guides,
       },
     ],
+    activeMatch: '^/guide/',
   },
   {
     text: 'Integrations',
@@ -94,6 +95,7 @@ const Nav: DefaultTheme.NavItem[] = [
         link: 'https://github.com/unocss/unocss/tree/main/examples',
       },
     ],
+    activeMatch: '^/integrations/',
   },
   {
     text: 'Config',
@@ -107,6 +109,7 @@ const Nav: DefaultTheme.NavItem[] = [
         items: Configs,
       },
     ],
+    activeMatch: '^/config/',
   },
   {
     text: 'Presets',
@@ -132,6 +135,7 @@ const Nav: DefaultTheme.NavItem[] = [
         items: Extractors,
       },
     ],
+    activeMatch: '^/(presets|transformers|extractors)/',
   },
   { text: 'Interactive Docs', link: `${ogUrl}interactive/`, target: '_blank' },
   { text: 'Playground', link: `${ogUrl}play/`, target: '_blank' },


### PR DESCRIPTION
add activeMatch option in nav config , it can highlight the nav title In the same place

before:
<img width="967" alt="image" src="https://user-images.githubusercontent.com/96854855/232319217-d2a74ae7-2b4e-492e-ae99-f7f2fcf5c00c.png">

after:
<img width="723" alt="image" src="https://user-images.githubusercontent.com/96854855/232319440-c639908f-e628-4c1f-98bb-9089165c0d93.png">
