### PR TITLE
fix(preset-attributify): remove ternary handling

### DIFF
--- a/packages/preset-attributify/src/extractor.ts
+++ b/packages/preset-attributify/src/extractor.ts
@@ -55,9 +55,7 @@ export function extractorAttributify(options?: AttributifyOptions): Extractor {
             if (options?.prefixedOnly && options.prefix && !name.startsWith(options.prefix))
               return []
 
-            const extractTernary = Array.from(content.matchAll(/(?:[\?:].*?)(["'])([^\1]*?)\1/gms))
-              .map(([,,v]) => v.split(splitterRE)).flat()
-            return (extractTernary.length ? extractTernary : content.split(splitterRE))
+            return content.split(splitterRE)
               .filter(v => Boolean(v) && v !== ':')
               .map(v => `[${name}~="${v}"]`)
           }

--- a/test/cases/preset-attributify/case-1/input.html
+++ b/test/cases/preset-attributify/case-1/input.html
@@ -12,7 +12,7 @@
   p="t-2"
   pt="2"
   border="rounded-xl x-1 x-style-dashed"
-  :font="foo > bar ? 'mono' : 'sans'"
+  font="mono sans"
   v-bind:p="y-2 x-4"
   border="2 rounded blue-200"
   un-children="m-auto"


### PR DESCRIPTION
Closes #2271

If you were using ternaries with attributes, and the rules you have used are generating false positives you don't want, you could:

- Move those ternaries to `class` attribute
- Block false positives with `blocklist` option: https://unocss.dev/guide/extracting#blocklist