### PR TITLE
refactor(svelte-scoped)!: rewrite `svelte-scoped` mode

### DIFF
--- a/test/__snapshots__/svelte-scoped.test.ts.snap
+++ b/test/__snapshots__/svelte-scoped.test.ts.snap
@@ -1,75 +1,17 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`svelte-scoped > attributify 1`] = `
-"<div
-  class:uno-otwx4w={true}
-  class:uno-g3ok09={true}
-  class:uno-ut4lmc={true}
-  class:uno-99czie={true}
-  class:uno-il0ztn={true}
-/>
-
-<style>
-  :global(.uno-g3ok09) {
-    --un-bg-opacity: 1;
-    background-color: rgba(248, 113, 113, var(--un-bg-opacity));
-  }
-  :global(.uno-il0ztn:hover, .uno-ut4lmc:hover) {
-    --un-bg-opacity: 1;
-    background-color: rgba(96, 165, 250, var(--un-bg-opacity));
-  }
-  :global(.uno-otwx4w) {
-    background-attachment: fixed;
-  }
-  :global(.uno-99czie:hover) {
-    --un-text-opacity: 1;
-    color: rgba(255, 255, 255, var(--un-text-opacity));
-  }
-</style>
-"
-`;
-
-exports[`svelte-scoped > attributify 2`] = `
-"<div
-  class:_bg-red_7dkb0w={true}
-  class:_bg-fixed_7dkb0w={true}
-  class:_hover:bg-blue_7dkb0w={true}
-  class:_hover-bg-blue_7dkb0w={true}
-  class:_hover-text-white_7dkb0w={true}
-/>
-
-<style>
-  :global(._bg-red_7dkb0w) {
-    --un-bg-opacity: 1;
-    background-color: rgba(248, 113, 113, var(--un-bg-opacity));
-  }
-  :global(._hover-bg-blue_7dkb0w:hover, ._hover\\\\:bg-blue_7dkb0w:hover) {
-    --un-bg-opacity: 1;
-    background-color: rgba(96, 165, 250, var(--un-bg-opacity));
-  }
-  :global(._bg-fixed_7dkb0w) {
-    background-attachment: fixed;
-  }
-  :global(._hover-text-white_7dkb0w:hover) {
-    --un-text-opacity: 1;
-    color: rgba(255, 255, 255, var(--un-text-opacity));
-  }
-</style>
-"
-`;
-
 exports[`svelte-scoped > everything 1`] = `
-"<div class=\\"uno-o8l1as\\" />
-<div class:logo class=\\"foo bar\\" />
-<div class:uno-y37ej3={foo} class=\\"shortcut\\" />
+"<div class=\\"uno-r3fudk\\" />
+<div class:uno-15d6f5={logo} class=\\"foo bar\\" />
+<div class:uno-dpcg8b={foo} class=\\"uno-ih6c0o\\" />
 
-<div class=\\"uno-opam79 foo\\">
-  <div class=\\"uno-deus5r\\" />
-  <Button class=\\"uno-deus5r\\" />
+<div class=\\"uno-h7bfmv foo\\">
+  <div class=\\"uno-xbwnix\\" />
+  <Button class=\\"uno-xbwnix\\" />
 </div>
 
 <style>
-  :global(.logo) {
+  :global(.uno-15d6f5) {
     background: url(\\"data:image/svg+xml;utf8,%3Csvg viewBox='0 0 256 308' display='inline-block' vertical-align='middle' width='1em' height='1em' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill='%23FF3E00' d='M239.682 40.707C211.113-.182 154.69-12.301 113.895 13.69L42.247 59.356a82.198 82.198 0 0 0-37.135 55.056a86.566 86.566 0 0 0 8.536 55.576a82.425 82.425 0 0 0-12.296 30.719a87.596 87.596 0 0 0 14.964 66.244c28.574 40.893 84.997 53.007 125.787 27.016l71.648-45.664a82.182 82.182 0 0 0 37.135-55.057a86.601 86.601 0 0 0-8.53-55.577a82.409 82.409 0 0 0 12.29-30.718a87.573 87.573 0 0 0-14.963-66.244'/%3E%3Cpath fill='%23FFF' d='M106.889 270.841c-23.102 6.007-47.497-3.036-61.103-22.648a52.685 52.685 0 0 1-9.003-39.85a49.978 49.978 0 0 1 1.713-6.693l1.35-4.115l3.671 2.697a92.447 92.447 0 0 0 28.036 14.007l2.663.808l-.245 2.659a16.067 16.067 0 0 0 2.89 10.656a17.143 17.143 0 0 0 18.397 6.828a15.786 15.786 0 0 0 4.403-1.935l71.67-45.672a14.922 14.922 0 0 0 6.734-9.977a15.923 15.923 0 0 0-2.713-12.011a17.156 17.156 0 0 0-18.404-6.832a15.78 15.78 0 0 0-4.396 1.933l-27.35 17.434a52.298 52.298 0 0 1-14.553 6.391c-23.101 6.007-47.497-3.036-61.101-22.649a52.681 52.681 0 0 1-9.004-39.849a49.428 49.428 0 0 1 22.34-33.114l71.664-45.677a52.218 52.218 0 0 1 14.563-6.398c23.101-6.007 47.497 3.036 61.101 22.648a52.685 52.685 0 0 1 9.004 39.85a50.559 50.559 0 0 1-1.713 6.692l-1.35 4.116l-3.67-2.693a92.373 92.373 0 0 0-28.037-14.013l-2.664-.809l.246-2.658a16.099 16.099 0 0 0-2.89-10.656a17.143 17.143 0 0 0-18.398-6.828a15.786 15.786 0 0 0-4.402 1.935l-71.67 45.674a14.898 14.898 0 0 0-6.73 9.975a15.9 15.9 0 0 0 2.709 12.012a17.156 17.156 0 0 0 18.404 6.832a15.841 15.841 0 0 0 4.402-1.935l27.345-17.427a52.147 52.147 0 0 1 14.552-6.397c23.101-6.006 47.497 3.037 61.102 22.65a52.681 52.681 0 0 1 9.003 39.848a49.453 49.453 0 0 1-22.34 33.12l-71.664 45.673a52.218 52.218 0 0 1-14.563 6.398'/%3E%3C/svg%3E\\")
       no-repeat;
     background-size: 100% 100%;
@@ -80,10 +22,10 @@ exports[`svelte-scoped > everything 1`] = `
     height: 1em;
     width: 6em;
   }
-  :global(.shortcut) {
+  :global(.uno-ih6c0o) {
     width: 1.25rem;
   }
-  :global(.uno-o8l1as) {
+  :global(.uno-r3fudk) {
     --un-scale-x: 0.05;
     --un-scale-y: 0.05;
     transform: translateX(var(--un-translate-x))
@@ -95,41 +37,41 @@ exports[`svelte-scoped > everything 1`] = `
     --un-bg-opacity: 1;
     background-color: rgba(239, 68, 68, var(--un-bg-opacity));
   }
-  :global(.uno-opam79 > :not([hidden]) ~ :not([hidden])) {
+  :global(.uno-h7bfmv > :not([hidden]) ~ :not([hidden])) {
     --un-space-x-reverse: 0;
     margin-left: calc(0.25rem * calc(1 - var(--un-space-x-reverse)));
     margin-right: calc(0.25rem * var(--un-space-x-reverse));
   }
-  :global([dir=\\"rtl\\"] .uno-opam79 > :not([hidden]) ~ :not([hidden])) {
+  :global([dir=\\"rtl\\"] .uno-h7bfmv > :not([hidden]) ~ :not([hidden])) {
     --un-space-x-reverse: 1;
   }
-  :global(.dark .uno-o8l1as:hover) {
+  :global(.dark .uno-r3fudk:hover) {
     --un-bg-opacity: 1;
     background-color: rgba(34, 197, 94, var(--un-bg-opacity));
   }
-  :global(.uno-opam79) {
+  :global(.uno-h7bfmv) {
     text-align: center;
   }
-  :global(.uno-deus5r) {
+  :global(.uno-xbwnix) {
     font-size: 0.875rem;
     line-height: 1.25rem;
   }
-  :global(.uno-deus5r:hover) {
-    --un-text-opacity: 1;
-    color: rgba(248, 113, 113, var(--un-text-opacity));
-  }
-  :global(.uno-y37ej3) {
+  :global(.uno-dpcg8b) {
     --un-text-opacity: 1;
     color: rgba(251, 146, 60, var(--un-text-opacity));
   }
+  :global(.uno-xbwnix:hover) {
+    --un-text-opacity: 1;
+    color: rgba(248, 113, 113, var(--un-text-opacity));
+  }
   @media (min-width: 640px) {
-    :global(.uno-opam79) {
+    :global(.uno-h7bfmv) {
       text-align: left;
     }
-    :global([dir=\\"rtl\\"] .uno-opam79) {
+    :global([dir=\\"rtl\\"] .uno-h7bfmv) {
       text-align: right;
     }
-    :global(.uno-o8l1as) {
+    :global(.uno-r3fudk) {
       font-size: 1.25rem;
       line-height: 1.75rem;
     }
@@ -140,20 +82,20 @@ exports[`svelte-scoped > everything 1`] = `
 
 exports[`svelte-scoped > everything 2`] = `
 "<div
-  class=\\"_bg-red-500_7dkb0w _dark:hover:bg-green-500_7dkb0w _scale-5_7dkb0w _sm:text-xl_7dkb0w _transform_7dkb0w\\"
+  class=\\"_uno-r3fudk__bg-red-500 _uno-r3fudk__dark:hover:bg-green-500 _uno-r3fudk__scale-5 _uno-r3fudk__sm:text-xl _uno-r3fudk__transform\\"
 />
-<div class:logo class=\\"foo bar\\" />
-<div class:_text-orange-400_7dkb0w={foo} class=\\"shortcut\\" />
+<div class:_uno-15d6f5__logo={logo} class=\\"foo bar\\" />
+<div class:_uno-dpcg8b__text-orange-400={foo} class=\\"_uno-ih6c0o__shortcut\\" />
 
 <div
-  class=\\"_rtl:sm:text-right_7dkb0w _rtl:space-x-reverse_7dkb0w _sm:text-left_7dkb0w _space-x-1_7dkb0w _text-center_7dkb0w foo\\"
+  class=\\"_uno-h7bfmv__rtl:sm:text-right _uno-h7bfmv__rtl:space-x-reverse _uno-h7bfmv__sm:text-left _uno-h7bfmv__space-x-1 _uno-h7bfmv__text-center foo\\"
 >
-  <div class=\\"_hover:text-red_7dkb0w _text-sm_7dkb0w\\" />
-  <Button class=\\"_hover:text-red_7dkb0w _text-sm_7dkb0w\\" />
+  <div class=\\"_uno-xbwnix__hover:text-red _uno-xbwnix__text-sm\\" />
+  <Button class=\\"_uno-xbwnix__hover:text-red _uno-xbwnix__text-sm\\" />
 </div>
 
 <style>
-  :global(.logo) {
+  :global(._uno-15d6f5__logo) {
     background: url(\\"data:image/svg+xml;utf8,%3Csvg viewBox='0 0 256 308' display='inline-block' vertical-align='middle' width='1em' height='1em' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill='%23FF3E00' d='M239.682 40.707C211.113-.182 154.69-12.301 113.895 13.69L42.247 59.356a82.198 82.198 0 0 0-37.135 55.056a86.566 86.566 0 0 0 8.536 55.576a82.425 82.425 0 0 0-12.296 30.719a87.596 87.596 0 0 0 14.964 66.244c28.574 40.893 84.997 53.007 125.787 27.016l71.648-45.664a82.182 82.182 0 0 0 37.135-55.057a86.601 86.601 0 0 0-8.53-55.577a82.409 82.409 0 0 0 12.29-30.718a87.573 87.573 0 0 0-14.963-66.244'/%3E%3Cpath fill='%23FFF' d='M106.889 270.841c-23.102 6.007-47.497-3.036-61.103-22.648a52.685 52.685 0 0 1-9.003-39.85a49.978 49.978 0 0 1 1.713-6.693l1.35-4.115l3.671 2.697a92.447 92.447 0 0 0 28.036 14.007l2.663.808l-.245 2.659a16.067 16.067 0 0 0 2.89 10.656a17.143 17.143 0 0 0 18.397 6.828a15.786 15.786 0 0 0 4.403-1.935l71.67-45.672a14.922 14.922 0 0 0 6.734-9.977a15.923 15.923 0 0 0-2.713-12.011a17.156 17.156 0 0 0-18.404-6.832a15.78 15.78 0 0 0-4.396 1.933l-27.35 17.434a52.298 52.298 0 0 1-14.553 6.391c-23.101 6.007-47.497-3.036-61.101-22.649a52.681 52.681 0 0 1-9.004-39.849a49.428 49.428 0 0 1 22.34-33.114l71.664-45.677a52.218 52.218 0 0 1 14.563-6.398c23.101-6.007 47.497 3.036 61.101 22.648a52.685 52.685 0 0 1 9.004 39.85a50.559 50.559 0 0 1-1.713 6.692l-1.35 4.116l-3.67-2.693a92.373 92.373 0 0 0-28.037-14.013l-2.664-.809l.246-2.658a16.099 16.099 0 0 0-2.89-10.656a17.143 17.143 0 0 0-18.398-6.828a15.786 15.786 0 0 0-4.402 1.935l-71.67 45.674a14.898 14.898 0 0 0-6.73 9.975a15.9 15.9 0 0 0 2.709 12.012a17.156 17.156 0 0 0 18.404 6.832a15.841 15.841 0 0 0 4.402-1.935l27.345-17.427a52.147 52.147 0 0 1 14.552-6.397c23.101-6.006 47.497 3.037 61.102 22.65a52.681 52.681 0 0 1 9.003 39.848a49.453 49.453 0 0 1-22.34 33.12l-71.664 45.673a52.218 52.218 0 0 1-14.563 6.398'/%3E%3C/svg%3E\\")
       no-repeat;
     background-size: 100% 100%;
@@ -164,10 +106,10 @@ exports[`svelte-scoped > everything 2`] = `
     height: 1em;
     width: 6em;
   }
-  :global(.shortcut) {
+  :global(._uno-ih6c0o__shortcut) {
     width: 1.25rem;
   }
-  :global(._scale-5_7dkb0w) {
+  :global(._uno-r3fudk__scale-5) {
     --un-scale-x: 0.05;
     --un-scale-y: 0.05;
     transform: translateX(var(--un-translate-x))
@@ -177,7 +119,7 @@ exports[`svelte-scoped > everything 2`] = `
       skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x))
       scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z));
   }
-  :global(._transform_7dkb0w) {
+  :global(._uno-r3fudk__transform) {
     transform: translateX(var(--un-translate-x))
       translateY(var(--un-translate-y)) translateZ(var(--un-translate-z))
       rotate(var(--un-rotate)) rotateX(var(--un-rotate-x))
@@ -185,50 +127,50 @@ exports[`svelte-scoped > everything 2`] = `
       skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x))
       scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z));
   }
-  :global(._space-x-1_7dkb0w > :not([hidden]) ~ :not([hidden])) {
+  :global(._uno-h7bfmv__space-x-1 > :not([hidden]) ~ :not([hidden])) {
     --un-space-x-reverse: 0;
     margin-left: calc(0.25rem * calc(1 - var(--un-space-x-reverse)));
     margin-right: calc(0.25rem * var(--un-space-x-reverse));
   }
   :global(
       [dir=\\"rtl\\"]
-        ._rtl\\\\:space-x-reverse_7dkb0w
+        ._uno-h7bfmv__rtl\\\\:space-x-reverse
         > :not([hidden])
         ~ :not([hidden])
     ) {
     --un-space-x-reverse: 1;
   }
-  :global(._bg-red-500_7dkb0w) {
+  :global(._uno-r3fudk__bg-red-500) {
     --un-bg-opacity: 1;
     background-color: rgba(239, 68, 68, var(--un-bg-opacity));
   }
-  :global(.dark ._dark\\\\:hover\\\\:bg-green-500_7dkb0w:hover) {
+  :global(.dark ._uno-r3fudk__dark\\\\:hover\\\\:bg-green-500:hover) {
     --un-bg-opacity: 1;
     background-color: rgba(34, 197, 94, var(--un-bg-opacity));
   }
-  :global(._text-center_7dkb0w) {
+  :global(._uno-h7bfmv__text-center) {
     text-align: center;
   }
-  :global(._text-sm_7dkb0w) {
+  :global(._uno-xbwnix__text-sm) {
     font-size: 0.875rem;
     line-height: 1.25rem;
   }
-  :global(._hover\\\\:text-red_7dkb0w:hover) {
-    --un-text-opacity: 1;
-    color: rgba(248, 113, 113, var(--un-text-opacity));
-  }
-  :global(._text-orange-400_7dkb0w) {
+  :global(._uno-dpcg8b__text-orange-400) {
     --un-text-opacity: 1;
     color: rgba(251, 146, 60, var(--un-text-opacity));
   }
+  :global(._uno-xbwnix__hover\\\\:text-red:hover) {
+    --un-text-opacity: 1;
+    color: rgba(248, 113, 113, var(--un-text-opacity));
+  }
   @media (min-width: 640px) {
-    :global(._sm\\\\:text-left_7dkb0w) {
+    :global(._uno-h7bfmv__sm\\\\:text-left) {
       text-align: left;
     }
-    :global([dir=\\"rtl\\"] ._rtl\\\\:sm\\\\:text-right_7dkb0w) {
+    :global([dir=\\"rtl\\"] ._uno-h7bfmv__rtl\\\\:sm\\\\:text-right) {
       text-align: right;
     }
-    :global(._sm\\\\:text-xl_7dkb0w) {
+    :global(._uno-r3fudk__sm\\\\:text-xl) {
       font-size: 1.25rem;
       line-height: 1.75rem;
     }
@@ -237,15 +179,11 @@ exports[`svelte-scoped > everything 2`] = `
 "
 `;
 
-exports[`svelte-scoped > search attributify candidates only on template 1`] = `undefined`;
-
-exports[`svelte-scoped > search attributify candidates only on template 2`] = `undefined`;
-
 exports[`svelte-scoped > shortcut with icon 1`] = `
-"<span class=\\"logo\\" />
+"<span class=\\"uno-15d6f5\\" />
 
 <style>
-  :global(.logo) {
+  :global(.uno-15d6f5) {
     background: url(\\"data:image/svg+xml;utf8,%3Csvg viewBox='0 0 256 308' display='inline-block' vertical-align='middle' width='1em' height='1em' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill='%23FF3E00' d='M239.682 40.707C211.113-.182 154.69-12.301 113.895 13.69L42.247 59.356a82.198 82.198 0 0 0-37.135 55.056a86.566 86.566 0 0 0 8.536 55.576a82.425 82.425 0 0 0-12.296 30.719a87.596 87.596 0 0 0 14.964 66.244c28.574 40.893 84.997 53.007 125.787 27.016l71.648-45.664a82.182 82.182 0 0 0 37.135-55.057a86.601 86.601 0 0 0-8.53-55.577a82.409 82.409 0 0 0 12.29-30.718a87.573 87.573 0 0 0-14.963-66.244'/%3E%3Cpath fill='%23FFF' d='M106.889 270.841c-23.102 6.007-47.497-3.036-61.103-22.648a52.685 52.685 0 0 1-9.003-39.85a49.978 49.978 0 0 1 1.713-6.693l1.35-4.115l3.671 2.697a92.447 92.447 0 0 0 28.036 14.007l2.663.808l-.245 2.659a16.067 16.067 0 0 0 2.89 10.656a17.143 17.143 0 0 0 18.397 6.828a15.786 15.786 0 0 0 4.403-1.935l71.67-45.672a14.922 14.922 0 0 0 6.734-9.977a15.923 15.923 0 0 0-2.713-12.011a17.156 17.156 0 0 0-18.404-6.832a15.78 15.78 0 0 0-4.396 1.933l-27.35 17.434a52.298 52.298 0 0 1-14.553 6.391c-23.101 6.007-47.497-3.036-61.101-22.649a52.681 52.681 0 0 1-9.004-39.849a49.428 49.428 0 0 1 22.34-33.114l71.664-45.677a52.218 52.218 0 0 1 14.563-6.398c23.101-6.007 47.497 3.036 61.101 22.648a52.685 52.685 0 0 1 9.004 39.85a50.559 50.559 0 0 1-1.713 6.692l-1.35 4.116l-3.67-2.693a92.373 92.373 0 0 0-28.037-14.013l-2.664-.809l.246-2.658a16.099 16.099 0 0 0-2.89-10.656a17.143 17.143 0 0 0-18.398-6.828a15.786 15.786 0 0 0-4.402 1.935l-71.67 45.674a14.898 14.898 0 0 0-6.73 9.975a15.9 15.9 0 0 0 2.709 12.012a17.156 17.156 0 0 0 18.404 6.832a15.841 15.841 0 0 0 4.402-1.935l27.345-17.427a52.147 52.147 0 0 1 14.552-6.397c23.101-6.006 47.497 3.037 61.102 22.65a52.681 52.681 0 0 1 9.003 39.848a49.453 49.453 0 0 1-22.34 33.12l-71.664 45.673a52.218 52.218 0 0 1-14.563 6.398'/%3E%3C/svg%3E\\")
       no-repeat;
     background-size: 100% 100%;

--- a/test/svelte-scoped.test.ts
+++ b/test/svelte-scoped.test.ts
@@ -42,10 +42,10 @@ describe('svelte-scoped', () => {
   test('simple', async () => {
     const code = '<div class="bg-red-500" />'
     expect(await transform(code)).toMatchInlineSnapshot(`
-      "<div class=\\"uno-orrz3z\\" />
+      "<div class=\\"uno-qecmtp\\" />
 
       <style>
-        :global(.uno-orrz3z) {
+        :global(.uno-qecmtp) {
           --un-bg-opacity: 1;
           background-color: rgba(239, 68, 68, var(--un-bg-opacity));
         }
@@ -53,47 +53,12 @@ describe('svelte-scoped', () => {
       "
     `)
     expect(await transform(code, { combine: false })).toMatchInlineSnapshot(`
-      "<div class=\\"_bg-red-500_7dkb0w\\" />
+      "<div class=\\"_uno-qecmtp__bg-red-500\\" />
 
       <style>
-        :global(._bg-red-500_7dkb0w) {
+        :global(._uno-qecmtp__bg-red-500) {
           --un-bg-opacity: 1;
           background-color: rgba(239, 68, 68, var(--un-bg-opacity));
-        }
-      </style>
-      "
-    `)
-  })
-
-  test('does not change shortcut names', async () => {
-    const code = `
-    <div class="shortcut mb-1 foo" />
-    <div class:shortcut />
-    `.trim()
-    expect(await transform(code)).toMatchInlineSnapshot(`
-      "<div class=\\"uno-2se4c1 shortcut foo\\" />
-      <div class:shortcut />
-
-      <style>
-        :global(.uno-2se4c1) {
-          margin-bottom: 0.25rem;
-        }
-        :global(.shortcut) {
-          width: 1.25rem;
-        }
-      </style>
-      "
-    `)
-    expect(await transform(code, { combine: false })).toMatchInlineSnapshot(`
-      "<div class=\\"_mb-1_7dkb0w shortcut foo\\" />
-      <div class:shortcut />
-
-      <style>
-        :global(._mb-1_7dkb0w) {
-          margin-bottom: 0.25rem;
-        }
-        :global(.shortcut) {
-          width: 1.25rem;
         }
       </style>
       "
@@ -103,18 +68,18 @@ describe('svelte-scoped', () => {
   test('wraps parent and child dependent classes like rtl: and space-x-1 with :global() wrapper', async () => {
     const code = '<div class="mb-1 text-sm rtl:right-0 space-x-1" />'
     expect(await transform(code)).toMatchInlineSnapshot(`
-      "<div class=\\"uno-795nkx\\" />
+      "<div class=\\"uno-5o8qvr\\" />
 
       <style>
-        :global([dir=\\"rtl\\"] .uno-795nkx) {
+        :global([dir=\\"rtl\\"] .uno-5o8qvr) {
           right: 0;
         }
-        :global(.uno-795nkx) {
+        :global(.uno-5o8qvr) {
           margin-bottom: 0.25rem;
           font-size: 0.875rem;
           line-height: 1.25rem;
         }
-        :global(.uno-795nkx > :not([hidden]) ~ :not([hidden])) {
+        :global(.uno-5o8qvr > :not([hidden]) ~ :not([hidden])) {
           --un-space-x-reverse: 0;
           margin-left: calc(0.25rem * calc(1 - var(--un-space-x-reverse)));
           margin-right: calc(0.25rem * var(--un-space-x-reverse));
@@ -124,22 +89,22 @@ describe('svelte-scoped', () => {
     `)
     expect(await transform(code, { combine: false })).toMatchInlineSnapshot(`
       "<div
-        class=\\"_mb-1_7dkb0w _rtl:right-0_7dkb0w _space-x-1_7dkb0w _text-sm_7dkb0w\\"
+        class=\\"_uno-5o8qvr__mb-1 _uno-5o8qvr__rtl:right-0 _uno-5o8qvr__space-x-1 _uno-5o8qvr__text-sm\\"
       />
 
       <style>
-        :global([dir=\\"rtl\\"] ._rtl\\\\:right-0_7dkb0w) {
+        :global([dir=\\"rtl\\"] ._uno-5o8qvr__rtl\\\\:right-0) {
           right: 0;
         }
-        :global(._mb-1_7dkb0w) {
+        :global(._uno-5o8qvr__mb-1) {
           margin-bottom: 0.25rem;
         }
-        :global(._space-x-1_7dkb0w > :not([hidden]) ~ :not([hidden])) {
+        :global(._uno-5o8qvr__space-x-1 > :not([hidden]) ~ :not([hidden])) {
           --un-space-x-reverse: 0;
           margin-left: calc(0.25rem * calc(1 - var(--un-space-x-reverse)));
           margin-right: calc(0.25rem * var(--un-space-x-reverse));
         }
-        :global(._text-sm_7dkb0w) {
+        :global(._uno-5o8qvr__text-sm) {
           font-size: 0.875rem;
           line-height: 1.25rem;
         }
@@ -158,13 +123,39 @@ describe('svelte-scoped', () => {
     <div class:flex class="bar" />
     `.trim(), { format: false })
     expect(result).toMatchInlineSnapshot(`
-      "<div class=\\"uno-oo7fkj\\"/>
-          <div class:uno-oo7fkj={bar} />
-          <div class:uno-oo7fkj={flex} />
-          <div class:uno-oo7fkj={flex}/>
-          <div class:uno-oo7fkj={flex}>
-          <div class:uno-oo7fkj={flex} class=\\"bar\\" />
-      <style>:global(.uno-oo7fkj){display:flex;}</style>"
+      "<div class=\\"uno-ntbwax\\"/>
+          <div class:uno-ntbwax=\\"{bar}\\" />
+          <div class:uno-ntbwax=\\"{flex}\\" />
+          <div class:uno-ntbwax=\\"{flex}\\"/>
+          <div class:uno-ntbwax=\\"{flex}\\">
+          <div class:uno-ntbwax=\\"{flex}\\" class=\\"bar\\" />
+      <style>:global(.uno-ntbwax){display:flex;}</style>"
+    `)
+  })
+
+  test('handles class directives, including shorthand syntax; do not handle if class name is not known', async () => {
+    const result = await transform(`
+    <div class:flex={bar} />
+    <div class:flex />
+    <div class:foo={bar} />
+    <div class:bar />
+    <div class:foo class="bar" />
+    <div class:bar class="bar" />
+    `.trim())
+    expect(result).toMatchInlineSnapshot(`
+      "<div class:uno-ntbwax={bar} />
+      <div class:uno-ntbwax={flex} />
+      <div class:foo={bar} />
+      <div class:bar />
+      <div class:foo class=\\"bar\\" />
+      <div class:bar class=\\"bar\\" />
+
+      <style>
+        :global(.uno-ntbwax) {
+          display: flex;
+        }
+      </style>
+      "
     `)
   })
 
@@ -178,11 +169,11 @@ describe('svelte-scoped', () => {
     const result = await transform(`
     <div class="dark:hover:sm:space-x-1" />`.trim())
     expect(result).toMatchInlineSnapshot(`
-      "<div class=\\"uno-1eyzu3\\" />
+      "<div class=\\"uno-ghi1pr\\" />
 
       <style>
         @media (min-width: 640px) {
-          :global(.dark .uno-1eyzu3:hover > :not([hidden]) ~ :not([hidden])) {
+          :global(.dark .uno-ghi1pr:hover > :not([hidden]) ~ :not([hidden])) {
             --un-space-x-reverse: 0;
             margin-left: calc(0.25rem * calc(1 - var(--un-space-x-reverse)));
             margin-right: calc(0.25rem * var(--un-space-x-reverse));
@@ -196,10 +187,10 @@ describe('svelte-scoped', () => {
   test('does not place :global() around animate-bounce keyframe digits', async () => {
     const result = await transform('<div class="animate-bounce" />')
     expect(result).toMatchInlineSnapshot(`
-      "<div class=\\"uno-swfyci\\" />
+      "<div class=\\"uno-08wkbk\\" />
 
       <style>
-        :global(.uno-swfyci) {
+        :global(.uno-08wkbk) {
           animation: bounce 1s linear infinite;
         }
         @keyframes bounce {
@@ -230,16 +221,16 @@ describe('svelte-scoped', () => {
     <style></style>`, { format: false })
     expect(backticks).toMatchInlineSnapshot(`
       "<script></script>
-          <span class=\`uno-k2ufqh\` />
-          <style>:global(.uno-k2ufqh){font-weight:700;}</style>"
+          <span class=\\"uno-7eon1d\\" />
+          <style>:global(.uno-7eon1d){font-weight:700;}</style>"
     `)
     const singleQuotes = await transform(`
     <span class='font-bold' />`.trim())
     expect(singleQuotes).toMatchInlineSnapshot(`
-      "<span class=\\"uno-k2ufqh\\" />
+      "<span class=\\"uno-7eon1d\\" />
 
       <style>
-        :global(.uno-k2ufqh) {
+        :global(.uno-7eon1d) {
           font-weight: 700;
         }
       </style>
@@ -253,26 +244,26 @@ describe('svelte-scoped', () => {
     <span class="font-bold {bar ? 'text-red-600' : 'text-(green-500 blue-400) font-semibold boo'} underline foo {baz ? 'italic ' : ''}">Hello</span>`.trim())
     expect(result).toMatchInlineSnapshot(`
       "<span
-        class=\\"uno-r4l94t {bar ? 'uno-ffvc5a' : 'uno-24bnl1 boo'} foo {baz
-          ? 'uno-br1nw8'
+        class=\\"uno-ub1kk5 foo {bar ? 'uno-3mbu3c' : 'uno-1wg5ef boo'} {baz
+          ? 'uno-mfrd4i'
           : ''}\\">Hello</span
       >
 
       <style>
-        :global(.uno-24bnl1) {
+        :global(.uno-1wg5ef) {
           font-weight: 600;
           --un-text-opacity: 1;
           color: rgba(96, 165, 250, var(--un-text-opacity));
           color: rgba(34, 197, 94, var(--un-text-opacity));
         }
-        :global(.uno-r4l94t) {
+        :global(.uno-ub1kk5) {
           font-weight: 700;
           text-decoration-line: underline;
         }
-        :global(.uno-br1nw8) {
+        :global(.uno-mfrd4i) {
           font-style: italic;
         }
-        :global(.uno-ffvc5a) {
+        :global(.uno-3mbu3c) {
           --un-text-opacity: 1;
           color: rgba(220, 38, 38, var(--un-text-opacity));
         }
@@ -282,34 +273,177 @@ describe('svelte-scoped', () => {
   })
 
   test('handles classes in inline expressions', async () => {
-    const result = await transform(`
-    <span class={classnames('text-red-500', foo ? "font-bold" : 'font-medium', 'foo', bar && 'hover:(bg-blue-500 text-white) baz')}>Hello</span>`.trim())
-    expect(result).toMatchInlineSnapshot(`
+    const code = `
+      <span
+        class={classnames(
+          'text-red-500 px-4 py-2',
+          foo ? "font-bold shortcut" : 'font-medium',
+          'foo',
+          bar && 'hover:(bg-blue-500 text-white) baz',
+        )}
+      >
+        Hello
+      </span>
+
+      <input
+        class={classnames(
+          'border border-gray-300 rounded px-4 py-2 transition focus:foo hover:border-gray-400 data-[error]:siblings:aria-[invalid]:visible',
+          'left-icon' in $$slots && 'pl-10'
+        )}
+        {...$$restProps}
+      />
+    `.trim()
+    expect(await transform(code)).toMatchInlineSnapshot(`
       "<span
         class={classnames(
-          \\"uno-ik91av\\",
-          foo ? \\"uno-k2ufqh\\" : \\"uno-wgrcwx\\",
+          \\"uno-fjmpfw\\",
+          foo ? \\"uno-a6q3c1\\" : \\"uno-ochcf1\\",
           \\"foo\\",
-          bar && \\"uno-484hzz baz\\"
-        )}>Hello</span
+          bar && \\"uno-shagg1 baz\\"
+        )}
       >
+        Hello
+      </span>
+
+      <input
+        class={classnames(
+          \\"uno-aoxmfn focus:foo\\",
+          \\"left-icon\\" in $$slots && \\"uno-rm5qbw\\"
+        )}
+        {...$$restProps}
+      />
 
       <style>
-        :global(.uno-484hzz:hover) {
+        :global(.uno-aoxmfn[aria-invalid] ~ *[data-error]) {
+          visibility: visible;
+        }
+        :global(.uno-a6q3c1) {
+          width: 1.25rem;
+          font-weight: 700;
+        }
+        :global(.uno-aoxmfn) {
+          border-width: 1px;
+          --un-border-opacity: 1;
+          border-color: rgba(209, 213, 219, var(--un-border-opacity));
+          border-radius: 0.25rem;
+          padding-left: 1rem;
+          padding-right: 1rem;
+          padding-top: 0.5rem;
+          padding-bottom: 0.5rem;
+          transition-property: color, background-color, border-color, outline-color,
+            text-decoration-color, fill, stroke, opacity, box-shadow, transform,
+            filter, backdrop-filter;
+          transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+          transition-duration: 150ms;
+        }
+        :global(.uno-aoxmfn:hover) {
+          --un-border-opacity: 1;
+          border-color: rgba(156, 163, 175, var(--un-border-opacity));
+        }
+        :global(.uno-shagg1:hover) {
           --un-bg-opacity: 1;
           background-color: rgba(59, 130, 246, var(--un-bg-opacity));
           --un-text-opacity: 1;
           color: rgba(255, 255, 255, var(--un-text-opacity));
         }
-        :global(.uno-k2ufqh) {
-          font-weight: 700;
-        }
-        :global(.uno-wgrcwx) {
-          font-weight: 500;
-        }
-        :global(.uno-ik91av) {
+        :global(.uno-fjmpfw) {
+          padding-left: 1rem;
+          padding-right: 1rem;
+          padding-top: 0.5rem;
+          padding-bottom: 0.5rem;
           --un-text-opacity: 1;
           color: rgba(239, 68, 68, var(--un-text-opacity));
+        }
+        :global(.uno-rm5qbw) {
+          padding-left: 2.5rem;
+        }
+        :global(.uno-ochcf1) {
+          font-weight: 500;
+        }
+      </style>
+      "
+    `)
+    expect(await transform(code, { combine: false })).toMatchInlineSnapshot(`
+      "<span
+        class={classnames(
+          \\"_uno-fjmpfw__px-4 _uno-fjmpfw__py-2 _uno-fjmpfw__text-red-500\\",
+          foo
+            ? \\"_uno-a6q3c1__font-bold _uno-a6q3c1__shortcut\\"
+            : \\"_uno-ochcf1__font-medium\\",
+          \\"foo\\",
+          bar && \\"_uno-shagg1__hover:bg-blue-500 _uno-shagg1__hover:text-white baz\\"
+        )}
+      >
+        Hello
+      </span>
+
+      <input
+        class={classnames(
+          \\"_uno-aoxmfn__border _uno-aoxmfn__border-gray-300 _uno-aoxmfn__data-[error]:siblings:aria-[invalid]:visible _uno-aoxmfn__hover:border-gray-400 _uno-aoxmfn__px-4 _uno-aoxmfn__py-2 _uno-aoxmfn__rounded _uno-aoxmfn__transition focus:foo\\",
+          \\"left-icon\\" in $$slots && \\"_uno-rm5qbw__pl-10\\"
+        )}
+        {...$$restProps}
+      />
+
+      <style>
+        :global(
+            ._uno-aoxmfn__data-\\\\[error\\\\]\\\\:siblings\\\\:aria-\\\\[invalid\\\\]\\\\:visible[aria-invalid]
+              ~ *[data-error]
+          ) {
+          visibility: visible;
+        }
+        :global(._uno-a6q3c1__shortcut) {
+          width: 1.25rem;
+        }
+        :global(._uno-aoxmfn__border) {
+          border-width: 1px;
+        }
+        :global(._uno-aoxmfn__border-gray-300) {
+          --un-border-opacity: 1;
+          border-color: rgba(209, 213, 219, var(--un-border-opacity));
+        }
+        :global(._uno-aoxmfn__hover\\\\:border-gray-400:hover) {
+          --un-border-opacity: 1;
+          border-color: rgba(156, 163, 175, var(--un-border-opacity));
+        }
+        :global(._uno-aoxmfn__rounded) {
+          border-radius: 0.25rem;
+        }
+        :global(._uno-shagg1__hover\\\\:bg-blue-500:hover) {
+          --un-bg-opacity: 1;
+          background-color: rgba(59, 130, 246, var(--un-bg-opacity));
+        }
+        :global(._uno-aoxmfn__px-4, ._uno-fjmpfw__px-4) {
+          padding-left: 1rem;
+          padding-right: 1rem;
+        }
+        :global(._uno-aoxmfn__py-2, ._uno-fjmpfw__py-2) {
+          padding-top: 0.5rem;
+          padding-bottom: 0.5rem;
+        }
+        :global(._uno-rm5qbw__pl-10) {
+          padding-left: 2.5rem;
+        }
+        :global(._uno-a6q3c1__font-bold) {
+          font-weight: 700;
+        }
+        :global(._uno-ochcf1__font-medium) {
+          font-weight: 500;
+        }
+        :global(._uno-fjmpfw__text-red-500) {
+          --un-text-opacity: 1;
+          color: rgba(239, 68, 68, var(--un-text-opacity));
+        }
+        :global(._uno-shagg1__hover\\\\:text-white:hover) {
+          --un-text-opacity: 1;
+          color: rgba(255, 255, 255, var(--un-text-opacity));
+        }
+        :global(._uno-aoxmfn__transition) {
+          transition-property: color, background-color, border-color, outline-color,
+            text-decoration-color, fill, stroke, opacity, box-shadow, transform,
+            filter, backdrop-filter;
+          transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+          transition-duration: 150ms;
         }
       </style>
       "
@@ -322,27 +456,27 @@ describe('svelte-scoped', () => {
     expect(result).toMatchInlineSnapshot(`
       "<span
         class={classnames(
-          \\"uno-ik91av\\",
-          foo ? \\"uno-k2ufqh\\" : \\"uno-wgrcwx\\",
+          \\"uno-jz8hdl\\",
+          foo ? \\"uno-7eon1d\\" : \\"uno-ochcf1\\",
           \\"foo\\",
-          bar && \\"uno-484hzz baz\\"
+          bar && \\"uno-shagg1 baz\\"
         )}>Hello</span
       >
 
       <style>
-        :global(.uno-484hzz:hover) {
+        :global(.uno-shagg1:hover) {
           --un-bg-opacity: 1;
           background-color: rgba(59, 130, 246, var(--un-bg-opacity));
           --un-text-opacity: 1;
           color: rgba(255, 255, 255, var(--un-text-opacity));
         }
-        :global(.uno-k2ufqh) {
+        :global(.uno-7eon1d) {
           font-weight: 700;
         }
-        :global(.uno-wgrcwx) {
+        :global(.uno-ochcf1) {
           font-weight: 500;
         }
-        :global(.uno-ik91av) {
+        :global(.uno-jz8hdl) {
           --un-text-opacity: 1;
           color: rgba(239, 68, 68, var(--un-text-opacity));
         }
@@ -362,23 +496,47 @@ describe('svelte-scoped', () => {
     expect(result).toMatchInlineSnapshot('undefined')
   })
 
+  test('preserve existing style tag', async () => {
+    const result = await transform(`
+    <div class="px-2" />
+    <style lang="scss">
+      .foo {
+        color: red;
+      }
+    </style>`.trim())
+    expect(result).toMatchInlineSnapshot(`
+      "<div class=\\"uno-u9076x\\" />
+
+      <style lang=\\"scss\\">
+        .foo {
+          color: red;
+        }
+        :global(.uno-u9076x) {
+          padding-left: 0.5rem;
+          padding-right: 0.5rem;
+        }
+      </style>
+      "
+    `)
+  })
+
   test('dev, only hash but not combine mode, handles classes that fail when coming at the beginning of a shortcut name', async () => {
     const code = '<div class="mb-1 !mt-2 md:mr-3 space-x-1" />'
     expect(await transform(code)).toMatchInlineSnapshot(`
-      "<div class=\\"uno-8mjgqp\\" />
+      "<div class=\\"uno-apjhc7\\" />
 
       <style>
-        :global(.uno-8mjgqp) {
+        :global(.uno-apjhc7) {
           margin-top: 0.5rem !important;
           margin-bottom: 0.25rem;
         }
-        :global(.uno-8mjgqp > :not([hidden]) ~ :not([hidden])) {
+        :global(.uno-apjhc7 > :not([hidden]) ~ :not([hidden])) {
           --un-space-x-reverse: 0;
           margin-left: calc(0.25rem * calc(1 - var(--un-space-x-reverse)));
           margin-right: calc(0.25rem * var(--un-space-x-reverse));
         }
         @media (min-width: 768px) {
-          :global(.uno-8mjgqp) {
+          :global(.uno-apjhc7) {
             margin-right: 0.75rem;
           }
         }
@@ -386,46 +544,30 @@ describe('svelte-scoped', () => {
       "
     `)
     expect(await transform(code, { combine: false })).toMatchInlineSnapshot(`
-      "<div class=\\"_!mt-2_7dkb0w _mb-1_7dkb0w _md:mr-3_7dkb0w _space-x-1_7dkb0w\\" />
+      "<div
+        class=\\"_uno-apjhc7__!mt-2 _uno-apjhc7__mb-1 _uno-apjhc7__md:mr-3 _uno-apjhc7__space-x-1\\"
+      />
 
       <style>
-        :global(._\\\\!mt-2_7dkb0w) {
+        :global(._uno-apjhc7__\\\\!mt-2) {
           margin-top: 0.5rem !important;
         }
-        :global(._mb-1_7dkb0w) {
+        :global(._uno-apjhc7__mb-1) {
           margin-bottom: 0.25rem;
         }
-        :global(._space-x-1_7dkb0w > :not([hidden]) ~ :not([hidden])) {
+        :global(._uno-apjhc7__space-x-1 > :not([hidden]) ~ :not([hidden])) {
           --un-space-x-reverse: 0;
           margin-left: calc(0.25rem * calc(1 - var(--un-space-x-reverse)));
           margin-right: calc(0.25rem * var(--un-space-x-reverse));
         }
         @media (min-width: 768px) {
-          :global(._md\\\\:mr-3_7dkb0w) {
+          :global(._uno-apjhc7__md\\\\:mr-3) {
             margin-right: 0.75rem;
           }
         }
       </style>
       "
     `)
-  })
-
-  test('attributify', async () => {
-    const code = `
-    <div bg="red fixed hover:blue" hover="bg-blue text-white"  />
-        `.trim()
-    expect(await transform(code)).toMatchSnapshot()
-    expect(await transform(code, { combine: false })).toMatchSnapshot()
-  })
-
-  test('search attributify candidates only on template', async () => {
-    const code = `<script lang="ts">
-    $: visible
-  </script>
-  
-  <Render {visible}></Render>`.trim()
-    expect(await transform(code)).toMatchSnapshot()
-    expect(await transform(code, { combine: false })).toMatchSnapshot()
   })
 
   test('everything', async () => {
@@ -441,15 +583,5 @@ describe('svelte-scoped', () => {
     `.trim()
     expect(await transform(code)).toMatchSnapshot()
     expect(await transform(code, { combine: false })).toMatchSnapshot()
-  })
-
-  // BUG: When this plugin is run on a component library first, and then in a project second, make sure to use different hashing prefixes because when `uno.parseToken()` checks a previously hashed class like `.uno-ssrvwc` it will add it to uno's cache of non-matches, then when `uno.generate()` runs it will not output the result of that shortcut. I don't know the proper solution to this and I don't think clearing uno's cache of non-matches is right. To see this bug run the following test:
-  test.skip('BUG: when a hashed style already exists (from an imported component library that was already processed), and style is found again it will not be output', async () => {
-    const result = await transform(`
-    <div class="uno-ssrvwc hidden" />`.trim())
-    expect(result).toMatchInlineSnapshot(`
-      "<div class=\\"uno-ssrvwc uno-ssrvwc\\" />
-      <style></style>"
-    `)
   })
 })


### PR DESCRIPTION
Existing implementation of `svelte-scoped` plugin has some flaws such as incapability of parsing complex svelte expression strings. This PR thoroughly rewrites `svelte-scoped` plugin transformation code and make some optimization.

## Notable, and possible breaking changes
* Overall transformation pipeline is greatly simplified for code readability and performance improvement.
* Drop attributify mode, which was buggy and had negative effect on performance and should be handled in the separated plugin.
* Shortcuts will be hashed as the same as rest of other utilities. It makes generated code more consistent and works in an expected manner. It's new behavior is also aligned with `@unocss/transformer-compile-class`, which compiles everything including user-defined shortcuts to a single generated class.
* Class hashes will be consistent between production and development mode. In before, the same `px-2 py-1` class will be hashed into `uno-nv0d81` in production and `_px-2_8thd01 _py-1_8thd01` in development because different hash algorithm was used. It will now hashed into `_uno-nv0d81__px-2 _uno-nv0d81__py-1` in development, make it deterministic between production and development environment. Developers will be able to know what will be the actual compiled class name in the production while developing, and will be able to track down production code to development code by comparing the hashed class names.

## Bug fixes
* Some utilities was not generated when handling complex expressions in `class=` attribute.
* Class directives wrapped in quotes such as `class:flex="{flex}"` will be correctly handled.
* Existing style tag attributes will be preserved such as `lang="scss"`.

## Questions
* Still not sure it is a good decision to drop attributify support. Although it was somewhat buggy, degrading performance (previous implementation was really more like workaround), and non-standard in svelte (typescript and `svelte-check` will emit error if non-standard html attributes are used in the code), there is a some demand for it and I'm not a great fan of making user-facing breaking change.
* Since this PR has some opinionated changes, I'm open for any discussions.