### PR TITLE
feat(preset-web-fonts): `custom` provider support

### DIFF
--- a/docs/presets/web-fonts.md
+++ b/docs/presets/web-fonts.md
@@ -55,6 +55,7 @@ import { presetWebFonts } from 'unocss'
 Currently supported Providers:
 
 - `none` - do nothing, treat the font as system font
+- `custom`- use custom url to fetch font source
 - `google` - [Google Fonts](https://fonts.google.com/)
 - `bunny` - [Privacy-Friendly Google Fonts](https://fonts.bunny.net/)
 - `fontshare` - [Quality Font Service by ITF](https://www.fontshare.com/)
@@ -118,6 +119,10 @@ interface WebFontMeta {
    * @default <matches root config>
    */
   provider?: WebFontsProviders
+  /**
+   * Override the provider url
+   */
+  url?: string
 }
 ```
 
@@ -145,6 +150,11 @@ Inline CSS `@import()`.
 
 Use your own function to fetch font source. See [Custom fetch function](#custom-fetch-function).
 
+### url
+- **Type:** `string`
+- **Default:** `undefined`
+
+Custom url to fetch font source. Only used if `provider` is `custom`.
 
 ## Example
 

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -1,8 +1,9 @@
 import type { Preset } from '@unocss/core'
 import { toArray } from '@unocss/core'
 import { BunnyFontsProvider } from './providers/bunny'
-import { GoogleFontsProvider } from './providers/google'
+import { CustomProvider } from './providers/custom'
 import { FontshareProvider } from './providers/fontshare'
+import { GoogleFontsProvider } from './providers/google'
 import { NoneProvider } from './providers/none'
 import type { WebFontMeta, WebFontsOptions, WebFontsProviders } from './types'
 
@@ -26,6 +27,7 @@ const providers = {
   google: GoogleFontsProvider,
   bunny: BunnyFontsProvider,
   fontshare: FontshareProvider,
+  custom: CustomProvider,
   none: NoneProvider,
 }
 

--- a/packages/preset-web-fonts/src/providers/custom.ts
+++ b/packages/preset-web-fonts/src/providers/custom.ts
@@ -1,0 +1,24 @@
+import type { Provider, WebFontsProviders } from '../types'
+
+export const CustomProvider: Provider = createCustomProvider('custom')
+
+export function createCustomProvider(name: WebFontsProviders): Provider {
+  return {
+    name,
+    getImportUrl(fonts) {
+      const urls = fonts
+        .filter(i => i.provider === name)
+        .map(i => i.url)
+
+      const uniqueUrls = urls
+        .filter((element, index) => urls.indexOf(element) === index)
+
+      if (uniqueUrls.length > 1)
+        throw new Error('Only one custom font provider can be used at a time')
+      return uniqueUrls[0]
+    },
+    getFontName(font) {
+      return `"${font.name}"`
+    },
+  }
+}

--- a/packages/preset-web-fonts/src/types.ts
+++ b/packages/preset-web-fonts/src/types.ts
@@ -1,4 +1,4 @@
-export type WebFontsProviders = 'google' | 'bunny' | 'fontshare' | 'none'
+export type WebFontsProviders = 'google' | 'bunny' | 'fontshare' | 'custom' | 'none'
 
 export interface WebFontMeta {
   name: string
@@ -9,6 +9,10 @@ export interface WebFontMeta {
    * @default <matches root config>
    */
   provider?: WebFontsProviders
+  /**
+   * Override the provider url
+   */
+  url?: string
 }
 
 export interface WebFontsOptions {


### PR DESCRIPTION
This PR enables custom provider for `@unocss/preset-web-fonts`.

Custom fonts are provided by url, but not on google fonts.

May close #2237 