### PR TITLE
fix(transformer-variant-group): add return

### DIFF
--- a/packages/transformer-variant-group/src/index.ts
+++ b/packages/transformer-variant-group/src/index.ts
@@ -24,7 +24,7 @@ export default function transformerVariantGroup(options: TransformerVariantGroup
     name: '@unocss/transformer-variant-group',
     enforce: 'pre',
     transform(s) {
-      expandVariantGroup(s, options.separators)
+      return expandVariantGroup(s, options.separators)
     },
   }
 }


### PR DESCRIPTION
It seems to `return` in `transform` hook was missed.

**Context**
I tried to use transformer-variant-group stand alone as vite plugin in nuxt. And it doesn't work without `return`