### PR TITLE
feat(global): support vite inline import

### DIFF
--- a/examples/vite-vue3/package.json
+++ b/examples/vite-vue3/package.json
@@ -17,6 +17,7 @@
     "@vitejs/plugin-vue": "^4.1.0",
     "typescript": "^5.0.4",
     "unocss": "link:../../packages/unocss",
-    "vite": "^4.2.1"
+    "vite": "^4.3.4",
+    "vite-plugin-inspect": "^0.7.25"
   }
 }

--- a/examples/vite-vue3/src/App.vue
+++ b/examples/vite-vue3/src/App.vue
@@ -1,5 +1,10 @@
+<script setup lang="ts">
+import cssWithLayer from 'uno:shortcuts.css?inline'
+import css from 'uno.css?inline'
+</script>
+
 <template>
-  <div text-center font-sans p4>
+  <div font-sans p4>
     <div logo />
     <div text-green5 text-lg>
       Hello UnoCSS + Vue
@@ -7,5 +12,7 @@
     <div i-custom-icon />
     <div i-custom-multi-line-attr />
     <div hidden class="bg-[url(../src/uno.svg)] bg-[url(/uno.svg)]" />
+    <pre>{{ css }}</pre>
+    <pre>{{ cssWithLayer }}</pre>
   </div>
 </template>

--- a/examples/vite-vue3/src/main.ts
+++ b/examples/vite-vue3/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
-import App from './App.vue'
 import 'uno.css'
+import 'uno:shortcuts.css'
+import App from './App.vue'
 
 createApp(App).mount('#app')

--- a/examples/vite-vue3/vite.config.ts
+++ b/examples/vite-vue3/vite.config.ts
@@ -5,6 +5,7 @@ import UnoCSS from 'unocss/vite'
 import presetAttributify from '@unocss/preset-attributify'
 import presetIcons from '@unocss/preset-icons'
 import presetUno from '@unocss/preset-uno'
+import Inspect from 'vite-plugin-inspect'
 import { FileSystemIconLoader } from '@iconify/utils/lib/loader/node-loaders'
 
 const iconDirectory = resolve(__dirname, 'icons')
@@ -13,6 +14,7 @@ const iconDirectory = resolve(__dirname, 'icons')
 export default defineConfig({
   plugins: [
     Vue(),
+    Inspect(),
     UnoCSS({
       shortcuts: [
         { logo: 'i-logos-vue w-6em h-6em transform transition-800' },

--- a/packages/shared-integration/src/layers.ts
+++ b/packages/shared-integration/src/layers.ts
@@ -3,8 +3,8 @@ export const VIRTUAL_ENTRY_ALIAS = [
 ]
 export const LAYER_MARK_ALL = '__ALL__'
 
-export const RESOLVED_ID_WITH_QUERY_RE = /[\/\\]__uno(?:(_.*?))?\.css(\?.*)?$/
-export const RESOLVED_ID_RE = /[\/\\]__uno(?:(_.*?))?\.css$/
+export const RESOLVED_ID_WITH_QUERY_RE = /[\/\\]__uno(?:_(.*?))?\.css(\?.*)?$/
+export const RESOLVED_ID_RE = /[\/\\]__uno(?:_(.*?))?\.css$/
 
 export function resolveId(id: string) {
   if (id.match(RESOLVED_ID_WITH_QUERY_RE))
@@ -13,9 +13,10 @@ export function resolveId(id: string) {
   for (const alias of VIRTUAL_ENTRY_ALIAS) {
     const match = id.match(alias)
     if (match) {
-      return (match[1]
-        ? `/__uno_${match[1]}.css`
-        : '/__uno.css') + (match[2] || '')
+      const [layer, query = ''] = match.slice(1)
+      return (layer
+        ? `/__uno_${layer}.css`
+        : '/__uno.css') + query
     }
   }
 }

--- a/packages/shared-integration/src/layers.ts
+++ b/packages/shared-integration/src/layers.ts
@@ -13,15 +13,15 @@ export function resolveId(id: string) {
   for (const alias of VIRTUAL_ENTRY_ALIAS) {
     const match = id.match(alias)
     if (match) {
-      return match[1]
+      return (match[1]
         ? `/__uno_${match[1]}.css`
-        : '/__uno.css'
+        : '/__uno.css') + (match[2] || '')
     }
   }
 }
 
 export function resolveLayer(id: string) {
-  const match = id.match(RESOLVED_ID_RE)
+  const match = id.match(RESOLVED_ID_WITH_QUERY_RE)
   if (match)
     return match[1] || LAYER_MARK_ALL
 }

--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -88,6 +88,7 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
             entry += '&used'
 
           const layer = resolveLayer(entry)
+
           if (layer) {
             vfsLayers.add(layer)
             if (importer)
@@ -100,7 +101,7 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
         const layer = resolveLayer(getPath(id))
         if (layer) {
           vfsLayers.add(layer)
-          return ` ${getLayerPlaceholder(layer)}`
+          return getLayerPlaceholder(layer)
         }
       },
       moduleParsed({ id, importedIds }) {


### PR DESCRIPTION
fix #2533

because of https://github.com/vitejs/vite/issues/12912, the HMR of the virtual module is unavailable by default at the moment

Before it is fixed,  it is also working by `/__uno.css?inline`

```ts
import unocssText from 'virtual:uno.css?inline';

const unocssStyle = document.createElement('style');
unocssStyle.dataset.source = 'unocss'
unocssStyle.textContent = unocssText;
export default unocssStyle;

if (import.meta.hot) {
    import.meta.hot.accept('/__uno.css?inline', (newModule) => {
        const text2 = newModule?.default as string;
        unocssStyle.textContent = text2 ?? ``;
    });
}
```


