### PR TITLE
fix(preset-mini): border arbitrary width (#2572)

### DIFF
--- a/packages/preset-mini/src/_utils/utilities.ts
+++ b/packages/preset-mini/src/_utils/utilities.ts
@@ -91,6 +91,9 @@ export function parseColor(body: string, theme: Theme): ParsedColorValue | undef
   const bracket = h.bracketOfColor(main)
   const bracketOrMain = bracket || main
 
+  if (h.numberWithUnit(bracketOrMain))
+    return
+
   if (bracketOrMain.match(/^#[\da-fA-F]+/g))
     color = bracketOrMain
   else if (bracketOrMain.match(/^hex-[\da-fA-F]+/g))

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -148,12 +148,12 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .bg-opacity-45{--un-bg-opacity:0.45;}
 .all-\[svg\]\:fill-red svg{--un-fill-opacity:1;fill:rgba(248,113,113,var(--un-fill-opacity));}
 .fill-\[\#123\]{--un-fill-opacity:1;fill:rgba(17,34,51,var(--un-fill-opacity));}
-.fill-\[1rem\]{fill:1rem;}
 .fill-current{fill:currentColor;}
 .fill-green-400{--un-fill-opacity:1;fill:rgba(74,222,128,var(--un-fill-opacity));}
 .fill-opacity-\$opacity-variable{--un-fill-opacity:var(--opacity-variable);}
 .fill-opacity-80{--un-fill-opacity:0.8;}
 .fill-none{fill:none;}
+.stroke-\[1rem\],
 .stroke-size-\[1rem\],
 .stroke-width-\[1rem\]{stroke-width:1rem;}
 .stroke-size-\$variable,
@@ -172,7 +172,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .stroke-offset-1px{stroke-dashoffset:1px;}
 .stroke-offset-none{stroke-dashoffset:0;}
 .stroke-\[\#123\]{--un-stroke-opacity:1;stroke:rgba(17,34,51,var(--un-stroke-opacity));}
-.stroke-\[1rem\]{stroke:1rem;}
 .stroke-current{stroke:currentColor;}
 .stroke-green-400{--un-stroke-opacity:1;stroke:rgba(74,222,128,var(--un-stroke-opacity));}
 .stroke-opacity-\$opacity-variable{--un-stroke-opacity:var(--opacity-variable);}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -691,7 +691,6 @@ export const presetMiniTargets: string[] = [
   'fill-opacity-80',
   'fill-opacity-$opacity-variable',
   'fill-[#123]',
-  'fill-[1rem]',
   'stroke-none',
   'stroke-current',
   'stroke-green-400',

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -186,5 +186,7 @@ describe('color utils', () => {
 
     // invalid
     expect(fn('hex-invalid')).eql({})
+    expect(fn('5px')).eql(undefined)
+    expect(fn('5rem')).eql(undefined)
   })
 })


### PR DESCRIPTION
Hello,

This PR fixes the problem described on #2572 where `border-[6px]` was transformed on `border-color` and not `border-width`.

Not sure if what I did is valid, but I added an early return when the value has any number with a unit to the `parseColor` function.

Had to change some tests:
- I don't think that `fill-[1rem]` is a valid class. Source: https://developer.mozilla.org/pt-BR/docs/Web/SVG/Attribute/fill
- `stroke-\[1rem\]` changed to `stroke-width`, which I think is the correct one

This is my first PR for the project, so sorry if my solution is not the best. I'm happy to improve it