### PR TITLE
feat(extractor-pug): accept Pug compile options

### DIFF
--- a/packages/extractor-pug/src/index.ts
+++ b/packages/extractor-pug/src/index.ts
@@ -6,7 +6,7 @@ export default function extractorPug(): Extractor {
   async function compile(code: string, id: string) {
     const Pug = await import('pug')
     try {
-      return Pug.compile(code, { filename: id })()
+      return Pug.compile(code, { filename: id, doctype: 'html' })()
       // other build processes will catch pug errors
     }
     catch { }

--- a/packages/extractor-pug/src/index.ts
+++ b/packages/extractor-pug/src/index.ts
@@ -1,12 +1,13 @@
 import type { Extractor } from '@unocss/core'
+import type { Options } from 'pug'
 
 const regexVueTemplate = /<template.*?lang=['"]pug['"][^>]*?>\s*([\s\S]*?\s*)<\/template>/gm
 
-export default function extractorPug(): Extractor {
+export default function extractorPug(options: Options = {}): Extractor {
   async function compile(code: string, id: string) {
     const Pug = await import('pug')
     try {
-      return Pug.compile(code, { filename: id, doctype: 'html' })()
+      return Pug.compile(code, { filename: id, doctype: 'html', ...options })()
       // other build processes will catch pug errors
     }
     catch { }


### PR DESCRIPTION
Allows `doctype: 'html'` and other Pug configurations to be supported by extractor-pug.