### PR TITLE
fix(preset-mini): allow to use hyphens and numbers in theme config without nesting

### DIFF
--- a/packages/preset-mini/src/_utils/utilities.ts
+++ b/packages/preset-mini/src/_utils/utilities.ts
@@ -103,6 +103,12 @@ export function parseColor(body: string, theme: Theme): ParsedColorValue | undef
 
   color = color || bracket
 
+  if (!color) {
+    const colorData = getThemeColor(theme, [main])
+    if (typeof colorData === 'string')
+      color = colorData
+  }
+
   let no = 'DEFAULT'
   if (!color) {
     let colorData

--- a/test/assets/output/preset-mini-non-nested-theme-colors.css
+++ b/test/assets/output/preset-mini-non-nested-theme-colors.css
@@ -1,0 +1,5 @@
+/* layer: default */
+.bg-numbered321{--un-bg-opacity:1;background-color:rgba(51,34,17,var(--un-bg-opacity));}
+.bg-with-hyphen{--un-bg-opacity:1;background-color:rgba(18,52,86,var(--un-bg-opacity));}
+.text-numbered-123{--un-text-opacity:1;color:rgba(17,34,51,var(--un-text-opacity));}
+.text-with-hyphen{--un-text-opacity:1;color:rgba(18,52,86,var(--un-text-opacity));}

--- a/test/preset-mini.test.ts
+++ b/test/preset-mini.test.ts
@@ -12,16 +12,19 @@ const uno = createGenerator({
   ],
   theme: {
     colors: {
-      custom: {
+      'custom': {
         a: 'var(--custom)',
         b: 'rgba(var(--custom), %alpha)',
       },
-      a: {
+      'a': {
         b: {
           c: '#514543',
         },
         camelCase: '#234',
       },
+      'with-hyphen': '#123456',
+      'numbered-123': '#123',
+      'numbered321': '#321',
     },
     spacing: {
       safe: 'max(env(safe-area-inset-left), env(safe-area-inset-right))',
@@ -124,6 +127,18 @@ describe('preset-mini', () => {
 
     expect(css).toMatchFileSnapshot('./assets/output/preset-mini-nested-theme-colors.css')
     expect(matched.size).toBe(3)
+  })
+
+  test('non-nested theme colors with hyphens and/or numbers', async () => {
+    const { css, matched } = await uno.generate([
+      'text-with-hyphen',
+      'bg-with-hyphen',
+      'text-numbered-123',
+      'bg-numbered321',
+    ], { preflights: false })
+
+    expect(css).toMatchFileSnapshot('./assets/output/preset-mini-non-nested-theme-colors.css')
+    expect(matched.size).toBe(4)
   })
 
   test('none targets', async () => {


### PR DESCRIPTION
this fixes #2600 
and also allows to use colors with hyphens in `theme.colors` as direct key

both are allowed in tailwind ( https://play.tailwindcss.com/jJv3sLB9uE?file=config ) and windicss