### PR TITLE
docs: update expected type in variants example

### DIFF
--- a/docs/config/presets.md
+++ b/docs/config/presets.md
@@ -14,9 +14,9 @@ export default function myPreset(options: MyPresetOptions): Preset {
     rules: [
       // ...
     ],
-    variants: {
+    variants: [
       // ...
-    },
+    ],
     // it supports most of the configuration you could have in the root config
   }
 }


### PR DESCRIPTION
The expected type that comes from the [variant](https://github.com/unocss/unocss/blob/main/packages/core/src/types.ts#LL334C5-L334C5) is `Array` not `Object`