### PR TITLE
Fix example code in docs

### DIFF
--- a/docs/presets/web-fonts.md
+++ b/docs/presets/web-fonts.md
@@ -80,7 +80,7 @@ export default defineConfig({
     presetUno(),
     presetWebFonts({
       // use axios with an https proxy
-      customFetch: (url: string) => axios.get(url, { httpsAgent: new ProxyAgent('https://localhost:7890') }),
+      customFetch: (url: string) => axios.get(url, { httpsAgent: new ProxyAgent('https://localhost:7890') }).then(it => it.data),
       provider: 'google',
       fonts: {
         sans: 'Roboto',


### PR DESCRIPTION
This mistake made me unfortunate for a while.
<img width="589" alt="image" src="https://github.com/unocss/unocss/assets/1720349/dc6aebf0-355d-4d3c-99f0-11d47dddeb63">
