### PR TITLE
fix(preset-mini): `content-none` should render `{ content: none }`

### DIFF
--- a/packages/preset-mini/src/_rules/static.ts
+++ b/packages/preset-mini/src/_rules/static.ts
@@ -84,7 +84,7 @@ export const contentVisibility: Rule[] = [
 export const contents: Rule[] = [
   [/^content-(.+)$/, ([, v]) => ({ content: h.bracket.cssvar(v) })],
   ['content-empty', { content: '""' }],
-  ['content-none', { content: '""' }],
+  ['content-none', { content: 'none' }],
 ]
 
 export const breaks: Rule[] = [

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -302,8 +302,8 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .content-\[string\:attr\(dashed-attr\)\]{content:attr(dashed-attr);}
 .content-\[string\:attr\(underlined\\_attr\)\]{content:attr(underlined_attr);}
 .content-\$unocss-var{content:var(--unocss-var);}
-.content-empty,
-.content-none{content:"";}
+.content-empty{content:"";}
+.content-none{content:none;}
 .font-\[system-ui\]{font-family:system-ui;}
 .font-\$font-name{font-family:var(--font-name);}
 .font-mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;}


### PR DESCRIPTION
fix #2645

**Description**:
The issue is related to the distinction between content-empty and content-none in the static.ts file. Currently, content-empty sets the content to an empty character (""), whereas content-none should set the none attribute of the content. However, the code incorrectly sets content: '""' for content-none. This pull request fixes this inconsistency.

**Changes Made**:
-  Modified the code in static.ts to correctly set content: 'none' for content-none.