### PR TITLE
feat(webpack): add scan-only mode to  adapt webpack5 persistent cache 

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -648,6 +648,12 @@ export interface ExtraContentOptions {
    * Plain text to be extracted
    */
   plain?: string[]
+
+  /**
+   * enable/disable file watching
+   * @default false
+   */
+  enableWatch?: boolean
 }
 
 /**


### PR DESCRIPTION
**fix**：https://github.com/unocss/unocss/pull/419

**Description:**
This issue is related to webpack5 persistent cache because @unocss/webpack using loaders to extract code . Inspired by Windicss's pre-scanning, I think we can do it similarly. Fortunately there is a solution already: https://github.com/unocss/unocss/pull/1963. 

Therefore, I added an option `scanModeOnly`  to only use file-sacnning to extract code, which can solve the issue of persistent caching.