### PR TITLE
fix(astro): the reset style is overwritten

### DIFF
--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -44,7 +44,7 @@ function AstroVitePlugin(options: AstroVitePluginOptions): Plugin {
         && id.includes(UNO_QUERY_KEY)
         && id.includes('.css')
       )
-        return ''
+        return null
     },
   }
 }


### PR DESCRIPTION
fix: #2655 

Returning the empty string will override the SSR generation style. 

I'm confused, the unocss example won't