### PR TITLE
docs(svelte-scoped): change "server hooks" to "hooks.server.js" in error message and docs

### DIFF
--- a/docs/integrations/svelte-scoped.md
+++ b/docs/integrations/svelte-scoped.md
@@ -224,7 +224,7 @@ Add the `%unocss-svelte-scoped.global%` placeholder into your `<head>` tag. In S
 </head>
 ```
 
-If using SvelteKit, you also must add the following to the `transformPageChunk` hook in your `server.hooks.js` file:
+If using SvelteKit, you also must add the following to the `transformPageChunk` hook in your `hooks.server.js` file:
 
 ```js
 /** @type {import('@sveltejs/kit').Handle} */

--- a/docs/integrations/svelte-scoped.md
+++ b/docs/integrations/svelte-scoped.md
@@ -224,7 +224,7 @@ Add the `%unocss-svelte-scoped.global%` placeholder into your `<head>` tag. In S
 </head>
 ```
 
-If using SvelteKit, you also must add the following to the `transformPageChunk` hook in your `hooks.server.js` file:
+If using SvelteKit, you also must add the following to the `transformPageChunk` hook in your `server.hooks.js` file:
 
 ```js
 /** @type {import('@sveltejs/kit').Handle} */

--- a/packages/svelte-scoped/src/vite/global.ts
+++ b/packages/svelte-scoped/src/vite/global.ts
@@ -31,7 +31,7 @@ export async function generateGlobalCss(uno: UnoGenerator, injectReset?: UnocssS
 
 const SVELTE_ERROR = `[unocss] You have not setup the svelte-scoped global styles correctly. You must place '${PLACEHOLDER_USER_SETS_IN_INDEX_HTML}' in your index.html file.
 `
-const SVELTE_KIT_ERROR = `[unocss] You have not setup the svelte-scoped global styles correctly. You must place '${PLACEHOLDER_USER_SETS_IN_INDEX_HTML}' in your app.html file. You also need to have a transformPageChunk hook in your server hooks file with: \`html.replace('${PLACEHOLDER_USER_SETS_IN_INDEX_HTML}', '${GLOBAL_STYLES_PLACEHOLDER}')\`. You can see an example of the usage at https://github.com/unocss/unocss/tree/main/examples/sveltekit-scoped.`
+const SVELTE_KIT_ERROR = `[unocss] You have not setup the svelte-scoped global styles correctly. You must place '${PLACEHOLDER_USER_SETS_IN_INDEX_HTML}' in your app.html file. You also need to have a transformPageChunk hook in your hooks.server.js file with: \`html.replace('${PLACEHOLDER_USER_SETS_IN_INDEX_HTML}', '${GLOBAL_STYLES_PLACEHOLDER}')\`. You can see an example of the usage at https://github.com/unocss/unocss/tree/main/examples/sveltekit-scoped.`
 
 export function checkTransformPageChunkHook(server: ViteDevServer, isSvelteKit: boolean) {
   server.middlewares.use((req, res, next) => {


### PR DESCRIPTION
The docs say `server.hooks.js` instead of `hooks.server.js` so fixing that, also updated the error message to be more clear about what the file name should be.