### PR TITLE
fix(vscode): attributify auto complete

### DIFF
--- a/packages/preset-attributify/src/autocomplete.ts
+++ b/packages/preset-attributify/src/autocomplete.ts
@@ -54,15 +54,10 @@ export function autocompleteExtractorAttributify(options?: AttributifyOptions): 
       if (attrValues === undefined) {
         return {
           extracted: attrNameWithoutPrefix,
-          transformSuggestions(suggestion) {
-            if (hasPrefix)
-              return suggestion.map(s => options.prefix! + s)
-            else
-              return suggestion
-          },
           resolveReplacement(suggestion) {
+            const startOffset = hasPrefix ? options.prefix!.length : 0
             return {
-              start: attrsPos,
+              start: attrsPos + startOffset,
               end: attrsPos + attrName!.length,
               replacement: suggestion,
             }

--- a/packages/vscode/src/autocomplete.ts
+++ b/packages/vscode/src/autocomplete.ts
@@ -36,10 +36,12 @@ const delimiters = ['-', ':']
 
 class UnoCompletionItem extends CompletionItem {
   uno: UnoGenerator
+  value: string
 
-  constructor(label: string, kind: CompletionItemKind, uno: UnoGenerator) {
+  constructor(label: string, kind: CompletionItemKind, value: string, uno: UnoGenerator) {
     super(label, kind)
     this.uno = uno
+    this.value = value
   }
 }
 
@@ -119,7 +121,7 @@ export async function registerAutoComplete(
           const css = await getCSS(ctx!.uno, value)
           const colorString = getColorString(css)
           const itemKind = colorString ? CompletionItemKind.Color : CompletionItemKind.EnumMember
-          const item = new UnoCompletionItem(value, itemKind, ctx!.uno)
+          const item = new UnoCompletionItem(label, itemKind, value, ctx!.uno)
           const resolved = result.resolveReplacement(value)
 
           item.insertText = resolved.replacement
@@ -143,9 +145,9 @@ export async function registerAutoComplete(
 
     async resolveCompletionItem(item) {
       if (item.kind === CompletionItemKind.Color)
-        item.detail = await (await getPrettiedCSS(item.uno, item.label as string)).prettified
+        item.detail = await (await getPrettiedCSS(item.uno, item.value)).prettified
       else
-        item.documentation = await getMarkdown(item.uno, item.label as string)
+        item.documentation = await getMarkdown(item.uno, item.value)
       return item
     },
   }

--- a/playground/src/composables/uno.ts
+++ b/playground/src/composables/uno.ts
@@ -39,9 +39,10 @@ export async function getHint(context: CompletionContext): Promise<CompletionRes
   const resolved = result.resolveReplacement(result.suggestions[0][0])
   return {
     from: resolved.start,
-    options: result.suggestions.map(([, label]) => {
+    options: result.suggestions.map(([value, label]) => {
       return ({
         label,
+        apply: value,
         type: 'text',
         boost: 99,
       })

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -121,25 +121,18 @@ describe('attributify', async () => {
       expect(res1).not.toBeNull()
 
       expect(res1!.extracted).toMatchInlineSnapshot('"text-cent"')
-      expect(res1!.transformSuggestions!([`${res1!.extracted}1`, `${res1!.extracted}2`]))
-        .toMatchInlineSnapshot(`
-          [
-            "un-text-cent1",
-            "un-text-cent2",
-          ]
-        `)
 
       const reversed1 = res1!.resolveReplacement(`${res1!.extracted}1`)
       expect(reversed1).toMatchInlineSnapshot(`
         {
           "end": 18,
           "replacement": "text-cent1",
-          "start": 6,
+          "start": 9,
         }
       `)
 
       expect(fixtureWithPrefix.slice(reversed1.start, reversed1.end))
-        .toMatchInlineSnapshot('"un-text-cent"')
+        .toMatchInlineSnapshot('"text-cent"')
 
       const res2 = await autocompleteExtractorAttributify({ prefix: 'un-' }).extract({
         content: fixtureWithPrefix,


### PR DESCRIPTION
#2643 worked with the playground but wasn't working with the VSCode extension due to the behavior differences with the playground. This PR make it work with VSCode extension.

![image](https://github.com/unocss/unocss/assets/49056869/00cecdcd-ccc4-465a-aeb0-1bcc807fe1bf)
![image](https://github.com/unocss/unocss/assets/49056869/68724a91-efbf-490c-bc1e-a4d538cbf142)

