### PR TITLE
feat(vscode): ignore config load failed root

### DIFF
--- a/packages/vscode/src/utils.ts
+++ b/packages/vscode/src/utils.ts
@@ -122,3 +122,11 @@ export function isSubdir(parent: string, child: string) {
   const relative = path.relative(parent, child)
   return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
 }
+
+export function isFulfilled<T>(result: PromiseSettledResult<T>): result is PromiseFulfilledResult<T> {
+  return result.status === 'fulfilled'
+}
+
+export function isRejected(result: PromiseSettledResult<unknown>): result is PromiseRejectedResult {
+  return result.status === 'rejected'
+}


### PR DESCRIPTION
It was not possible to run `unocss.reload` when one of the root failed to load the config.

For example, when two directory exists and `npm i` was ran only in one of them.
