### PR TITLE
docs: navbar links for PR preview

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -138,8 +138,8 @@ const Nav: DefaultTheme.NavItem[] = [
     ],
     activeMatch: '^/(presets|transformers|extractors)/',
   },
-  { text: 'Interactive Docs', link: `${ogUrl}interactive/`, target: '_blank' },
-  { text: 'Playground', link: `${ogUrl}play/`, target: '_blank' },
+  { text: 'Interactive Docs', link: '/interactive/', target: '_blank' },
+  { text: 'Playground', link: '/play/', target: '_blank' },
   {
     text: `v${version}`,
     items: [


### PR DESCRIPTION
This is a revert of #2449. I fixed the bug in vitepress (https://github.com/vuejs/vitepress/pull/2400).
This will make the navbar links to link to the PR's playground/interactive docs from the netlify preview docs.
