### PR TITLE
docs: update `extractorSvelte` usage in vite.md

### DIFF
--- a/docs/integrations/vite.md
+++ b/docs/integrations/vite.md
@@ -195,7 +195,7 @@ export default {
   plugins: [
     UnoCSS({
       extractors: [
-        extractorSvelte
+        extractorSvelte(),
       ],
       /* more options */
     }),
@@ -223,7 +223,7 @@ const config = {
   plugins: [
     UnoCSS({
       extractors: [
-        extractorSvelte()
+        extractorSvelte(),
       ],
       /* more options */
     }),


### PR DESCRIPTION
Add missing `()` for `extractorSvelte`