### PR TITLE
fix(svelte-scoped): don't add spaces when class names include expressions as just part of them

### DIFF
--- a/packages/svelte-scoped/src/preprocess/transformClasses/index.test.ts
+++ b/packages/svelte-scoped/src/preprocess/transformClasses/index.test.ts
@@ -287,7 +287,7 @@ describe('transform', () => {
         color: red;
       }
     </style>`.trim())
-    expect(result).toMatchInlineSnapshot('undefined')
+    expect(result).toBe(undefined)
   })
 
   it('in dev, when it only hashes but does not combine, handles classes that fail when coming at the beginning of a shortcut name', async () => {


### PR DESCRIPTION
fixes #2676 