### PR TITLE
fix(svelte-scoped): properly pass vite command to UnocssSveltePreprocess

### DIFF
--- a/packages/svelte-scoped/src/preprocess/index.ts
+++ b/packages/svelte-scoped/src/preprocess/index.ts
@@ -8,7 +8,7 @@ import type { SvelteScopedContext, UnocssSveltePreprocessOptions } from './types
 
 export * from './types.d.js'
 
-export default function UnocssSveltePreprocess(options: UnocssSveltePreprocessOptions = {}, unoContextFromVite?: SvelteScopedContext): PreprocessorGroup {
+export default function UnocssSveltePreprocess(options: UnocssSveltePreprocessOptions = {}, unoContextFromVite?: SvelteScopedContext, isViteBuild?: () => boolean): PreprocessorGroup {
   if (!options.classPrefix)
     options.classPrefix = 'spu-'
 
@@ -18,6 +18,9 @@ export default function UnocssSveltePreprocess(options: UnocssSveltePreprocessOp
     markup: async ({ content, filename }) => {
       if (!uno)
         uno = await getGenerator(options.configOrPath, unoContextFromVite)
+
+      if (isViteBuild && !options.combine)
+        options.combine = isViteBuild()
 
       return await transformClasses({ content, filename: filename || '', uno, options })
     },

--- a/packages/svelte-scoped/src/vite/passPreprocessToSveltePlugin.ts
+++ b/packages/svelte-scoped/src/vite/passPreprocessToSveltePlugin.ts
@@ -4,16 +4,19 @@ import UnocssSveltePreprocess from '../preprocess'
 import type { UnocssSvelteScopedViteOptions } from './types'
 
 export function PassPreprocessToSveltePlugin(options: UnocssSvelteScopedViteOptions = {}, ctx: SvelteScopedContext): Plugin {
+  let commandIsBuild = true
+  const isBuild = () => commandIsBuild
+
   return {
     name: 'unocss:svelte-scoped:pass-preprocess',
     enforce: 'pre',
 
-    configResolved(viteConfig) {
-      options = { ...options, combine: viteConfig.command === 'build' }
+    configResolved({ command }) {
+      commandIsBuild = command === 'build'
     },
 
     api: {
-      sveltePreprocess: UnocssSveltePreprocess(options, ctx),
+      sveltePreprocess: UnocssSveltePreprocess(options, ctx, isBuild),
     },
   }
 }


### PR DESCRIPTION
Fixes #2658 (as much as possible) by respecting the intended combine distinction between dev and prod.