### PR TITLE
docs: fix uno.md about interactive doc link

### DIFF
--- a/docs/presets/uno.md
+++ b/docs/presets/uno.md
@@ -64,7 +64,7 @@ For example, both `ml-3` (Tailwind), `ms-2` (Bootstrap), `ma4` (Tachyons), and `
 ## Rules
 This preset is compatible with [Tailwind CSS](https://tailwindcss.com/) and [Windi CSS](https://windicss.org/), you can refer to their [documentation](https://tailwindcss.com/docs) for detailed usage.
 
-For all rules and presets included in this preset, please refer to our [interactive docs](/interactive/) or directly go to the [source code](https://github.com/unocss/unocss/tree/main/packages/preset-uno).
+For all rules and presets included in this preset, please refer to our [interactive docs](https://unocss.dev/interactive/) or directly go to the [source code](https://github.com/unocss/unocss/tree/main/packages/preset-uno).
 
 ## Options
 


### PR DESCRIPTION
When I read the [Rule](https://unocss.dev/presets/uno#rules) chapter in [preset docs](https://unocss.dev/presets/uno)，I clicked the interactive doc link and got a 404 page, so I do like this.