### PR TITLE
feat: add text-wrap css property

### DIFF
--- a/packages/preset-mini/src/_rules/default.ts
+++ b/packages/preset-mini/src/_rules/default.ts
@@ -12,7 +12,7 @@ import { rings } from './ring'
 import { boxShadows } from './shadow'
 import { aspectRatio, sizes } from './size'
 import { margins, paddings } from './spacing'
-import { appearances, breaks, contains, contentVisibility, contents, cursors, displays, fontSmoothings, fontStyles, pointerEvents, resizes, textOverflows, textTransforms, userSelects, whitespaces } from './static'
+import { appearances, breaks, contains, contentVisibility, contents, cursors, displays, fontSmoothings, fontStyles, pointerEvents, resizes, textOverflows, textTransforms, textWraps, userSelects, whitespaces } from './static'
 import { transforms } from './transform'
 import { cssProperty, cssVariables } from './variables'
 import { questionMark } from './question-mark'
@@ -79,6 +79,7 @@ export const rules: Rule[] = [
   willChange,
   containerParent,
   contains,
+  textWraps,
 
   // should be the last
   questionMark,

--- a/packages/preset-mini/src/_rules/static.ts
+++ b/packages/preset-mini/src/_rules/static.ts
@@ -94,6 +94,12 @@ export const breaks: Rule[] = [
   ['break-keep', { 'word-break': 'keep-all' }],
 ]
 
+export const textWraps: Rule[] = [
+  ['text-wrap', { 'text-wrap': 'wrap' }],
+  ['text-nowrap', { 'text-wrap': 'nowrap' }],
+  ['text-balance', { 'text-wrap': 'balance' }],
+]
+
 export const textOverflows: Rule[] = [
   ['truncate', { 'overflow': 'hidden', 'text-overflow': 'ellipsis', 'white-space': 'nowrap' }],
   ['text-truncate', { 'overflow': 'hidden', 'text-overflow': 'ellipsis', 'white-space': 'nowrap' }],

--- a/packages/preset-wind/src/rules/default.ts
+++ b/packages/preset-wind/src/rules/default.ts
@@ -74,6 +74,7 @@ export const rules: Rule[] = [
   _.paddings,
   _.textAligns,
   _.textIndents,
+  _.textWraps,
   _.verticalAligns,
   _.fonts,
   _.textTransforms,

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -958,6 +958,9 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .contain-\[size_layout_paint\]{contain:size layout paint;}
 .contain-\[size_layout\]{contain:size layout;}
 .contain-layout{contain:layout;}
+.text-wrap{text-wrap:wrap;}
+.text-nowrap{text-wrap:nowrap;}
+.text-balance{text-wrap:balance;}
 @container (min-width: 10.5rem){
 .\@\[10\.5rem\]-text-red{--un-text-opacity:1;color:rgba(248,113,113,var(--un-text-opacity));}
 }

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -658,6 +658,9 @@ export const presetMiniTargets: string[] = [
   'break-words',
   'break-keep',
   'text-clip',
+  'text-wrap',
+  'text-nowrap',
+  'text-balance',
   'case-upper', // !
   'case-normal', // !
   'case-inherit', // !


### PR DESCRIPTION
# Summary
I'm adding css `text-wrap` which is now supported by chrome 114 https://caniuse.com/?search=text-wrap

it will be supported in [tailwindcss](https://github.com/tailwindlabs/tailwindcss/pull/11320) next version

