### PR TITLE
docs(preset-web-fonts): modify the usage of customFetch in the documentation

### DIFF
--- a/docs/presets/web-fonts.md
+++ b/docs/presets/web-fonts.md
@@ -66,6 +66,17 @@ PR welcome to add more providers. 🙌
 ### Custom fetch function
 
 Use your own function to fetch font source.
+::: code-group
+  ```bash [pnpm]
+  pnpm add -D https-proxy-agent
+  ```
+  ```bash [yarn]
+  yarn add -D https-proxy-agent
+  ```
+  ```bash [npm]
+  npm install -D https-proxy-agent
+  ```
+:::
 
 ```ts
 // uno.config.ts
@@ -73,14 +84,19 @@ import { defineConfig } from 'unocss'
 import presetWebFonts from '@unocss/preset-web-fonts'
 import presetUno from '@unocss/preset-uno'
 import axios from 'axios'
-import ProxyAgent from 'proxy-agent'
+import { HttpsProxyAgent } from 'https-proxy-agent'
 
 export default defineConfig({
   presets: [
     presetUno(),
     presetWebFonts({
       // use axios with an https proxy
-      customFetch: (url: string) => axios.get(url, { httpsAgent: new ProxyAgent('https://localhost:7890') }).then(it => it.data),
+      // clash default port 7890, v2rayN default port 10809
+      customFetch: (url: string) => {
+        return axios
+          .get(url, { httpsAgent: new HttpsProxyAgent('http://127.0.0.1:7890') })
+          .then(it => it.data)
+      },
       provider: 'google',
       fonts: {
         sans: 'Roboto',


### PR DESCRIPTION
### What issue did I discover
In the current documentation, when using `proxy-agent` in the `uno.config.ts`, you will encounter an error message saying `proxyAgent.default is not a constructor`.

![image](https://github.com/unocss/unocss/assets/46062895/72a42ae2-484f-451e-bf57-ef2c23c16ea9)
---
### What did I modify
I have updated the documentation to use `https-proxy-agent`, and in actual testing with Clash and v2rayN proxies, it functions correctly without any error messages

### Screenshot of the test results
**clash**
![image](https://github.com/unocss/unocss/assets/46062895/d59e3491-3bea-449f-a8eb-68593c99c597)

---
**v2rayN**
![image](https://github.com/unocss/unocss/assets/46062895/27e9a554-ac9c-4448-b7ff-a2e9800b1b51)

