### PR TITLE
feat!: normalize extraction `content` sources

### DIFF
--- a/bench/run.mjs
+++ b/bench/run.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-import { execSync } from 'child_process'
-import { join } from 'path'
+import { execSync } from 'node:child_process'
+import { join } from 'node:path'
 import fs from 'fs-extra'
 import { escapeSelector } from '@unocss/core'
 import { dir, getVersions, targets } from './meta.mjs'

--- a/docs/guide/extracting.md
+++ b/docs/guide/extracting.md
@@ -4,13 +4,15 @@ outline: deep
 
 # Extracting
 
+UnoCSS works by searching for the utilities usages from your codebase and generate the corresponding CSS on-demand. And we call this process **extracting**.
+
 ## Content Sources
 
 UnoCSS supports extracting utilities usages from multiple sources:
 
 - [Pipeline](#extracting-from-build-tools-pipeline) - Extract right from your build tools pipeline
 - [Filesystem](#extracting-from-filesystem) - Extract from your filesystem by reading and watching files
-- [Inline](#extracting-from-plain-text) - Extract from inline plain text
+- [Inline](#extracting-from-inline-text) - Extract from inline plain text
 
 Usages of utilities that comes from different sources will be merged together and generate the final CSS.
 

--- a/docs/guide/extracting.md
+++ b/docs/guide/extracting.md
@@ -1,17 +1,55 @@
+---
+outline: deep
+---
+
 # Extracting
 
-Since UnoCSS works **at build time**, it means that only statically presented utilities will be generated and shipped to your app. Utilities that are used dynamically or fetched from external resources at runtime might not be applied.
+## Content Sources
 
-By default, UnoCSS will extract the utilities usage from files in your build pipeline with extension `.jsx`, `.tsx`, `.vue`, `.md`, `.html`, `.svelte`, `.astro` and then generate the appropriate CSS on demand.
+UnoCSS supports extracting utilities usages from multiple sources:
 
-`.js` and `.ts` files are **NOT included by default**.
+- [Pipeline](#extracting-from-build-tools-pipeline) - Extract right from your build tools pipeline
+- [Filesystem](#extracting-from-filesystem) - Extract from your filesystem by reading and watching files
+- [Inline](#extracting-from-plain-text) - Extract from inline plain text
 
-You can add `@unocss-include`, per-file basis, anywhere in the file that you want UnoCSS to scan, or add `*.js` or `*.ts` in the configuration to include all js/ts files as scan targets.
+Usages of utilities that comes from different sources will be merged together and generate the final CSS.
+
+
+### Extracting from Build Tools Pipeline
+
+This is supported in the [Vite](/integrations/vite) and [Webpack](/integrations/webpack) integrations.
+
+UnoCSS will read the content that goes through your build tools pipeline and extract the utilities usages from them. This is the most efficient and accurate way to extract as we only extract the usages that are actually used in your app smartly, and no additional file IO is made during the extraction.
+
+By default, UnoCSS will extract the utilities usage from files in your build pipeline with extension `.jsx`, `.tsx`, `.vue`, `.md`, `.html`, `.svelte`, `.astro` and then generate the appropriate CSS on demand. `.js` and `.ts` files are **NOT included by default**.
+
+To configure them, you can update your `uno.config.ts`:
+
+```ts
+// uno.config.ts
+export default defineConfig({
+  content: {
+    pipeline: {
+      include: [
+        // the default
+        /\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/,
+        // include js/ts files
+        'src/**/*.{js,ts}',
+      ],
+      // exclude files
+      // exclude: []
+    }
+  }
+})
+```
+
+You can also add `@unocss-include` magic comment, per-file basis, anywhere in the file that you want UnoCSS to scan, or add `*.js` or `*.ts` in the configuration to include all js/ts files as scan targets.
 
 ```ts
 // ./some-utils.js
 
-// since `.js` files are not included by default, the following comment tells UnoCSS to force scan this file.
+// since `.js` files are not included by default,
+// the following comment tells UnoCSS to force scan this file.
 // @unocss-include
 export const classes = {
   active: 'bg-primary text-white',
@@ -21,7 +59,52 @@ export const classes = {
 
 Similarly, you can also add `@unocss-ignore` to bypass the scanning and transforming for a file.
 
-## Safelist
+### Extracting from Filesystem
+
+In cases that you are using integrations that does not have access to the build tools pipeline (for example, the [PostCSS](/integrations/postcss) plugin), or you are integrating with backend frameworks that the code does not go through the pipeline, you can manually specify the files to be extracted.
+
+```ts
+// uno.config.ts
+export default defineConfig({
+  content: {
+    filesystem: [
+      'src/**/*.php',
+      'public/*.html',
+    ]
+  }
+})
+```
+
+The files matched will be read directly from the filesystem and watched for changes at dev mode.
+
+### Extracting from Inline Text
+
+Additionally, you can also extract utilities usages from inline text, that you might retrieve from else where.
+
+You may also pass an async function to return the content. But note that the function will only be called once at the build time.
+
+```ts
+// uno.config.ts
+export default defineConfig({
+  content: {
+    inline: [
+      // plain text
+      '<div class="p-4 text-red">Some text</div>',
+      // async getter
+      async () => {
+        const response = await fetch('https://example.com')
+        return response.text()
+      }
+    ]
+  }
+})
+```
+
+## Limitations
+
+Since UnoCSS works **at build time**, it means that only statically presented utilities will be generated and shipped to your app. Utilities that are used dynamically or fetched from external resources at runtime might **NOT** be applied.
+
+### Safelist
 
 Sometimes you might want to use dynamic concatenations like:
 
@@ -56,7 +139,7 @@ safelist: [
 
 If you are seeking for a true dynamic generation at runtime, you may want to check out the [@unocss/runtime](https://github.com/unocss/unocss/tree/main/packages/runtime) package.
 
-## Blocklist
+### Blocklist
 
 Similar to `safelist`, you can also configure `blocklist` to exclude some utilities from being generated. Different from `safelist`, `blocklist` accept both string for exact match and regex for pattern match.
 

--- a/docs/integrations/astro.md
+++ b/docs/integrations/astro.md
@@ -111,4 +111,4 @@ If you are building a meta framework on top of UnoCSS, see [this file](https://g
 
 ## Notes
 
-[`client:only`](https://docs.astro.build/en/reference/directives-reference/#clientonly) components must be placed in [`components`](https://docs.astro.build/en/core-concepts/project-structure/#srccomponents) folder or added to UnoCSS's `extraContent` config in order to be processed.
+[`client:only`](https://docs.astro.build/en/reference/directives-reference/#clientonly) components must be placed in [`components`](https://docs.astro.build/en/core-concepts/project-structure/#srccomponents) folder or added to UnoCSS's `content` config in order to be processed.

--- a/docs/integrations/postcss.md
+++ b/docs/integrations/postcss.md
@@ -23,10 +23,7 @@ npm i -D @unocss/postcss
 // postcss.config.cjs
 module.exports = {
   plugins: {
-    '@unocss/postcss': {
-      // Optional
-      content: ['**/*.{html,js,ts,jsx,tsx,vue,svelte,astro}'],
-    },
+    '@unocss/postcss': {},
   },
 }
 ```
@@ -36,6 +33,11 @@ module.exports = {
 import { defineConfig, presetUno } from 'unocss'
 
 export default defineConfig({
+  content: {
+    filesystem: [
+      '**/*.{html,js,ts,jsx,tsx,vue,svelte,astro}',
+    ]
+  },
   presets: [
     presetUno(),
   ],

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -85,9 +85,10 @@ export default function UnoCSSAstroIntegration<Theme extends {}>(
     hooks: {
       'astro:config:setup': async ({ config, updateConfig, injectScript }) => {
         // Adding components to UnoCSS's extra content
-        options.extraContent ||= {}
-        options.extraContent.filesystem ||= []
-        options.extraContent.filesystem.push(resolve(fileURLToPath(config.srcDir), 'components/**/*').replace(/\\/g, '/'))
+        const source = resolve(fileURLToPath(config.srcDir), 'components/**/*').replace(/\\/g, '/')
+        options.content ||= {}
+        options.content.filesystem ||= []
+        options.content.filesystem.push(source)
 
         const injects: string[] = []
         if (injectReset) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -658,7 +658,7 @@ export interface ContentOptions {
   /**
    * Inline text to be extracted
    */
-  inline?: (string | { code: string; id?: string } | (() => Thenable<string | { code: string; id?: string }>)) []
+  inline?: (string | { code: string; id?: string } | (() => Awaitable<string | { code: string; id?: string }>)) []
 
   /**
    * Filters to determine whether to extract certain modules from the build tools' transformation pipeline.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -649,14 +649,16 @@ export interface ContentOptions {
   /**
    * Glob patterns to extract from the file system, in addition to other content sources.
    *
-   * In dev mode, the files will be watched and trigger HMR
+   * In dev mode, the files will be watched and trigger HMR.
+   *
+   * @default []
    */
   filesystem?: string[]
 
   /**
-   * Plain text to be extracted
+   * Inline text to be extracted
    */
-  plain?: (string | { code: string; id?: string }) []
+  inline?: (string | { code: string; id?: string } | (() => Thenable<string | { code: string; id?: string }>)) []
 
   /**
    * Filters to determine whether to extract certain modules from the build tools' transformation pipeline.
@@ -666,14 +668,31 @@ export interface ContentOptions {
   pipeline?: {
     /**
      * Patterns that filter the files being extracted.
+     * Supports regular expressions and `picomatch` glob patterns.
+     *
+     * By default, `.ts` and `.js` files are NOT extracted.
+     *
+     * @see https://www.npmjs.com/package/picomatch
+     * @default [/\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/]
      */
     include?: FilterPattern
 
     /**
      * Patterns that filter the files NOT being extracted.
+     * Supports regular expressions and `picomatch` glob patterns.
+     *
+     * By default, `node_modules` and `dist` are also extracted.
+     *
+     * @see https://www.npmjs.com/package/picomatch
+     * @default [/\.(css|postcss|sass|scss|less|stylus|styl)($|\?)/]
      */
     exclude?: FilterPattern
   }
+
+  /**
+   * @deprecated Renamed to `inline`
+   */
+  plain?: (string | { code: string; id?: string }) []
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -664,8 +664,10 @@ export interface ContentOptions {
    * Filters to determine whether to extract certain modules from the build tools' transformation pipeline.
    *
    * Currently only works for Vite and Webpack integration.
+   *
+   * Set `false` to disable.
    */
-  pipeline?: {
+  pipeline?: false | {
     /**
      * Patterns that filter the files being extracted.
      * Supports regular expressions and `picomatch` glob patterns.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -645,9 +645,10 @@ export interface SourceCodeTransformer {
   transform: (code: MagicString, id: string, ctx: UnocssPluginContext) => Awaitable<void>
 }
 
-export interface ExtraContentOptions {
+export interface ContentOptions {
   /**
-   * Glob patterns to match the files to be extracted
+   * Glob patterns to extract from the file system, in addition to other content sources.
+   *
    * In dev mode, the files will be watched and trigger HMR
    */
   filesystem?: string[]
@@ -655,7 +656,24 @@ export interface ExtraContentOptions {
   /**
    * Plain text to be extracted
    */
-  plain?: string[]
+  plain?: (string | { code: string; id?: string }) []
+
+  /**
+   * Filters to determine whether to extract certain modules from the build tools' transformation pipeline.
+   *
+   * Currently only works for Vite and Webpack integration.
+   */
+  pipeline?: {
+    /**
+     * Patterns that filter the files being extracted.
+     */
+    include?: FilterPattern
+
+    /**
+     * Patterns that filter the files NOT being extracted.
+     */
+    exclude?: FilterPattern
+  }
 }
 
 /**
@@ -675,24 +693,40 @@ export interface PluginOptions {
   configDeps?: string[]
 
   /**
-   * Patterns that filter the files being extracted.
-   */
-  include?: FilterPattern
-
-  /**
-   * Patterns that filter the files NOT being extracted.
-   */
-  exclude?: FilterPattern
-
-  /**
    * Custom transformers to the source code
    */
   transformers?: SourceCodeTransformer[]
 
   /**
-   * Extra content outside of build pipeline (assets, backend, etc.) to be extracted
+   * Options for sources to be extracted as utilities usages
+   *
+   * Supported sources:
+   * - `filesystem` - extract from file system
+   * - `plain` - extract from plain inline text
+   * - `pipeline` - extract from build tools' transformation pipeline, such as Vite and Webpack
+   *
+   * The usage extracted from each source will be **merged** together.
    */
-  extraContent?: ExtraContentOptions
+  content?: ContentOptions
+
+  /** ========== DEPRECATED OPTIONS ========== **/
+
+  /**
+   * @deprecated Renamed to `content`
+   */
+  extraContent?: ContentOptions
+
+  /**
+   * Patterns that filter the files being extracted.
+   * @deprecated moved to `content.pipeline.include`
+   */
+  include?: FilterPattern
+
+  /**
+    * Patterns that filter the files NOT being extracted.
+    * @deprecated moved to `content.pipeline.exclude`
+    */
+  exclude?: FilterPattern
 }
 
 export interface UserConfig<Theme extends {} = {}> extends ConfigBase<Theme>, UserOnlyOptions<Theme>, GeneratorOptions, PluginOptions, CliOptions {}

--- a/packages/nuxt/src/options.ts
+++ b/packages/nuxt/src/options.ts
@@ -5,7 +5,7 @@ import presetWebFonts from '@unocss/preset-web-fonts'
 import presetTypography from '@unocss/preset-typography'
 import presetTagify from '@unocss/preset-tagify'
 import presetWind from '@unocss/preset-wind'
-import { defaultExclude } from '../../shared-integration/src/defaults'
+import { defaultPipelineExclude } from '../../shared-integration/src/defaults'
 import type { UnocssNuxtOptions } from './types'
 
 export function resolveOptions(options: UnocssNuxtOptions) {
@@ -26,8 +26,11 @@ export function resolveOptions(options: UnocssNuxtOptions) {
         options.presets.push(preset(typeof option === 'boolean' ? {} : option))
     }
   }
-  options.exclude = options.exclude || defaultExclude
-  // ignore macro files created by Nuxt
-  if (Array.isArray(options.exclude))
-    options.exclude.push(/\?macro=true/)
+
+  options.content ||= {}
+  options.content.pipeline ||= {}
+  options.content.pipeline.exclude ||= defaultPipelineExclude
+  if (Array.isArray(options.content.pipeline.exclude))
+    // ignore macro files created by Nuxt
+    options.content.pipeline.exclude.push(/\?macro=true/)
 }

--- a/packages/nuxt/src/options.ts
+++ b/packages/nuxt/src/options.ts
@@ -27,10 +27,12 @@ export function resolveOptions(options: UnocssNuxtOptions) {
     }
   }
 
-  options.content ||= {}
-  options.content.pipeline ||= {}
-  options.content.pipeline.exclude ||= defaultPipelineExclude
-  if (Array.isArray(options.content.pipeline.exclude))
+  options.content ??= {}
+  options.content.pipeline ??= {}
+  if (options.content.pipeline !== false) {
+    options.content.pipeline.exclude ??= defaultPipelineExclude
+    if (Array.isArray(options.content.pipeline.exclude))
     // ignore macro files created by Nuxt
-    options.content.pipeline.exclude.push(/\?macro=true/)
+      options.content.pipeline.exclude.push(/\?macro=true/)
+  }
 }

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -109,7 +109,7 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
         }
 
         const globs = uno.config.content?.filesystem ?? defaultFilesystemGlobs
-        const plainContent = uno.config.content?.plain ?? []
+        const plainContent = uno.config.content?.inline ?? []
 
         const entries = await fg(isScanTarget ? globs : from, {
           cwd,
@@ -124,6 +124,8 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
 
         promises.push(
           ...plainContent.map(async (c, idx) => {
+            if (typeof c === 'function')
+              c = await c()
             if (typeof c === 'string')
               c = { code: c }
             const { matched } = await uno.generate(c.code, { id: c.id ?? `__plain_content_${idx}__` })

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -6,7 +6,7 @@ import type { Result, Root } from 'postcss'
 import postcss from 'postcss'
 import { createGenerator, warnOnce } from '@unocss/core'
 import { loadConfig } from '@unocss/config'
-import { defaultIncludeGlobs } from '../../shared-integration/src/defaults'
+import { defaultFilesystemGlobs } from '../../shared-integration/src/defaults'
 import { parseApply } from './apply'
 import { parseTheme, themeFnRE } from './theme'
 import { parseScreen } from './screen'
@@ -108,11 +108,8 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
           throw new Error (`UnoCSS config not found: ${error.message}`)
         }
 
-        const globs = content?.filter(v => typeof v === 'string') as string[] ?? defaultIncludeGlobs
-        const rawContent = content?.filter(v => typeof v === 'object') as {
-          raw: string
-          extension: string
-        }[] ?? []
+        const globs = uno.config.content?.filesystem ?? defaultFilesystemGlobs
+        const plainContent = uno.config.content?.plain ?? []
 
         const entries = await fg(isScanTarget ? globs : from, {
           cwd,
@@ -126,10 +123,10 @@ function unocss(options: UnoPostcssPluginOptions = {}) {
         await parseScreen(root, uno, directiveMap.screen)
 
         promises.push(
-          ...rawContent.map(async (v) => {
-            const { matched } = await uno.generate(v.raw, {
-              id: `unocss.${v.extension}`,
-            })
+          ...plainContent.map(async (c, idx) => {
+            if (typeof c === 'string')
+              c = { code: c }
+            const { matched } = await uno.generate(c.code, { id: c.id ?? `__plain_content_${idx}__` })
 
             for (const candidate of matched)
               classes.add(candidate)

--- a/packages/shared-integration/src/content.ts
+++ b/packages/shared-integration/src/content.ts
@@ -8,10 +8,12 @@ export async function setupContentExtractor(ctx: UnocssPluginContext, shouldWatc
   const { content } = await ctx.getConfig()
   const { extract, tasks, root, filter } = ctx
 
-  // plain text
-  if (content?.plain) {
+  // inline text
+  if (content?.inline) {
     await Promise.all(
-      content.plain.map((c, idx) => {
+      content.inline.map(async (c, idx) => {
+        if (typeof c === 'function')
+          c = await c()
         if (typeof c === 'string')
           c = { code: c }
         return extract(c.code, c.id ?? `__plain_content_${idx}__`)

--- a/packages/shared-integration/src/content.ts
+++ b/packages/shared-integration/src/content.ts
@@ -4,22 +4,24 @@ import fg from 'fast-glob'
 import type { UnocssPluginContext } from '@unocss/core'
 import { applyTransformers } from './transformers'
 
-export async function setupExtraContent(ctx: UnocssPluginContext, shouldWatch = false) {
-  const { extraContent } = await ctx.getConfig()
+export async function setupContentExtractor(ctx: UnocssPluginContext, shouldWatch = false) {
+  const { content } = await ctx.getConfig()
   const { extract, tasks, root, filter } = ctx
 
   // plain text
-  if (extraContent?.plain) {
+  if (content?.plain) {
     await Promise.all(
-      extraContent.plain.map((code, idx) => {
-        return extract(code, `__extra_content_${idx}__`)
+      content.plain.map((c, idx) => {
+        if (typeof c === 'string')
+          c = { code: c }
+        return extract(c.code, c.id ?? `__plain_content_${idx}__`)
       }),
     )
   }
 
   // filesystem
-  if (extraContent?.filesystem) {
-    const files = await fg(extraContent.filesystem, { cwd: root })
+  if (content?.filesystem) {
+    const files = await fg(content.filesystem, { cwd: root })
 
     async function extractFile(file: string) {
       const code = await fs.readFile(file, 'utf-8')

--- a/packages/shared-integration/src/context.ts
+++ b/packages/shared-integration/src/context.ts
@@ -5,6 +5,7 @@ import type { UnocssPluginContext, UserConfig, UserConfigDefaults } from '@unocs
 import { BetterMap, createGenerator } from '@unocss/core'
 import { CSS_PLACEHOLDER, IGNORE_COMMENT, INCLUDE_COMMENT } from './constants'
 import { defaultPipelineExclude, defaultPipelineInclude } from './defaults'
+import { deprecationCheck } from './deprecation'
 
 export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
   configOrPath?: Config | string,
@@ -31,6 +32,7 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
   async function reloadConfig() {
     const result = await loadConfig(root, configOrPath, extraConfigSources, defaults)
     resolveConfigResult(result)
+    deprecationCheck(result.config)
 
     rawConfig = result.config
     configFileList = result.sources

--- a/packages/shared-integration/src/context.ts
+++ b/packages/shared-integration/src/context.ts
@@ -4,7 +4,7 @@ import { loadConfig } from '@unocss/config'
 import type { UnocssPluginContext, UserConfig, UserConfigDefaults } from '@unocss/core'
 import { BetterMap, createGenerator } from '@unocss/core'
 import { CSS_PLACEHOLDER, IGNORE_COMMENT, INCLUDE_COMMENT } from './constants'
-import { defaultExclude, defaultInclude } from './defaults'
+import { defaultPipelineExclude, defaultPipelineInclude } from './defaults'
 
 export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
   configOrPath?: Config | string,
@@ -16,7 +16,7 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
   let rawConfig = {} as Config
   let configFileList: string[] = []
   const uno = createGenerator(rawConfig, defaults)
-  let rollupFilter = createFilter(defaultInclude, defaultExclude)
+  let rollupFilter = createFilter(defaultPipelineInclude, defaultPipelineExclude)
 
   const invalidations: Array<() => void> = []
   const reloadListeners: Array<() => void> = []
@@ -37,8 +37,8 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
     uno.setConfig(rawConfig)
     uno.config.envMode = 'dev'
     rollupFilter = createFilter(
-      rawConfig.include || defaultInclude,
-      rawConfig.exclude || defaultExclude,
+      rawConfig.content?.pipeline?.include || rawConfig.include || defaultPipelineInclude,
+      rawConfig.content?.pipeline?.exclude || rawConfig.exclude || defaultPipelineExclude,
     )
     tokens.clear()
     await Promise.all(modules.map((code, id) => uno.applyExtractors(code, id, tokens)))

--- a/packages/shared-integration/src/context.ts
+++ b/packages/shared-integration/src/context.ts
@@ -38,10 +38,12 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
     configFileList = result.sources
     uno.setConfig(rawConfig)
     uno.config.envMode = 'dev'
-    rollupFilter = createFilter(
-      rawConfig.content?.pipeline?.include || rawConfig.include || defaultPipelineInclude,
-      rawConfig.content?.pipeline?.exclude || rawConfig.exclude || defaultPipelineExclude,
-    )
+    rollupFilter = rawConfig.content?.pipeline === false
+      ? () => false
+      : createFilter(
+        rawConfig.content?.pipeline?.include || rawConfig.include || defaultPipelineInclude,
+        rawConfig.content?.pipeline?.exclude || rawConfig.exclude || defaultPipelineExclude,
+      )
     tokens.clear()
     await Promise.all(modules.map((code, id) => uno.applyExtractors(code, id, tokens)))
     invalidate()

--- a/packages/shared-integration/src/defaults.ts
+++ b/packages/shared-integration/src/defaults.ts
@@ -1,8 +1,10 @@
 import { cssIdRE } from '@unocss/core'
 
 // picomatch patterns, used with rollup's createFilter
-export const defaultExclude = [cssIdRE]
-export const defaultInclude = [/\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/]
+export const defaultPipelineExclude = [cssIdRE]
+export const defaultPipelineInclude = [/\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/]
 
 // micromatch patterns, used in postcss plugin
-export const defaultIncludeGlobs = ['**/*.{html,js,ts,jsx,tsx,vue,svelte,astro,elm,php,phtml,mdx,md}']
+export const defaultFilesystemGlobs = [
+  '**/*.{html,js,ts,jsx,tsx,vue,svelte,astro,elm,php,phtml,mdx,md}',
+]

--- a/packages/shared-integration/src/deprecation.ts
+++ b/packages/shared-integration/src/deprecation.ts
@@ -17,6 +17,9 @@ export function deprecationCheck(config: UserConfig) {
   if (config.extraContent)
     warn('`extraContent` option is deprecated, use `content` instead.')
 
+  if (config.content?.plain)
+    warn('`content.plain` option is renamed to `content.inline`.')
+
   if (warned && typeof process !== 'undefined' && process.env.CI)
     throw new Error('deprecation warning')
 }

--- a/packages/shared-integration/src/deprecation.ts
+++ b/packages/shared-integration/src/deprecation.ts
@@ -1,0 +1,22 @@
+import type { UserConfig } from '@unocss/core'
+
+export function deprecationCheck(config: UserConfig) {
+  let warned = false
+
+  function warn(msg: string) {
+    warned = true
+    console.warn(`[unocss] ${msg}`)
+  }
+
+  if (config.include)
+    warn('`include` option is deprecated, use `content.pipeline.include` instead.')
+
+  if (config.exclude)
+    warn('`exclude` option is deprecated, use `content.pipeline.exclude` instead.')
+
+  if (config.extraContent)
+    warn('`extraContent` option is deprecated, use `content` instead.')
+
+  if (warned && typeof process !== 'undefined' && process.env.CI)
+    throw new Error('deprecation warning')
+}

--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -14,7 +14,7 @@ import {
   resolveLayer,
 } from '../../integration'
 import type { VitePluginConfig } from '../../types'
-import { setupExtraContent } from '../../../../shared-integration/src/extra-content'
+import { setupContentExtractor } from '../../../../shared-integration/src/content'
 
 // https://github.com/vitejs/vite/blob/main/packages/plugin-legacy/src/index.ts#L742-L744
 function isLegacyChunk(chunk: RenderedChunk, options: NormalizedOutputOptions) {
@@ -191,7 +191,7 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
         viteConfig = config
       },
       buildStart() {
-        tasks.push(setupExtraContent(ctx, viteConfig.command === 'serve'))
+        tasks.push(setupContentExtractor(ctx, viteConfig.command === 'serve'))
       },
     },
     {

--- a/packages/vite/src/modes/vue-scoped.ts
+++ b/packages/vite/src/modes/vue-scoped.ts
@@ -18,10 +18,12 @@ export function VueScopedPlugin({ uno, ready }: UnocssPluginContext): Plugin {
     enforce: 'pre',
     async configResolved() {
       const { config } = await ready
-      filter = createFilter(
-        config.content?.pipeline?.include ?? config.include ?? [/\.vue$/],
-        config.content?.pipeline?.exclude ?? config.exclude ?? defaultPipelineExclude,
-      )
+      filter = config.content?.pipeline === false
+        ? () => false
+        : createFilter(
+          config.content?.pipeline?.include ?? config.include ?? [/\.vue$/],
+          config.content?.pipeline?.exclude ?? config.exclude ?? defaultPipelineExclude,
+        )
     },
     transform(code, id) {
       if (!filter(id))

--- a/packages/vite/src/modes/vue-scoped.ts
+++ b/packages/vite/src/modes/vue-scoped.ts
@@ -1,10 +1,10 @@
 import type { Plugin } from 'vite'
 import { createFilter } from '@rollup/pluginutils'
 import type { UnocssPluginContext } from '@unocss/core'
-import { defaultExclude } from '../integration'
+import { defaultPipelineExclude } from '../integration'
 
 export function VueScopedPlugin({ uno, ready }: UnocssPluginContext): Plugin {
-  let filter = createFilter([/\.vue$/], defaultExclude)
+  let filter = createFilter([/\.vue$/], defaultPipelineExclude)
 
   async function transformSFC(code: string) {
     const { css } = await uno.generate(code)
@@ -19,8 +19,8 @@ export function VueScopedPlugin({ uno, ready }: UnocssPluginContext): Plugin {
     async configResolved() {
       const { config } = await ready
       filter = createFilter(
-        config.include || [/\.vue$/],
-        config.exclude || defaultExclude,
+        config.content?.pipeline?.include ?? config.include ?? [/\.vue$/],
+        config.content?.pipeline?.exclude ?? config.exclude ?? defaultPipelineExclude,
       )
     },
     transform(code, id) {

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -3,7 +3,7 @@ import type { ResolvedUnpluginOptions, UnpluginOptions } from 'unplugin'
 import { createUnplugin } from 'unplugin'
 import WebpackSources from 'webpack-sources'
 import { createContext } from '../../shared-integration/src/context'
-import { setupExtraContent } from '../../shared-integration/src/extra-content'
+import { setupContentExtractor } from '../../shared-integration/src/content'
 import { getHash } from '../../shared-integration/src/hash'
 import { HASH_PLACEHOLDER_RE, LAYER_MARK_ALL, LAYER_PLACEHOLDER_RE, RESOLVED_ID_RE, getHashPlaceholder, getLayerPlaceholder, resolveId, resolveLayer } from '../../shared-integration/src/layers'
 import { applyTransformers } from '../../shared-integration/src/transformers'
@@ -43,7 +43,7 @@ export default function WebpackPlugin<Theme extends {}>(
     }
 
     // TODO: detect webpack's watch mode and enable watcher
-    tasks.push(setupExtraContent(ctx))
+    tasks.push(setupContentExtractor(ctx))
 
     const entries = new Set<string>()
     const hashes = new Map<string, string>()

--- a/test/postcss.test.ts
+++ b/test/postcss.test.ts
@@ -11,7 +11,7 @@ const config: UserConfig = {
     filesystem: [
       './test/assets/preset-wind-targets.ts',
     ],
-    plain: [{
+    inline: [{
       code: presetWindTargets.join(' '),
       id: 'targets.html',
     }],
@@ -63,7 +63,7 @@ function pcssLite() {
       configOrPath: <UserConfig>{
         content: {
           filesystem: [],
-          plain: [
+          inline: [
             {
               code: '<div class="relative p4 test example">',
               id: 'inline.html',

--- a/test/postcss.test.ts
+++ b/test/postcss.test.ts
@@ -1,6 +1,5 @@
-/* eslint-disable unused-imports/no-unused-imports */
 import type { UserConfig } from '@unocss/core'
-import { createGenerator, escapeSelector } from '@unocss/core'
+import { escapeSelector } from '@unocss/core'
 import presetWind from '@unocss/preset-wind'
 import postcssPlugin from '@unocss/postcss'
 import { describe, expect, test } from 'vitest'
@@ -8,6 +7,15 @@ import postcss from 'postcss'
 import { presetWindTargets } from './assets/preset-wind-targets'
 
 const config: UserConfig = {
+  content: {
+    filesystem: [
+      './test/assets/preset-wind-targets.ts',
+    ],
+    plain: [{
+      code: presetWindTargets.join(' '),
+      id: 'targets.html',
+    }],
+  },
   presets: [
     presetWind({
       dark: 'media',
@@ -52,12 +60,16 @@ function pcss() {
 function pcssLite() {
   return postcss(
     postcssPlugin({
-      content: [
-        {
-          raw: '<div class="relative p4 test example">', extension: 'html',
-        },
-      ],
       configOrPath: <UserConfig>{
+        content: {
+          filesystem: [],
+          plain: [
+            {
+              code: '<div class="relative p4 test example">',
+              id: 'inline.html',
+            },
+          ],
+        },
         presets: [
           presetWind(),
           {


### PR DESCRIPTION
rework #2503, thanks to @sibbng

close #2503

Breaking changes:

- `extraContent` option is renamed to `content`
- `include` option is moved to `content.pipeline.include`
- `exclude` option is moved to `content.pipeline.exclude`
- `content.plain` is removed to `content.inline`
- inline `content` option in PostCSS plugin is removed in favor of the normalized `content` option in `uno.config.ts`

Features:

- `content.inline` now support providing async functions
- set `content.pipeline` to false can disable pipeline extract completely, close #2652
- improve docs

For more details, please refer to https://unocss.dev/guide/extracting#content-sources