### PR TITLE
fix(preset-wind): wrong output for animate-iteration-count

### DIFF
--- a/packages/preset-wind/src/rules/animation.ts
+++ b/packages/preset-wind/src/rules/animation.ts
@@ -62,7 +62,7 @@ export const animations: Rule<Theme>[] = [
   ],
 
   // others
-  [/^animate-(?:iteration-|count-|iteration-count-)(.+)$/, ([, d]) => ({ 'animation-iteration-count': h.bracket.cssvar(d) ?? d.replace(/\-/g, ',') }), { autocomplete: ['animate-(iteration|count|iteration-count)', 'animate-(iteration|count|iteration-count)-<num>'] }],
+  [/^animate-(?:iteration-count-|iteration-|count-)(.+)$/, ([, d]) => ({ 'animation-iteration-count': h.bracket.cssvar(d) ?? d.replace(/\-/g, ',') }), { autocomplete: ['animate-(iteration|count|iteration-count)', 'animate-(iteration|count|iteration-count)-<num>'] }],
   [/^animate-(play-state-|play-|state-)?(.+)$/,
     ([, t, d]) => ['paused', 'running', ...[t ? globalKeywords : []]].includes(d) ? { 'animation-play-state': d } : undefined,
     {

--- a/test/__snapshots__/postcss.test.ts.snap
+++ b/test/__snapshots__/postcss.test.ts.snap
@@ -104,11 +104,11 @@ exports[`postcss > @unocss 1`] = `
 .animate-normal{animation-direction:normal;}
 .animate-reverse{animation-direction:reverse;}
 .animate-count-2\\\\.4{animation-iteration-count:2.4;}
-.animate-iteration-2{animation-iteration-count:2;}
-.animate-iteration-count-\\\\[2\\\\,4\\\\,infinity\\\\]{animation-iteration-count:count,[2,4,infinity];}
-.animate-iteration-count-\\\\$variable{animation-iteration-count:count,$variable;}
-.animate-iteration-count-2{animation-iteration-count:count,2;}
-.animate-iteration-count-2-4-infinity{animation-iteration-count:count,2,4,infinity;}
+.animate-iteration-2,
+.animate-iteration-count-2{animation-iteration-count:2;}
+.animate-iteration-count-\\\\[2\\\\,4\\\\,infinity\\\\],
+.animate-iteration-count-2-4-infinity{animation-iteration-count:2,4,infinity;}
+.animate-iteration-count-\\\\$variable{animation-iteration-count:var(--variable);}
 .animate-paused,
 .animate-play-paused{animation-play-state:paused;}
 .animate-play-state-running,

--- a/test/assets/output/preset-wind-targets.css
+++ b/test/assets/output/preset-wind-targets.css
@@ -72,11 +72,11 @@
 .animate-normal{animation-direction:normal;}
 .animate-reverse{animation-direction:reverse;}
 .animate-count-2\.4{animation-iteration-count:2.4;}
-.animate-iteration-2{animation-iteration-count:2;}
-.animate-iteration-count-\[2\,4\,infinity\]{animation-iteration-count:count,[2,4,infinity];}
-.animate-iteration-count-\$variable{animation-iteration-count:count,$variable;}
-.animate-iteration-count-2{animation-iteration-count:count,2;}
-.animate-iteration-count-2-4-infinity{animation-iteration-count:count,2,4,infinity;}
+.animate-iteration-2,
+.animate-iteration-count-2{animation-iteration-count:2;}
+.animate-iteration-count-\[2\,4\,infinity\],
+.animate-iteration-count-2-4-infinity{animation-iteration-count:2,4,infinity;}
+.animate-iteration-count-\$variable{animation-iteration-count:var(--variable);}
 .animate-paused,
 .animate-play-paused{animation-play-state:paused;}
 .animate-play-state-running,


### PR DESCRIPTION
fix all `animate-iteration-count-*` usage, a wider range match should place before other

![image](https://github.com/unocss/unocss/assets/29378026/ae2194f3-1a0c-404c-97a4-bac05dfeeae6)
