### PR TITLE
feat(shared-integration): add skip magic comment

### DIFF
--- a/docs/guide/extracting.md
+++ b/docs/guide/extracting.md
@@ -61,6 +61,25 @@ export const classes = {
 
 Similarly, you can also add `@unocss-ignore` to bypass the scanning and transforming for a file.
 
+If you want the UnoCSS to skip a block of code without being extracted, you can use `@unocss-skip-start` `@unocss-skip-end` in pairs:
+
+```html
+<p class="text-green text-xl">
+  Green Large
+</p>
+
+<!-- @unocss-skip-end -->
+<!-- `text-red` will not be extracted -->
+<p class="text-red">
+  Red
+</p>
+<!-- @unocss-skip-end -->
+```
+
+:::tip
+You can use `@unocss-skip-start` `@unocss-skip-end` magic comment in any extracting files, and must be used **in pairs** to be effective.
+:::
+
 ### Extracting from Filesystem
 
 In cases that you are using integrations that does not have access to the build tools pipeline (for example, the [PostCSS](/integrations/postcss) plugin), or you are integrating with backend frameworks that the code does not go through the pipeline, you can manually specify the files to be extracted.

--- a/examples/vite-vue3/src/App.vue
+++ b/examples/vite-vue3/src/App.vue
@@ -6,6 +6,8 @@
     </div>
     <div i-custom-icon />
     <div i-custom-multi-line-attr />
+    <!-- @unocss-skip-start -->
     <div hidden class="bg-[url(../src/uno.svg)] bg-[url(/uno.svg)]" />
+    <!-- @unocss-skip-end -->
   </div>
 </template>

--- a/packages/inspector/node/index.ts
+++ b/packages/inspector/node/index.ts
@@ -5,6 +5,7 @@ import type { Plugin, ViteDevServer } from 'vite'
 import type { UnocssPluginContext } from '@unocss/core'
 import gzipSize from 'gzip-size'
 import type { ModuleInfo, ProjectInfo } from '../types'
+import { SKIP_COMMENT_RE } from '../../shared-integration/src/constants'
 
 const _dirname = typeof __dirname !== 'undefined'
   ? __dirname
@@ -48,7 +49,7 @@ export default function UnocssInspector(ctx: UnocssPluginContext): Plugin {
           return
         }
 
-        const result = await ctx.uno.generate(code, { id, preflights: false })
+        const result = await ctx.uno.generate(code.replace(SKIP_COMMENT_RE, ''), { id, preflights: false })
         const mod: ModuleInfo = {
           ...result,
           matched: Array.from(result.matched),

--- a/packages/shared-integration/src/constants.ts
+++ b/packages/shared-integration/src/constants.ts
@@ -2,3 +2,6 @@ export const INCLUDE_COMMENT = '@unocss-include'
 export const IGNORE_COMMENT = '@unocss-ignore'
 export const INCLUDE_COMMENT_IDE = '@unocss-ide-include'
 export const CSS_PLACEHOLDER = '@unocss-placeholder'
+export const SKIP_START_COMMENT = '@unocss-skip-start'
+export const SKIP_END_COMMENT = '@unocss-skip-end'
+export const SKIP_COMMENT_RE = new RegExp(`(\/\/\\s*?${SKIP_START_COMMENT}\\s*?|\\/\\*\\s*?${SKIP_START_COMMENT}\\s*?\\*\\/|<!--\\s*?${SKIP_START_COMMENT}\\s*?-->)[\\s\\S]*?(\/\/\\s*?${SKIP_END_COMMENT}\\s*?|\\/\\*\\s*?${SKIP_END_COMMENT}\\s*?\\*\\/|<!--\\s*?${SKIP_END_COMMENT}\\s*?-->)`, 'g')

--- a/packages/shared-integration/src/context.ts
+++ b/packages/shared-integration/src/context.ts
@@ -3,7 +3,7 @@ import type { LoadConfigResult, LoadConfigSource } from '@unocss/config'
 import { loadConfig } from '@unocss/config'
 import type { UnocssPluginContext, UserConfig, UserConfigDefaults } from '@unocss/core'
 import { BetterMap, createGenerator } from '@unocss/core'
-import { CSS_PLACEHOLDER, IGNORE_COMMENT, INCLUDE_COMMENT } from './constants'
+import { CSS_PLACEHOLDER, IGNORE_COMMENT, INCLUDE_COMMENT, SKIP_COMMENT_RE } from './constants'
 import { defaultPipelineExclude, defaultPipelineInclude } from './defaults'
 import { deprecationCheck } from './deprecation'
 
@@ -45,7 +45,7 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
         rawConfig.content?.pipeline?.exclude || rawConfig.exclude || defaultPipelineExclude,
       )
     tokens.clear()
-    await Promise.all(modules.map((code, id) => uno.applyExtractors(code, id, tokens)))
+    await Promise.all(modules.map((code, id) => uno.applyExtractors(code.replace(SKIP_COMMENT_RE, ''), id, tokens)))
     invalidate()
     dispatchReload()
 
@@ -83,7 +83,7 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
     if (id)
       modules.set(id, code)
     const len = tokens.size
-    await uno.applyExtractors(code, id, tokens)
+    await uno.applyExtractors(code.replace(SKIP_COMMENT_RE, ''), id, tokens)
     if (tokens.size > len)
       invalidate()
   }

--- a/packages/shared-integration/src/hash.ts
+++ b/packages/shared-integration/src/hash.ts
@@ -6,3 +6,15 @@ export function getHash(input: string, length = 8) {
     .digest('hex')
     .slice(0, length)
 }
+
+export function hash(str: string) {
+  let i
+  let l
+  let hval = 0x811C9DC5
+
+  for (i = 0, l = str.length; i < l; i++) {
+    hval ^= str.charCodeAt(i)
+    hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24)
+  }
+  return (`00000${(hval >>> 0).toString(36)}`).slice(-6)
+}

--- a/packages/shared-integration/src/transformers.ts
+++ b/packages/shared-integration/src/transformers.ts
@@ -3,7 +3,10 @@ import MagicString from 'magic-string'
 import type { EncodedSourceMap } from '@ampproject/remapping'
 import remapping from '@ampproject/remapping'
 import type { SourceMap } from 'rollup'
-import { IGNORE_COMMENT } from './constants'
+import { IGNORE_COMMENT, SKIP_COMMENT_RE } from './constants'
+import { hash } from './hash'
+
+const skipMap = new Map<string, string>()
 
 export async function applyTransformers(
   ctx: UnocssPluginContext,
@@ -19,8 +22,9 @@ export async function applyTransformers(
     return
 
   let code = original
-  let s = new MagicString(code)
+  let s = new MagicString(transformSkipCode(code))
   const maps: EncodedSourceMap[] = []
+
   for (const t of transformers) {
     if (t.idFilter) {
       if (!t.idFilter(id))
@@ -31,7 +35,7 @@ export async function applyTransformers(
     }
     await t.transform(s, id, ctx)
     if (s.hasChanged()) {
-      code = s.toString()
+      code = restoreSkipCode(s.toString())
       maps.push(s.generateMap({ hires: true, source: id }) as EncodedSourceMap)
       s = new MagicString(code)
     }
@@ -44,4 +48,24 @@ export async function applyTransformers(
       map: remapping(maps, () => null) as SourceMap,
     }
   }
+}
+
+function transformSkipCode(code: string) {
+  for (const item of Array.from(code.matchAll(SKIP_COMMENT_RE))) {
+    if (item != null) {
+      const matched = item[0]
+      const withHashKey = `@unocss-skip-placeholder-${hash(matched)}`
+      skipMap.set(withHashKey, matched)
+      code = code.replace(matched, withHashKey)
+    }
+  }
+
+  return code
+}
+
+function restoreSkipCode(code: string) {
+  for (const [withHashKey, matched] of skipMap.entries())
+    code = code.replace(withHashKey, matched)
+
+  return code
 }

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -39,7 +39,6 @@ describe.concurrent('fixtures', () => {
     // transformer-directives
     expect(css).not.contains('@apply')
     expect(css).contains('gap:.25rem')
-    expect(css).contains('gap:.5rem')
 
     // transformer-variant-group
     expect(js).contains('text-sm')
@@ -51,6 +50,7 @@ describe.concurrent('fixtures', () => {
     expect(css).not.contains('.text-yellow')
     // test transform
     expect(css).contains('--at-apply')
+    expect(css).not.contains('gap:.5rem')
     expect(css).not.contains('.text-teal')
   })
 

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -48,7 +48,7 @@ describe.concurrent('fixtures', () => {
 
     // @unocss-skip magic comment
     // test extract
-    expect(css).not.contains('.text-green')
+    expect(css).not.contains('.text-yellow')
     // test transform
     expect(css).contains('--at-apply')
     expect(css).not.contains('.text-teal')

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -31,7 +31,7 @@ describe.concurrent('fixtures', () => {
     const js = await getGlobContent(root, 'dist/**/*.js')
 
     // basic
-    expect(css).contains('.text-red')
+    expect(css).not.contains('.text-red')
     // transformer-variant-group
     expect(css).contains('.text-sm')
     // transformer-compile-class

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -31,14 +31,13 @@ describe.concurrent('fixtures', () => {
     const js = await getGlobContent(root, 'dist/**/*.js')
 
     // basic
-    expect(css).not.contains('.text-red')
+    expect(css).contains('.text-red')
     // transformer-variant-group
     expect(css).contains('.text-sm')
     // transformer-compile-class
     expect(css).contains('.uno-tacwqa')
     // transformer-directives
     expect(css).not.contains('@apply')
-    expect(css).not.contains('--at-apply')
     expect(css).contains('gap:.25rem')
     expect(css).contains('gap:.5rem')
 
@@ -46,6 +45,13 @@ describe.concurrent('fixtures', () => {
     expect(js).contains('text-sm')
     // transformer-compile-class
     expect(js).contains('uno-tacwqa')
+
+    // @unocss-skip magic comment
+    // test extract
+    expect(css).not.contains('.text-green')
+    // test transform
+    expect(css).contains('--at-apply')
+    expect(css).not.contains('.text-teal')
   })
 
   it.skipIf(isWindows)('vite legacy', async () => {

--- a/test/fixtures/vite/src/main.css
+++ b/test/fixtures/vite/src/main.css
@@ -3,6 +3,8 @@
   --uno: gap-1;
 }
 
+/* @unocss-skip-start */
 .bar {
   --at-apply: gap-2;
 }
+/* @unocss-skip-end */

--- a/test/fixtures/vite/src/main.ts
+++ b/test/fixtures/vite/src/main.ts
@@ -6,16 +6,21 @@ import 'uno.css'
 const html = String.raw
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = html`
   <div class="font-sans p4">
-    <!-- @unocss-skip-start -->
     <p class="text-red">
       Red
     </p>
-    <!-- @unocss-skip-end -->
+    <!-- @unocss-skip-start -->
     <p class=":uno: text-green text-xl">
       Green Large
     </p>
+    <!-- @unocss-skip-end -->
     <p class="text-(blue sm)">
       Blue Small
     </p>
+    <!-- @unocss-skip-start -->
+    <p class="text-(teal xl)">
+      Skip transformer
+    </p>
+     <!-- @unocss-skip-end -->
   </div>
 `

--- a/test/fixtures/vite/src/main.ts
+++ b/test/fixtures/vite/src/main.ts
@@ -6,9 +6,11 @@ import 'uno.css'
 const html = String.raw
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = html`
   <div class="font-sans p4">
+    <!-- @unocss-skip-start -->
     <p class="text-red">
       Red
     </p>
+    <!-- @unocss-skip-end -->
     <p class=":uno: text-green text-xl">
       Green Large
     </p>

--- a/test/fixtures/vite/src/main.ts
+++ b/test/fixtures/vite/src/main.ts
@@ -10,10 +10,13 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = html`
       Red
     </p>
     <!-- @unocss-skip-start -->
-    <p class=":uno: text-green text-xl">
-      Green Large
+    <p class="text-yellow text-lg">
+      Teal Large
     </p>
     <!-- @unocss-skip-end -->
+    <p class=":uno: text-green text-xl">
+      Green XL
+    </p>
     <p class="text-(blue sm)">
       Blue Small
     </p>


### PR DESCRIPTION
close #2761 

This PR change: 
- add `@unocss-skip-start` (A) &  `@unocss-skip-end` (B) magic comments.
- In `extract` or `transform` step, will ignore some code that between A and B.