### PR TITLE
feat(cli): add `--stdout`

### DIFF
--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -120,6 +120,7 @@ For a list of options, head over to the [UnoCSS configurations](/config/) docs.
 | `-v, --version` | Display the current version of UnoCSS |
 | `-c, --config-file <file>` | Config file |
 | `-o, --out-file <file>` | The output filename for the generated UnoCSS file. Defaults to `uno.css` in the current working directory |
+| `--stdout` | Write the generated UnoCSS file to STDOUT. Will be ignored if `--watch` or `--out-file` is set |
 | `-w, --watch` | Indicates if the files found by the glob pattern should be watched |
 | `--preflights` | Enable preflight styles |
 | `-m, --minify` | Minify generated CSS |

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -120,7 +120,7 @@ For a list of options, head over to the [UnoCSS configurations](/config/) docs.
 | `-v, --version` | Display the current version of UnoCSS |
 | `-c, --config-file <file>` | Config file |
 | `-o, --out-file <file>` | The output filename for the generated UnoCSS file. Defaults to `uno.css` in the current working directory |
-| `--stdout` | Write the generated UnoCSS file to STDOUT. Will be ignored if `--watch` or `--out-file` is set |
+| `--stdout` | Write the generated UnoCSS file to STDOUT. Will cause the `--watch` and `--out-file` being ignored |
 | `-w, --watch` | Indicates if the files found by the glob pattern should be watched |
 | `--preflights` | Enable preflight styles |
 | `-m, --minify` | Minify generated CSS |

--- a/packages/cli/src/cli-start.ts
+++ b/packages/cli/src/cli-start.ts
@@ -15,6 +15,9 @@ export async function startCli(cwd = process.cwd(), argv = process.argv, options
     .option('-o, --out-file <file>', 'Output file', {
       default: cwd,
     })
+    .option('--stdout', 'Output to STDOUT', {
+      default: false,
+    })
     .option('-c, --config [file]', 'Config file')
     .option('-w, --watch', 'Watch for file changes')
     .option('--preflights', 'Enable preflights', { default: true })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -46,8 +46,10 @@ export async function build(_options: CliOptions) {
     }),
   )
 
-  consola.log(green(`${name} v${version}`))
-  consola.start(`UnoCSS ${options.watch ? 'in watch mode...' : 'for production...'}`)
+  if (!options.stdout) {
+    consola.log(green(`${name} v${version}`))
+    consola.start(`UnoCSS ${options.watch ? 'in watch mode...' : 'for production...'}`)
+  }
 
   const debouncedBuild = debounce(
     async () => {
@@ -57,7 +59,7 @@ export async function build(_options: CliOptions) {
   )
 
   const startWatcher = async () => {
-    if (!options.watch)
+    if (options.stdout || !options.watch)
       return
     const { patterns } = options
 
@@ -110,8 +112,6 @@ export async function build(_options: CliOptions) {
   async function generate(options: ResolvedCliOptions) {
     const sourceCache = Array.from(fileCache).map(([id, code]) => ({ id, code }))
 
-    const outFile = resolve(options.cwd || process.cwd(), options.outFile ?? 'uno.css')
-
     const preTransform = await transformFiles(sourceCache, 'pre')
     const defaultTransform = await transformFiles(preTransform)
     const postTransform = await transformFiles(defaultTransform, 'post')
@@ -134,6 +134,12 @@ export async function build(_options: CliOptions) {
       },
     )
 
+    if (options.stdout) {
+      process.stdout.write(css)
+      return
+    }
+
+    const outFile = resolve(options.cwd || process.cwd(), options.outFile ?? 'uno.css')
     const dir = dirname(outFile)
     if (!existsSync(dir))
       await fs.mkdir(dir, { recursive: true })

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -7,6 +7,7 @@ export interface CliOptions {
   outFile?: string
   watch?: boolean
   config?: string
+  stdout?: boolean
 
   // generate options
   preflights?: boolean


### PR DESCRIPTION
This implementation does not check the [`CliEntryItem`](https://unocss.dev/integrations/cli#configurations). I'm not sure what's the desired behavior if `outFile` in config and `--stdout` in CLI both occur.

close #2765