### PR TITLE
perf(autocomplete): better order with fuzzy search.

### DIFF
--- a/packages/autocomplete/src/create.ts
+++ b/packages/autocomplete/src/create.ts
@@ -11,7 +11,6 @@ export function createAutocomplete(uno: UnoGenerator, options: AutocompleteOptio
   const cache = new LRUCache<string, string[]>({ max: 5000 })
 
   let staticUtils: string[] = []
-  let staticFzf = new Fzf<string[]>([])
 
   const templates: (AutoCompleteTemplate | AutoCompleteFunction)[] = []
 
@@ -145,7 +144,7 @@ export function createAutocomplete(uno: UnoGenerator, options: AutocompleteOptio
 
   async function suggestStatic(input: string) {
     if (matchType === 'fuzzy')
-      return staticFzf.find(input).map(i => i.item)
+      return staticUtils
     return staticUtils.filter(i => i.startsWith(input))
   }
 
@@ -181,7 +180,6 @@ export function createAutocomplete(uno: UnoGenerator, options: AutocompleteOptio
       ...Object.keys(uno.config.rulesStaticMap),
       ...uno.config.shortcuts.filter(i => typeof i[0] === 'string').map(i => i[0] as string),
     ]
-    staticFzf = new Fzf(staticUtils)
     templates.length = 0
     templates.push(
       ...uno.config.autocomplete.templates || [],

--- a/test/autocomplete-fuzzy.test.ts
+++ b/test/autocomplete-fuzzy.test.ts
@@ -43,4 +43,9 @@ describe('autocomplete-fuzzy', () => {
     expect(await ac.suggest('bmc'))
       .includes('bg-mode-color')
   })
+
+  it('order', async () => {
+    const suggestions = await ac.suggest('ga')
+    expect(suggestions.indexOf('gap-0')).toBeLessThan(suggestions.indexOf('gap-1'))
+  })
 })


### PR DESCRIPTION
<img width="325" alt="image" src="https://github.com/unocss/unocss/assets/16945858/412ebd88-3555-4d6e-b523-5d8f05a7e63c">

**Through second search, we can have better ordering**