### PR TITLE
chore(docs): typo

### DIFF
--- a/docs/guide/extracting.md
+++ b/docs/guide/extracting.md
@@ -68,7 +68,7 @@ If you want the UnoCSS to skip a block of code without being extracted, you can 
   Green Large
 </p>
 
-<!-- @unocss-skip-end -->
+<!-- @unocss-skip-start -->
 <!-- `text-red` will not be extracted -->
 <p class="text-red">
   Red


### PR DESCRIPTION
should start with  <!-- @unocss-skip-start -->