### PR TITLE
fix(icons): loader does not exist is displayed in case of undefined

### DIFF
--- a/packages/preset-icons/src/core.ts
+++ b/packages/preset-icons/src/core.ts
@@ -124,7 +124,8 @@ export function createPresetIcons(lookupIconLoader: (options: IconsOptions) => P
 export function combineLoaders(loaders: UniversalIconLoader[]) {
   return (async (...args) => {
     for (const loader of loaders) {
-      if ( !loader ) continue;
+      if (!loader)
+        continue
       const result = await loader(...args)
       if (result)
         return result

--- a/packages/preset-icons/src/core.ts
+++ b/packages/preset-icons/src/core.ts
@@ -124,6 +124,7 @@ export function createPresetIcons(lookupIconLoader: (options: IconsOptions) => P
 export function combineLoaders(loaders: UniversalIconLoader[]) {
   return (async (...args) => {
     for (const loader of loaders) {
+      if ( !loader ) continue;
       const result = await loader(...args)
       if (result)
         return result


### PR DESCRIPTION
# Problem

![image](https://github.com/unocss/unocss/assets/59305952/3bd48446-4e60-4e95-aabd-824db19e7d6f)
Please take a look at the image above.

The `uno.config.ts`

``` typescript
import { defineConfig } from "unocss";
import presetIcons from '@unocss/preset-icons'

export default defineConfig({
  presets: [
    ...
    presetIcons({
      ...
    }),
  ],
});
```

When I started the project in the `electron-vite` ([Here](https://github.com/electron-vite)) template repository (Additionally: UnoCSS added), an error occurred!

![image](https://github.com/unocss/unocss/assets/59305952/4bb9c0a0-e5df-41df-ab4b-5f16f66ab954)

# Solution

I don't know what the problem exactly is, but when I ignore to load `undefined loader` it works and has no influence on functions.