### PR TITLE
docs: fix link to community presets

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -88,7 +88,7 @@ export default defineConfig({
 })
 ```
 
-So similarly, we provided a few [official presets](/presets/) for you to start using right away, and you can also find many interesting [community presets](/presets/#community).
+So similarly, we provided a few [official presets](/presets/) for you to start using right away, and you can also find many interesting [community presets](/presets/community).
 
 ## Play
 


### PR DESCRIPTION
### Why

There's no anchor to a community section in the [official presets page](https://unocss.dev/presets/) and no community section in that page. There is a dedicated [community presets page](https://unocss.dev/presets/community) in documentation. This PR simply update the link to this page instead of the going to the official presets page.