### PR TITLE
fix(variant-group): magic overwrite error.

### DIFF
--- a/packages/core/src/utils/variantGroup.ts
+++ b/packages/core/src/utils/variantGroup.ts
@@ -90,7 +90,7 @@ export function expandVariantGroup(str: string | MagicString, separators = ['-',
   }
   else {
     return str.length()
-      ? str.overwrite(0, str.length(), expanded)
+      ? str.overwrite(0, str.original.length, expanded)
       : str
   }
 }


### PR DESCRIPTION
close #2566 

If MagicString  's `end` > `original.length` , it will out of bounds.

see: [https://stackblitz.com/edit/stackblitz-starters-ditjvq?file=index.js](https://stackblitz.com/edit/stackblitz-starters-ditjvq?file=index.js)