### PR TITLE
feat(nuxt): Allow the usage of a custom reset for preflight

### DIFF
--- a/examples/nuxt3/app.vue
+++ b/examples/nuxt3/app.vue
@@ -11,5 +11,9 @@
 </template>
 
 <style>
+/**
+ * Alternatively, `preflight: true` or `preflight: "@unocss/reset/tailwind.css"` can be used on `nuxt.config.ts`
+ * to achieve the same behaviour
+ */
 @import '@unocss/reset/tailwind.css';
 </style>

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -45,8 +45,12 @@ export default defineNuxtModule<UnocssNuxtOptions>({
               ? 'export default () => {}'
               : 'import { defineNuxtPlugin } from \'#imports\'; export default defineNuxtPlugin(() => {})',
           ]
-          if (options.preflight)
-            lines.unshift('import \'@unocss/reset/tailwind.css\'')
+          if (options.preflight) {
+            const resetPath = typeof options.preflight === 'string'
+              ? options.preflight
+              : '@unocss/reset/tailwind.css'
+            lines.unshift(`import '${resetPath}'`)
+          }
           return lines.join('\n')
         },
       })

--- a/packages/nuxt/src/types.ts
+++ b/packages/nuxt/src/types.ts
@@ -24,11 +24,11 @@ export interface UnocssNuxtOptions extends UserConfig {
   autoImport?: boolean
 
   /**
-   * Injecting `@unocss/reset/tailwind.css` entry
-   *
+   * Include reset styles
+   * When passing `true`, `@unocss/reset/tailwind.css` will be used
    * @default false
    */
-  preflight?: boolean
+  preflight?: string | boolean
 
   /**
    * Installing UnoCSS components


### PR DESCRIPTION
Following the behavior that's already implemented for Astro, this changes allows the current `preflight` option on Nuxt to define a different reset import.

> Main motivation for this change is that I have a project that was impacted by #2127 and, even though I could use the reset of tailwind-compact from the .vue files instead of having it on the config, I think that having equivalent configuration options between frameworks would be better.