### PR TITLE
fix(vscode): better languageIds configure

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -41,9 +41,7 @@
           "description": "Disable the UnoCSS extension"
         },
         "unocss.languageIds": {
-          "type": [
-            "array"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           }


### PR DESCRIPTION
<img width="693" alt="image" src="https://github.com/unocss/unocss/assets/16945858/4796697e-e489-41a0-bf54-61aad9753080">

Just like `Iconify IntelliSense` or `Code Spell Checker`