### PR TITLE
fix(preset-web-fonts): sort weights as string using localeCompare

### DIFF
--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -27,7 +27,11 @@ export function normalizedFontMeta(meta: WebFontMeta | string, defaultProvider: 
   if (typeof meta !== 'string') {
     meta.provider = resolveProvider(meta.provider || defaultProvider)
     if (meta.weights)
-      meta.weights = [...new Set(meta.weights.map(Number).sort((a, b) => a - b))]
+      meta.weights = [
+        ...new Set(meta.weights.sort((a, b) => 
+          a.toString().localeCompare(b.toString(), 'en', { numeric: true }))
+        )
+      ]
     return meta as ResolvedWebFontMeta
   }
 

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -26,13 +26,9 @@ export { createGoogleCompatibleProvider as createGoogleProvider } from './provid
 export function normalizedFontMeta(meta: WebFontMeta | string, defaultProvider: WebFontsProviders): ResolvedWebFontMeta {
   if (typeof meta !== 'string') {
     meta.provider = resolveProvider(meta.provider || defaultProvider)
-    if (meta.weights) {
-      meta.weights = [
-        ...new Set(meta.weights.sort((a, b) =>
-          a.toString().localeCompare(b.toString(), 'en', { numeric: true })),
-        ),
-      ]
-    }
+    if (meta.weights)
+      meta.weights = [...new Set(meta.weights.sort((a, b) => a.toString().localeCompare(b.toString(), 'en', { numeric: true })))]
+
     return meta as ResolvedWebFontMeta
   }
 

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -28,7 +28,7 @@ export function normalizedFontMeta(meta: WebFontMeta | string, defaultProvider: 
     meta.provider = resolveProvider(meta.provider || defaultProvider)
     if (meta.weights) {
       meta.weights = [
-        ...new Set(meta.weights.sort((a, b) => 
+        ...new Set(meta.weights.sort((a, b) =>
           a.toString().localeCompare(b.toString(), 'en', { numeric: true })),
         ),
       ]

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -35,7 +35,7 @@ export function normalizedFontMeta(meta: WebFontMeta | string, defaultProvider: 
 
   return {
     name,
-    weights: [...new Set(weights.split(/[,;]\s*/).filter(Boolean).sort((a, b) => a.toString().localeCompare(b.toString(), 'en', { numeric: true })))],
+    weights: [...new Set(weights.split(/[,;]\s*/).filter(Boolean).sort((a, b) => a.localeCompare(b, 'en', { numeric: true })))],
     provider: resolveProvider(defaultProvider),
   }
 }

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -26,12 +26,13 @@ export { createGoogleCompatibleProvider as createGoogleProvider } from './provid
 export function normalizedFontMeta(meta: WebFontMeta | string, defaultProvider: WebFontsProviders): ResolvedWebFontMeta {
   if (typeof meta !== 'string') {
     meta.provider = resolveProvider(meta.provider || defaultProvider)
-    if (meta.weights)
+    if (meta.weights) {
       meta.weights = [
         ...new Set(meta.weights.sort((a, b) => 
-          a.toString().localeCompare(b.toString(), 'en', { numeric: true }))
-        )
+          a.toString().localeCompare(b.toString(), 'en', { numeric: true })),
+        ),
       ]
+    }
     return meta as ResolvedWebFontMeta
   }
 

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -24,10 +24,16 @@ function resolveProvider(provider: WebFontsProviders): Provider {
 export { createGoogleCompatibleProvider as createGoogleProvider } from './providers/google'
 
 export function normalizedFontMeta(meta: WebFontMeta | string, defaultProvider: WebFontsProviders): ResolvedWebFontMeta {
+  const sortFilterWeights = (weights: (string | number)[]) => [...new Set(weights
+    .map(Number)
+    .filter(w => !Number.isNaN(Number(w)))
+    .sort((a, b) => a - b),
+  )]
+
   if (typeof meta !== 'string') {
     meta.provider = resolveProvider(meta.provider || defaultProvider)
     if (meta.weights)
-      meta.weights = [...new Set(meta.weights.sort((a, b) => a.toString().localeCompare(b.toString(), 'en', { numeric: true })))]
+      meta.weights = sortFilterWeights(meta.weights)
 
     return meta as ResolvedWebFontMeta
   }
@@ -36,7 +42,7 @@ export function normalizedFontMeta(meta: WebFontMeta | string, defaultProvider: 
 
   return {
     name,
-    weights: [...new Set(weights.split(/[,;]\s*/).filter(Boolean).map(Number).sort((a, b) => a - b))],
+    weights: sortFilterWeights(weights.split(/[,;]\s*/).filter(Boolean)),
     provider: resolveProvider(defaultProvider),
   }
 }

--- a/packages/preset-web-fonts/src/index.ts
+++ b/packages/preset-web-fonts/src/index.ts
@@ -24,17 +24,10 @@ function resolveProvider(provider: WebFontsProviders): Provider {
 export { createGoogleCompatibleProvider as createGoogleProvider } from './providers/google'
 
 export function normalizedFontMeta(meta: WebFontMeta | string, defaultProvider: WebFontsProviders): ResolvedWebFontMeta {
-  const sortFilterWeights = (weights: (string | number)[]) => [...new Set(weights
-    .map(Number)
-    .filter(w => !Number.isNaN(Number(w)))
-    .sort((a, b) => a - b),
-  )]
-
   if (typeof meta !== 'string') {
     meta.provider = resolveProvider(meta.provider || defaultProvider)
     if (meta.weights)
-      meta.weights = sortFilterWeights(meta.weights)
-
+      meta.weights = [...new Set(meta.weights.sort((a, b) => a.toString().localeCompare(b.toString(), 'en', { numeric: true })))]
     return meta as ResolvedWebFontMeta
   }
 
@@ -42,7 +35,7 @@ export function normalizedFontMeta(meta: WebFontMeta | string, defaultProvider: 
 
   return {
     name,
-    weights: sortFilterWeights(weights.split(/[,;]\s*/).filter(Boolean)),
+    weights: [...new Set(weights.split(/[,;]\s*/).filter(Boolean).sort((a, b) => a.toString().localeCompare(b.toString(), 'en', { numeric: true })))],
     provider: resolveProvider(defaultProvider),
   }
 }

--- a/packages/preset-web-fonts/src/providers/bunny.ts
+++ b/packages/preset-web-fonts/src/providers/bunny.ts
@@ -13,7 +13,7 @@ export function createBunnyFontsProvider(
         if (!weights?.length)
           return `${formattedName}${italic ? ':i' : ''}`
 
-        let weightsAsString = weights.sort().map(weight => weight.toString())
+        let weightsAsString = weights.map(weight => weight.toString())
         // 1. if weights have at least one element that has 'i', ignore the `italic` flag.
         // 2. if none of the weights have an 'i' and italic is true, append an 'i'
         const weightsHaveItalic = weightsAsString.some(weight => weight.endsWith('i'))

--- a/test/preset-web-fonts.test.ts
+++ b/test/preset-web-fonts.test.ts
@@ -99,7 +99,7 @@ test('web-fonts weigth deduplicate', async () => {
           lato: [
             {
               name: 'Lato',
-              weights: ['1000', '200', '1000', '400', 'xxx'],
+              weights: ['1000', '200', '1000', '400'],
               italic: true,
             },
           ],

--- a/test/preset-web-fonts.test.ts
+++ b/test/preset-web-fonts.test.ts
@@ -99,7 +99,7 @@ test('web-fonts weigth deduplicate', async () => {
           lato: [
             {
               name: 'Lato',
-              weights: ['1000', '200', '1000', '400'],
+              weights: ['1000', '200', '1000', '400', 'xxx'],
               italic: true,
             },
           ],


### PR DESCRIPTION
Previously, the weights were converted to Number before sorting. This would lead to conversion of string to NaN.