### PR TITLE
chore: add npm homepage link

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.53.5",
   "private": true,
   "packageManager": "pnpm@8.6.6",
+  "homepage": "https://unocss.dev",
   "scripts": {
     "postinstall": "esno scripts/icon-collections.ts",
     "taze": "taze minor -wIr && pnpm -r --parallel run update-post",


### PR DESCRIPTION
The npm homepage has already displayed the content of README.md, you can add the official website address to the homepage of npm .

![image](https://github.com/unocss/unocss/assets/45450994/8934b035-3a31-4e65-a389-32adaecc4e9b)
