### PR TITLE
fix(preset-mini): remove grid-gap from generated CSS (deprecated in favor of gap), fix #2642

### DIFF
--- a/packages/preset-mini/src/_rules/gap.ts
+++ b/packages/preset-mini/src/_rules/gap.ts
@@ -12,7 +12,6 @@ function handleGap([, d = '', s]: string[], { theme }: RuleContext<Theme>) {
   const v = theme.spacing?.[s] ?? h.bracket.cssvar.global.rem(s)
   if (v != null) {
     return {
-      [`grid-${directions[d]}gap`]: v,
       [`${directions[d]}gap`]: v,
     }
   }

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -614,16 +614,16 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .grid-areas-\[prepend_content_append\]{grid-template-areas:"prepend content append";}
 .grid-areas-\[prepend_content_append\]-\[prepend_content_append\]{grid-template-areas:"prepend content append" "prepend content append";}
 .grid-areas-\$variable{grid-template-areas:var(--variable);}
-.gap-\$variable{grid-gap:var(--variable);gap:var(--variable);}
-.gap-4{grid-gap:1rem;gap:1rem;}
-.gap-inherit{grid-gap:inherit;gap:inherit;}
-.gap-none{grid-gap:0;gap:0;}
-.gap2{grid-gap:0.5rem;gap:0.5rem;}
-.-gap-y-5{grid-row-gap:-1.25rem;row-gap:-1.25rem;}
+.gap-\$variable{gap:var(--variable);}
+.gap-4{gap:1rem;}
+.gap-inherit{gap:inherit;}
+.gap-none{gap:0;}
+.gap2{gap:0.5rem;}
+.-gap-y-5{row-gap:-1.25rem;}
 .flex-gap-y-1,
-.grid-gap-y-1{grid-row-gap:0.25rem;row-gap:0.25rem;}
-.flex-gap-y-unset{grid-row-gap:unset;row-gap:unset;}
-.gap-x-1{grid-column-gap:0.25rem;column-gap:0.25rem;}
+.grid-gap-y-1{row-gap:0.25rem;}
+.flex-gap-y-unset{row-gap:unset;}
+.gap-x-1{column-gap:0.25rem;}
 .absolute{position:absolute;}
 .pos-fixed{position:fixed;}
 .position-sticky{position:sticky;}

--- a/test/preset-rem-to-px.test.ts
+++ b/test/preset-rem-to-px.test.ts
@@ -20,7 +20,7 @@ describe('rem-to-px', () => {
         .-p2{padding:-8px;}
         .m4{margin:16px;}
         .mx2{margin-left:8px;margin-right:8px;}
-        .gap2{grid-gap:8px;gap:8px;}"
+        .gap2{gap:8px;}"
       `)
   })
 
@@ -33,7 +33,7 @@ describe('rem-to-px', () => {
         .\\\\!-p2{padding:-8px !important;}
         .\\\\!m4{margin:16px !important;}
         .\\\\!mx2{margin-left:8px !important;margin-right:8px !important;}
-        .\\\\!gap2{grid-gap:8px !important;gap:8px !important;}"
+        .\\\\!gap2{gap:8px !important;}"
       `)
   })
 })


### PR DESCRIPTION
`grid-gap` was merged with `gap` (which works both with flexbox and grid) a few years back so this PR removes it from the generated CSS. 
`grid-column-gap` (now `column-gap`) and `grid-row-gap` (now `row-gap`) are also removed.
This should fix a few Vite errors that show up when you use flexbox but end up with `grid-gap` in the CSS instead of just `gap`.

As usual I have no idea what I'm doing so it's very possible I may have missed/broken something 😊 