### PR TITLE
feat(reset): sync tailwind resets, adding `font-feature-settings`

### DIFF
--- a/packages/reset/tailwind-compat.css
+++ b/packages/reset/tailwind-compat.css
@@ -158,6 +158,8 @@ optgroup,
 select,
 textarea {
   font-family: inherit; /* 1 */
+  font-feature-settings: inherit; /* 1 */
+  font-variation-settings: inherit; /* 1 */
   font-size: 100%; /* 1 */
   font-weight: inherit; /* 1 */
   line-height: inherit; /* 1 */

--- a/packages/reset/tailwind.css
+++ b/packages/reset/tailwind.css
@@ -154,6 +154,8 @@ optgroup,
 select,
 textarea {
   font-family: inherit; /* 1 */
+  font-feature-settings: inherit; /* 1 */
+  font-variation-settings: inherit; /* 1 */
   font-size: 100%; /* 1 */
   font-weight: inherit; /* 1 */
   line-height: inherit; /* 1 */


### PR DESCRIPTION
Include changes from the original Tailwind reset: https://github.com/tailwindlabs/tailwindcss/pull/10940

TLDR: Prevent font-feature-settings from being overridden by the user agent stylesheet for buttons, inputs, etc.