### PR TITLE
fix(core): move magic-string to dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,8 +40,10 @@
     "build": "unbuild",
     "stub": "unbuild --stub"
   },
+  "dependencies": {
+    "magic-string": "^0.30.1"
+  },
   "devDependencies": {
-    "magic-string": "^0.30.1",
     "unconfig": "^0.3.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,10 +548,11 @@ importers:
         version: 0.3.9
 
   packages/core:
-    devDependencies:
+    dependencies:
       magic-string:
         specifier: ^0.30.1
         version: 0.30.1
+    devDependencies:
       unconfig:
         specifier: ^0.3.9
         version: 0.3.9


### PR DESCRIPTION
`magic-string` is [imported](https://github.com/unocss/unocss/blob/ab78622a278d3d0432d95f927f1564019320d9b3/packages/core/src/utils/variantGroup.ts#L1) in `utils/variantGroup.ts` so should be listed as a dependency. 