### PR TITLE
fix(autocomplete): cartesian product mistake

### DIFF
--- a/packages/autocomplete/src/utils.ts
+++ b/packages/autocomplete/src/utils.ts
@@ -20,8 +20,6 @@ export function searchAttrKey(content: string, cursor: number) {
 }
 
 export function cartesian<T>(arr: T[][]): T[][] {
-  if (arr.length < 2)
-    return arr
   return arr.reduce(
     (a, b) => {
       const ret: T[][] = []

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -2,6 +2,7 @@ import { mergeDeep } from '@unocss/core'
 import { getComponent } from '@unocss/preset-mini/utils'
 import { expect, it } from 'vitest'
 import { addRemToPxComment, getColorString } from '@unocss/vscode/utils'
+import { cartesian } from '@unocss/autocomplete'
 
 it('mergeDeep', () => {
   expect(mergeDeep<any>({
@@ -113,4 +114,27 @@ it('addRemToPxComment', () => {
 
   expect(addRemToPxComment(text, 0)).eql(text)
   expect(addRemToPxComment(text, -1)).eql(text)
+})
+
+it('cartesian', () => {
+  const a = ['a', 'b', 'c']
+  const b = ['1', '2', '3']
+  // multiple
+  expect(cartesian([a, b])).eql([
+    ['a', '1'],
+    ['a', '2'],
+    ['a', '3'],
+    ['b', '1'],
+    ['b', '2'],
+    ['b', '3'],
+    ['c', '1'],
+    ['c', '2'],
+    ['c', '3'],
+  ])
+  // single
+  expect(cartesian([a])).eql([
+    ['a'],
+    ['b'],
+    ['c'],
+  ])
 })


### PR DESCRIPTION
When the Cartesian product function is passed in an array of length 1, the return value is mistake.
```ts
    const a = ['a', 'b', 'c']
    cartesian([a])
    // we need [['a'],['b'],['c']], not ['a','b','c']
```
This will cause problems with single-length group autocomplete part when fuzzy matching