### PR TITLE
Chore/test

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "size": "esno scripts/size.ts",
     "stub": "pnpm -r --filter=./packages/* --parallel run stub",
     "typecheck": "tsc --noEmit",
-    "test": "vitest && pnpm -F svelte-scoped test:integration",
+    "test": "pnpm -F svelte-scoped test:integration && vitest",
     "test:update": "vitest -u",
     "test:ci": "nr build && nr typecheck && nr lint && nr test"
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     alias,
   },
   test: {
+    testTimeout: 30 * 1000,
     name: 'unit',
     setupFiles: ['./test/setup.ts'],
     exclude: [...defaultExclude, '**/svelte-scoped/**'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     alias,
   },
   test: {
-    testTimeout: 30 * 1000,
+    testTimeout: 30_000,
     name: 'unit',
     setupFiles: ['./test/setup.ts'],
     exclude: [...defaultExclude, '**/svelte-scoped/**'],


### PR DESCRIPTION
This PR changes the vitest running order of the test script so that it can receive parameters. 
Now we can use `pnpm test [...filters]` or `pnpm t [...filters] `
And increase the test timeout, because `fixtures.test.ts` may timeout in ci on macOS