### PR TITLE
fix!: add vite as an optional peer dependency to core and astro

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -40,6 +40,14 @@
     "build": "unbuild",
     "stub": "unbuild --stub"
   },
+  "peerDependencies": {
+    "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@unocss/core": "workspace:*",
     "@unocss/reset": "workspace:*",

--- a/packages/unocss/package.json
+++ b/packages/unocss/package.json
@@ -107,10 +107,14 @@
     "stub": "unbuild --stub"
   },
   "peerDependencies": {
-    "@unocss/webpack": "workspace:*"
+    "@unocss/webpack": "workspace:*",
+    "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "@unocss/webpack": {
+      "optional": true
+    },
+    "vite": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,9 @@ importers:
       '@unocss/vite':
         specifier: workspace:*
         version: link:../vite
+      vite:
+        specifier: ^2.9.0 || ^3.0.0-0 || ^4.0.0
+        version: 4.4.9(@types/node@20.4.8)(terser@5.19.2)
     devDependencies:
       astro:
         specifier: ^2.10.1
@@ -986,6 +989,9 @@ importers:
       '@unocss/vite':
         specifier: workspace:*
         version: link:../vite
+      vite:
+        specifier: ^2.9.0 || ^3.0.0-0 || ^4.0.0
+        version: 4.4.9(@types/node@20.4.8)(terser@5.19.2)
     devDependencies:
       '@unocss/webpack':
         specifier: workspace:*


### PR DESCRIPTION
Closes #2431.

Currently on `unocss` installs with yarn those warnings are shown:
```
➤ YN0002: │ @unocss/astro@npm:0.54.0 doesn't provide vite (p2c1b4), requested by @unocss/vite
➤ YN0002: │ unocss@npm:0.54.0 [dc3fc] doesn't provide vite (pa8d36), requested by @unocss/vite
```
`@unocss/vite` peer depends on `vite`, but neither `unocss` nor `@unocss/astro` package provide that dependency in any form. Add it as an optional peer dependency to them.