### PR TITLE
docs: fix Qwik example

### DIFF
--- a/examples/qwik/src/root.tsx
+++ b/examples/qwik/src/root.tsx
@@ -1,12 +1,12 @@
 import { component$ } from '@builder.io/qwik'
-import { QwikCity, RouterOutlet } from '@builder.io/qwik-city'
+import { QwikCityProvider, RouterOutlet } from '@builder.io/qwik-city'
 import { RouterHead } from './components/router-head'
 import '@unocss/reset/tailwind.css'
 import 'uno.css'
 
 export default component$(() => {
   return (
-    <QwikCity>
+    <QwikCityProvider>
       <head>
         <meta charSet="utf-8" />
         <RouterHead />
@@ -14,6 +14,6 @@ export default component$(() => {
       <body lang="en">
         <RouterOutlet />
       </body>
-    </QwikCity>
+    </QwikCityProvider>
   )
 })

--- a/examples/qwik/src/routes/index.tsx
+++ b/examples/qwik/src/routes/index.tsx
@@ -5,13 +5,13 @@ export default component$(() => {
   const state = useStore({ count: 0 })
 
   return (
-    <div className="text-center">
-      <header className="bg-#282c34 min-h-100vh flex flex-col items-center justify-center color-white space-y-2em">
-        <div className="logo"/>
-        <h1 className="text-xl font-500 animate-bounce-alt animate-duration-2s">Hello Vite + Qwik!</h1>
+    <div class="text-center">
+      <header class="bg-#282c34 min-h-100vh flex flex-col items-center justify-center color-white space-y-2em">
+        <div class="logo"/>
+        <h1 class="text-xl font-500 animate-bounce-alt animate-duration-2s">Hello Vite + Qwik!</h1>
         <p>
           <button
-            className="bg-blue-400 hover:bg-blue-500 text-sm text-white font-mono font-light py-2 px-4 rounded border-2 border-blue-200"
+            class="bg-blue-400 hover:bg-blue-500 text-sm text-white font-mono font-light py-2 px-4 rounded border-2 border-blue-200"
             type="button"
             onClick$={() => state.count++}
           >
@@ -25,7 +25,7 @@ export default component$(() => {
             py-2 px-4
             ml-1em
             b-2 b-blue-200
-            className="rounded"
+            class="rounded"
             type="button"
             onClick$={() => state.count++}
           >
@@ -37,7 +37,7 @@ export default component$(() => {
         </p>
         <p>
           <a
-            className="color-#61dafb"
+            class="color-#61dafb"
             href="https://qwik.builder.io"
             target="_blank"
             rel="noopener noreferrer"
@@ -46,7 +46,7 @@ export default component$(() => {
           </a>
           {' | '}
           <a
-            className="color-#61dafb"
+            class="color-#61dafb"
             href="https://vitejs.dev/guide/features.html"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
The current example isn't compatible with Qwik-city, and className is deprecated

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/wmertens/unocss/tree/main/examples/qwik"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github.com/wmertens/unocss/tree/main/examples/qwik)._