### PR TITLE
chore(bench): instead deprecated `include` option

### DIFF
--- a/bench/fixtures/unocss/vite.config.mjs
+++ b/bench/fixtures/unocss/vite.config.mjs
@@ -5,7 +5,11 @@ export default defineConfig({
   plugins: [
     UnoCSS({
       mergeSelectors: false,
-      include: [/\.js$/],
+      content: {
+        pipeline: {
+          include: [/\.js$/],
+        },
+      },
     }),
   ],
 })


### PR DESCRIPTION
Use `content.pipeline.include` instead `include` option. The `include` option has been deprecated.

https://github.com/unocss/unocss/blob/93a081200ac88335ec65a20ccb20428230835658/packages/shared-integration/src/deprecation.ts#L11-L12