### PR TITLE
chore: fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "release": "bumpp -r",
     "size": "esno scripts/size.ts",
     "stub": "pnpm -r --filter=./packages/* --parallel run stub",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && pnpm -C packages/eslint-plugin run typecheck",
     "test": "vitest",
     "test:update": "vitest -u",
     "test:integration": "pnpm -F svelte-scoped test:integration",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -35,6 +35,7 @@
   },
   "scripts": {
     "build": "unbuild",
+    "typecheck": "tsc --noEmit",
     "lint": "nr build && cd ./fixtures && eslint ./src"
   },
   "dependencies": {

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -2,5 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "moduleResolution": "Bundler"
-  }
+  },
+  "exclude": [
+    "dist/**",
+    "node_modules/**",
+    "fixtures/**",
+  ]
 }

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -6,6 +6,6 @@
   "exclude": [
     "dist/**",
     "node_modules/**",
-    "fixtures/**",
+    "fixtures/**"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,6 +63,7 @@
     "**/examples/**",
     "**/fixtures/**",
     "**/interactive/**",
-    "**/test/dts/**"
+    "**/test/dts/**",
+    "packages/eslint-plugin/**"
   ]
 }


### PR DESCRIPTION
For some reason it seems tsc is using node10 resolution, this PR just excludes eslint-plugin from root typecheck script and includes a new typecheck script in eslint-plugin (that will run from root).