### PR TITLE
fix(astro): fix astro hmr warning

### DIFF
--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -93,7 +93,7 @@ function AstroVitePlugin(options: AstroVitePluginOptions): Plugin {
          */
         && !id.startsWith(nodeModulesPath)
       )
-        return ''
+        return null
     },
   }
 }


### PR DESCRIPTION
`return ''` will not generate __vite_css, and then caused hmr warnning.([unocss-hmr] failed to get unocss hash, hmr might not work)

This will fix #2812