### PR TITLE
fix(vscode): reload command

### DIFF
--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -16,12 +16,11 @@ async function registerRoot(ext: ExtensionContext, status: StatusBarItem, cwd: s
 
   const hasConfig = await contextLoader.loadContextInDirectory(cwd)
   // TODO: improve this to re-enable after configuration created
-  if (!hasConfig)
-    throw new Error(`➖ No config found in ${cwd}`)
-
-  registerAutoComplete(cwd, contextLoader, ext)
-  registerAnnotations(cwd, contextLoader, status, ext)
-  registerSelectionStyle(cwd, contextLoader)
+  if (hasConfig) {
+    registerAutoComplete(cwd, contextLoader, ext)
+    registerAnnotations(cwd, contextLoader, status, ext)
+    registerSelectionStyle(cwd, contextLoader)
+  }
 
   return contextLoader
 }
@@ -79,10 +78,9 @@ export async function activate(ext: ExtensionContext) {
     : projectPath
 
   try {
-    const contextLoader = await registerRoot(ext, status, cwd)
-
     ext.subscriptions.push(
       commands.registerCommand('unocss.reload', async () => {
+        const contextLoader = await registerRoot(ext, status, cwd)
         log.appendLine('🔁 Reloading...')
         await contextLoader.reload()
         log.appendLine('✅ Reloaded.')


### PR DESCRIPTION
I want to be able to load the unocss extension without restarting the whole vscode when installing unocss in a project.

Currently, the `unocss.reload` command is not registered when unocss is not installed in the workspace. 

This is caused by throwing the `➖ No config found in ${cwd}` exception. I rewrote this part of the code to not let the exception be thrown and not affect the original logic.

Additionally, I put registerRoot in the callback of the reload command so that it can check if unocss is installed.