### PR TITLE
fix(vscode): registerRoot calling

### DIFF
--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -78,9 +78,10 @@ export async function activate(ext: ExtensionContext) {
     : projectPath
 
   try {
+    const contextLoader = await registerRoot(ext, status, cwd)
+
     ext.subscriptions.push(
       commands.registerCommand('unocss.reload', async () => {
-        const contextLoader = await registerRoot(ext, status, cwd)
         log.appendLine('🔁 Reloading...')
         await contextLoader.reload()
         log.appendLine('✅ Reloaded.')


### PR DESCRIPTION
In #2979, `registerRoot` was placed in the callback of the reload command, which required us to run the reload command in v0.55.1 in order to load the context. This may lead some users to think that the unocss vscode extension is not working.
This PR rolled back the behavior before v0.55.1.