### PR TITLE
fix: include typings for min-h min-w in preset-attributify

### DIFF
--- a/packages/preset-attributify/src/jsx.ts
+++ b/packages/preset-attributify/src/jsx.ts
@@ -113,6 +113,8 @@ export type SeparateEnabled =
   | 'justify'
   | 'list'
   | 'm'
+  | 'min-h'
+  | 'min-w'
   | 'opacity'
   | 'order'
   | 'outline'


### PR DESCRIPTION
Using types for attributes as explained here: https://unocss.dev/presets/attributify#attributify-with-prefix, threw errors when using `min-h` and `min-w`. Those attributes are not included in the list. This PR adds those.