### PR TITLE
Allow runtime mutation observer optimization

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -251,13 +251,14 @@ export default function init(inlineConfig: RuntimeOptions = {}) {
   function observe() {
     if (observing)
       return
-    const target = html() || defaultDocument.body
-    if (!target)
+    const target = () => runtimeOptions.observer?.target ? runtimeOptions.observer.target() : (html() || defaultDocument.body);
+    if (!target())
       return
-    mutationObserver.observe(target, {
+    mutationObserver.observe(target(), {
       childList: true,
       subtree: true,
       attributes: true,
+      ...(runtimeOptions.observer?.attributeFilter ? { attributeFilter: runtimeOptions.observer.attributeFilter } : {}),
     })
     observing = true
   }


### PR DESCRIPTION
This is probably a more advanced usage config, but as it doesn't affect default behaviour I think it's a good addition with minimal bundle size impact.

The runtime's MutationObserver is basically watching the entire DOM for all mutations on all nodes and attributes, that's probably fine for most, but I would prefer if I could fine tune Uno CSS runtime so it does the least amount of work necessary, therefore I propose an addition the the runtime options, which allow granular control over:

a) what area of the DOM is monitored by returning a node to watch (including its child nodes) with `target`
b) which attributes to watch for mutations by providing an `attributeFilter` array

both config options are of course optional, default behaviour stays exactly as it is now and are summarized under `observer`

So now we could do this:

```
		...,
		runtime: {
			observer: {
				target: () => document.querySelector('.your-area-of-the-site-to-watch-for-mutations'),
				attributeFilter: ['class'], // only watch for changes in class attribute not all attributes
			},
		},
		...
```