### PR TITLE
fix(svelte-scoped): vite dev crash when configured with SSL

### DIFF
--- a/packages/svelte-scoped/src/_vite/global.ts
+++ b/packages/svelte-scoped/src/_vite/global.ts
@@ -39,7 +39,7 @@ export function checkTransformPageChunkHook(server: ViteDevServer, isSvelteKit: 
 
     res.write = function (chunk, ...rest) {
       // eslint-disable-next-line n/prefer-global/buffer
-      const str = (chunk instanceof Buffer) ? chunk.toString() : ((Array.isArray(chunk) || 'at' in chunk) ? Buffer.from(chunk).toString() : (`${chunk}`))
+      const str = typeof chunk === 'string' ? chunk : (chunk instanceof Buffer) ? chunk.toString() : ((Array.isArray(chunk) || 'at' in chunk) ? Buffer.from(chunk).toString() : (`${chunk}`))
 
       if (str.includes('<head>') && !str.includes(DEV_GLOBAL_STYLES_DATA_TITLE))
         server.config.logger.error(isSvelteKit ? SVELTE_KIT_ERROR : SVELTE_ERROR, { timestamp: true })


### PR DESCRIPTION
Hello! First PR to this repo 😁. Thanks already for all this great tool!

### 📖 What's in there?

fix #2965

Sveltekit application can't be run if their Vite config contains an SSL plugin (`vite-plugin-mkcert` or `@vitejs/plugin-basic-ssl`)
The `vite dev` command fails shortly with the error:
```
Internal server error: Cannot use 'in' operator to search for 'at' in import * as client_hooks from "/src/hooks.client.ts";
```

### 🧪 How to test?

Manual test:
1. build the new code: `nr build`
2. `cd example/sveltekit-scoped`
3. manually add to `package.json`, as a dev dependency: `"@vitejs/plugin-basic-ssl": "^1.0.1",`
4. manually add to `vite.config.ts`: `import basicSsl from '@vitejs/plugin-basic-ssl'`  and as the first vite plugin: `basicSsl(),`
5. `pnpm i`
6. `pnpm dev`
7. then browse to https://localhost:5173/ (note the https protocol with selfsigned certificate: you'll have to tell your browser that you really want to see the page 😅 )
    > the app loads properly. Without this fix, vite will crash with the error.

However, I couldn't find any existing automates test to inspire from.

If you want, I can try writing a test to spawn a mocked ViteDevServer and fetch index.html to check that we're sending right content.