### PR TITLE
chore: fix git-hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     }
   },
   "simple-git-hooks": {
-    "pre-commit": "esno scripts/prepare.ts && npx lint-staged"
+    "pre-commit": "npx esno scripts/prepare.ts && npx lint-staged"
   },
   "lint-staged": {
     "*.{js,ts,tsx,vue,md}": [


### PR DESCRIPTION
In pre-commit script, esno from npm cannot be called, use npx call instead
![image](https://github.com/unocss/unocss/assets/16945858/5355d909-bdeb-4333-9403-f227dd284265)
