### PR TITLE
pref(playground): detect transformers to show error

### DIFF
--- a/playground/__play.html
+++ b/playground/__play.html
@@ -32,7 +32,7 @@ if (window.parent.document.body.parentElement.className.includes('dark'))
   root.classList.toggle('dark', true)
 
 window.addEventListener('message', ({ data }) => {
-  const payload = JSON.parse(data)
+  const payload = typeof data === 'string' ? JSON.parse(data) : data
   if (payload.source !== 'unocss-playground')
     return
 

--- a/playground/src/auto-imports.d.ts
+++ b/playground/src/auto-imports.d.ts
@@ -30,8 +30,8 @@ declare global {
   const createUnrefFn: typeof import('@vueuse/core')['createUnrefFn']
   const cssFormatted: typeof import('./composables/prettier')['cssFormatted']
   const customCSS: typeof import('./composables/url')['customCSS']
-  const customCSSError: typeof import('./composables/uno')['customCSSError']
   const customCSSLayerName: typeof import('./composables/constants')['customCSSLayerName']
+  const customCSSWarn: typeof import('./composables/uno')['customCSSWarn']
   const customConfigError: typeof import('./composables/uno')['customConfigError']
   const customConfigRaw: typeof import('./composables/url')['customConfigRaw']
   const customRef: typeof import('vue')['customRef']
@@ -367,8 +367,8 @@ declare module 'vue' {
     readonly createUnrefFn: UnwrapRef<typeof import('@vueuse/core')['createUnrefFn']>
     readonly cssFormatted: UnwrapRef<typeof import('./composables/prettier')['cssFormatted']>
     readonly customCSS: UnwrapRef<typeof import('./composables/url')['customCSS']>
-    readonly customCSSError: UnwrapRef<typeof import('./composables/uno')['customCSSError']>
     readonly customCSSLayerName: UnwrapRef<typeof import('./composables/constants')['customCSSLayerName']>
+    readonly customCSSWarn: UnwrapRef<typeof import('./composables/uno')['customCSSWarn']>
     readonly customConfigError: UnwrapRef<typeof import('./composables/uno')['customConfigError']>
     readonly customConfigRaw: UnwrapRef<typeof import('./composables/url')['customConfigRaw']>
     readonly customRef: UnwrapRef<typeof import('vue')['customRef']>
@@ -698,8 +698,8 @@ declare module '@vue/runtime-core' {
     readonly createUnrefFn: UnwrapRef<typeof import('@vueuse/core')['createUnrefFn']>
     readonly cssFormatted: UnwrapRef<typeof import('./composables/prettier')['cssFormatted']>
     readonly customCSS: UnwrapRef<typeof import('./composables/url')['customCSS']>
-    readonly customCSSError: UnwrapRef<typeof import('./composables/uno')['customCSSError']>
     readonly customCSSLayerName: UnwrapRef<typeof import('./composables/constants')['customCSSLayerName']>
+    readonly customCSSWarn: UnwrapRef<typeof import('./composables/uno')['customCSSWarn']>
     readonly customConfigError: UnwrapRef<typeof import('./composables/uno')['customConfigError']>
     readonly customConfigRaw: UnwrapRef<typeof import('./composables/url')['customConfigRaw']>
     readonly customRef: UnwrapRef<typeof import('vue')['customRef']>

--- a/playground/src/auto-imports.d.ts
+++ b/playground/src/auto-imports.d.ts
@@ -30,6 +30,7 @@ declare global {
   const createUnrefFn: typeof import('@vueuse/core')['createUnrefFn']
   const cssFormatted: typeof import('./composables/prettier')['cssFormatted']
   const customCSS: typeof import('./composables/url')['customCSS']
+  const customCSSError: typeof import('./composables/uno')['customCSSError']
   const customCSSLayerName: typeof import('./composables/constants')['customCSSLayerName']
   const customConfigError: typeof import('./composables/uno')['customConfigError']
   const customConfigRaw: typeof import('./composables/url')['customConfigRaw']
@@ -366,6 +367,7 @@ declare module 'vue' {
     readonly createUnrefFn: UnwrapRef<typeof import('@vueuse/core')['createUnrefFn']>
     readonly cssFormatted: UnwrapRef<typeof import('./composables/prettier')['cssFormatted']>
     readonly customCSS: UnwrapRef<typeof import('./composables/url')['customCSS']>
+    readonly customCSSError: UnwrapRef<typeof import('./composables/uno')['customCSSError']>
     readonly customCSSLayerName: UnwrapRef<typeof import('./composables/constants')['customCSSLayerName']>
     readonly customConfigError: UnwrapRef<typeof import('./composables/uno')['customConfigError']>
     readonly customConfigRaw: UnwrapRef<typeof import('./composables/url')['customConfigRaw']>
@@ -696,6 +698,7 @@ declare module '@vue/runtime-core' {
     readonly createUnrefFn: UnwrapRef<typeof import('@vueuse/core')['createUnrefFn']>
     readonly cssFormatted: UnwrapRef<typeof import('./composables/prettier')['cssFormatted']>
     readonly customCSS: UnwrapRef<typeof import('./composables/url')['customCSS']>
+    readonly customCSSError: UnwrapRef<typeof import('./composables/uno')['customCSSError']>
     readonly customCSSLayerName: UnwrapRef<typeof import('./composables/constants')['customCSSLayerName']>
     readonly customConfigError: UnwrapRef<typeof import('./composables/uno')['customConfigError']>
     readonly customConfigRaw: UnwrapRef<typeof import('./composables/url')['customConfigRaw']>

--- a/playground/src/components/panel/PanelConfig.vue
+++ b/playground/src/components/panel/PanelConfig.vue
@@ -43,7 +43,7 @@ if (!customConfigRaw.value)
       class="scrolls"
     />
     <div
-      v-if="customConfigError"
+      v-if="!isCollapsed(index) && customConfigError"
       absolute
       left-0
       right-0

--- a/playground/src/components/panel/PanelCustomCss.vue
+++ b/playground/src/components/panel/PanelCustomCss.vue
@@ -11,10 +11,20 @@ const computedCustomCSS = computed({
     customCSS.value = value
   },
 })
+
+const errorBody = computed(() => {
+  if (customCSSError.value) {
+    const msg = customCSSError.value.message
+    const match = msg.match(/^(.+)'(.+)'(.+)$/)
+    if (match)
+      return `${match[1]}'<a inline-block b="b dashed red4" href="https://unocss.dev/transformers/directives" target='_blank'>${match[2]}</a>'${match[3]}`
+  }
+  return ''
+})
 </script>
 
 <template>
-  <Pane :min-size="titleHeightPercent" :size="panelSizes[index]" flex flex-col>
+  <Pane :min-size="titleHeightPercent" :size="panelSizes[index]" flex flex-col relative>
     <div class="flex flex-wrap bg-$cm-background">
       <TitleBar
         title="Custom CSS" w-full relative
@@ -53,6 +63,17 @@ const computedCustomCSS = computed({
       border="l
       gray-400/20"
       class="scrolls"
+    />
+    <div
+      v-if="options.transformCustomCSS && customCSSError"
+      absolute
+      left-0
+      right-0
+      bottom-0
+      p="x-2 y-1"
+      bg="red-400/20"
+      text="red-400 sm"
+      v-html="errorBody"
     />
   </Pane>
 </template>

--- a/playground/src/components/panel/PanelCustomCss.vue
+++ b/playground/src/components/panel/PanelCustomCss.vue
@@ -17,7 +17,7 @@ const errorBody = computed(() => {
     const msg = customCSSError.value.message
     const match = msg.match(/^(.+)'(.+)'(.+)$/)
     if (match)
-      return `${match[1]}'<a inline-block b="b dashed red4" href="https://unocss.dev/transformers/directives" target='_blank'>${match[2]}</a>'${match[3]}`
+      return `Warning: ${match[1]}<a inline-block b="b dashed yellow4" href="https://unocss.dev/transformers/directives" target='_blank'>${match[2]}</a>${match[3]}`
   }
   return ''
 })
@@ -65,14 +65,14 @@ const errorBody = computed(() => {
       class="scrolls"
     />
     <div
-      v-if="options.transformCustomCSS && customCSSError"
+      v-if="!isCollapsed(index) && options.transformCustomCSS && customCSSError"
       absolute
       left-0
       right-0
       bottom-0
       p="x-2 y-1"
-      bg="red-400/20"
-      text="red-400 sm"
+      bg="yellow-400/20"
+      text="yellow-400 sm"
       v-html="errorBody"
     />
   </Pane>

--- a/playground/src/components/panel/PanelCustomCss.vue
+++ b/playground/src/components/panel/PanelCustomCss.vue
@@ -12,9 +12,9 @@ const computedCustomCSS = computed({
   },
 })
 
-const errorBody = computed(() => {
-  if (customCSSError.value) {
-    const msg = customCSSError.value.message
+const WarnContent = computed(() => {
+  if (customCSSWarn.value) {
+    const msg = customCSSWarn.value.message
     const match = msg.match(/^(.+)'(.+)'(.+)$/)
     if (match)
       return `Warning: ${match[1]}<a inline-block b="b dashed yellow4" href="https://unocss.dev/transformers/directives" target='_blank'>${match[2]}</a>${match[3]}`
@@ -65,7 +65,7 @@ const errorBody = computed(() => {
       class="scrolls"
     />
     <div
-      v-if="!isCollapsed(index) && options.transformCustomCSS && customCSSError"
+      v-if="!isCollapsed(index) && options.transformCustomCSS && customCSSWarn && WarnContent"
       absolute
       left-0
       right-0
@@ -73,7 +73,7 @@ const errorBody = computed(() => {
       p="x-2 y-1"
       bg="yellow-400/20"
       text="yellow-400 sm"
-      v-html="errorBody"
+      v-html="WarnContent"
     />
   </Pane>
 </template>

--- a/playground/src/composables/panel.ts
+++ b/playground/src/composables/panel.ts
@@ -24,7 +24,7 @@ export function getInitialPanelSizes(percent: number): number[] {
 }
 
 export function isCollapsed(index: number) {
-  return panelSizes.value[index] <= titleHeightPercent.value + 0.1
+  return panelSizes.value[index] <= titleHeightPercent.value + 3
 }
 
 export function togglePanel(index: number) {

--- a/playground/src/composables/uno.ts
+++ b/playground/src/composables/uno.ts
@@ -8,6 +8,7 @@ import type { CompletionContext, CompletionResult } from '@codemirror/autocomple
 
 export const init = ref(false)
 export const customConfigError = ref<Error>()
+export const customCSSError = ref<Error>()
 
 export const uno = createGenerator({}, defaultConfig.value)
 export const output = shallowRef<GenerateResult>()
@@ -56,28 +57,25 @@ debouncedWatch(
   [customConfigRaw, customCSS],
   async () => {
     customConfigError.value = undefined
+    customCSSError.value = undefined
     try {
       const result = await evaluateUserConfig(customConfigRaw.value)
       if (result) {
         const preflights = (result.preflights ?? []).filter(p => p.layer !== customCSSLayerName)
         preflights.push({
           layer: customCSSLayerName,
-          getCSS: () => transformedCSS.value,
+          getCSS: () => cleanOutput(transformedCSS.value),
         })
 
         result.preflights = preflights
         customConfig = result
         reGenerate()
+        await detectTransformer()
+
         if (initial) {
           const { transformers = [] } = uno.config
-          if (transformers.length) {
+          if (transformers.length)
             transformed.value = await getTransformed('html')
-            const _p = uno.config.preflights.find(i => i.layer === customCSSLayerName)
-            _p!.getCSS = async () => {
-              transformedCSS.value = (await getTransformed('css')).output
-              return transformedCSS.value
-            }
-          }
           initial = false
         }
       }
@@ -95,8 +93,6 @@ watch(
   generate,
   { immediate: true },
 )
-
-watch(defaultConfig, reGenerate)
 
 function useTransformer() {
   const transformed = computedAsync(async () => await getTransformed('html'))
@@ -124,22 +120,35 @@ function useTransformer() {
   }
 
   async function getTransformed(type: 'html' | 'css') {
-    const id = type === 'html' ? 'input.html' : 'input.css'
-    const input = new MagicString(type === 'html' ? inputHTML.value : customCSS.value)
+    const isHTML = type === 'html'
+    const id = isHTML ? 'input.html' : 'input.css'
+    const input = new MagicString(isHTML ? inputHTML.value : customCSS.value)
     const annotations = []
     annotations.push(...await applyTransformers(input, id, 'pre'))
     annotations.push(...await applyTransformers(input, id))
     annotations.push(...await applyTransformers(input, id, 'post'))
-    return { output: type === 'css' ? cleanOutput(input.toString()) : input.toString(), annotations }
-  }
-
-  function cleanOutput(code: string) {
-    return code.replace(/\/\*\s*?[\s\S]*?\s*?\*\//g, '')
-      .replace(/\n\s+/g, '\n')
-      .trim()
+    return { output: isHTML ? input.toString() : cleanOutput(input.toString()), annotations }
   }
 
   return { transformedHTML, transformed, getTransformed, transformedCSS }
 }
 
+async function detectTransformer() {
+  const { transformers = [] } = uno.config
+  if (!transformers.some(t => t.name === '@unocss/transformer-directives')) {
+    const msg = 'You need to install \'@unocss/transformer-directives\' to use this feature.'
+    customCSSError.value = new Error(msg)
+    transformedCSS.value = customCSS.value
+  }
+  else {
+    transformedCSS.value = (await getTransformed('css')).output
+  }
+}
+
 export { transformedHTML, transformedCSS }
+
+function cleanOutput(code: string) {
+  return code.replace(/\/\*\s*?[\s\S]*?\s*?\*\//g, '')
+    .replace(/\n\s+/g, '\n')
+    .trim()
+}

--- a/playground/src/composables/uno.ts
+++ b/playground/src/composables/uno.ts
@@ -136,7 +136,7 @@ function useTransformer() {
 async function detectTransformer() {
   const { transformers = [] } = uno.config
   if (!transformers.some(t => t.name === '@unocss/transformer-directives')) {
-    const msg = 'You need to install \'@unocss/transformer-directives\' to use this feature.'
+    const msg = 'Using directives requires \'@unocss/transformer-directives\' to be installed.'
     customCSSError.value = new Error(msg)
     transformedCSS.value = customCSS.value
   }

--- a/playground/src/composables/uno.ts
+++ b/playground/src/composables/uno.ts
@@ -8,7 +8,7 @@ import type { CompletionContext, CompletionResult } from '@codemirror/autocomple
 
 export const init = ref(false)
 export const customConfigError = ref<Error>()
-export const customCSSError = ref<Error>()
+export const customCSSWarn = ref<Error>()
 
 export const uno = createGenerator({}, defaultConfig.value)
 export const output = shallowRef<GenerateResult>()
@@ -57,7 +57,7 @@ debouncedWatch(
   [customConfigRaw, customCSS],
   async () => {
     customConfigError.value = undefined
-    customCSSError.value = undefined
+    customCSSWarn.value = undefined
     try {
       const result = await evaluateUserConfig(customConfigRaw.value)
       if (result) {
@@ -137,7 +137,7 @@ async function detectTransformer() {
   const { transformers = [] } = uno.config
   if (!transformers.some(t => t.name === '@unocss/transformer-directives')) {
     const msg = 'Using directives requires \'@unocss/transformer-directives\' to be installed.'
-    customCSSError.value = new Error(msg)
+    customCSSWarn.value = new Error(msg)
     transformedCSS.value = customCSS.value
   }
   else {


### PR DESCRIPTION
Related #3065, #3061

Optimized to check whether `transformerDirectives` exists in advance, and give a friendly reminder for it.

<img width="852" alt="image" src="https://github.com/unocss/unocss/assets/42139754/43eee6a5-7df8-4eb6-b771-2bd527e9c4ca">

See [Playground](https://deploy-preview-3066--unocss.netlify.app/play/?html=DwEwlgbgBAFgtAMwK4BsVQC4FMAeG4DGWAdtgE5QIq5QDOW1B%2BxA9sVlAIZoBcGZnYrTAYwbOABYADFIB8AKChRQkKAFtOCpUpXRseOAFYc6BAHcAjDK7EwG7HABGLJMSJxuGG3c4OCL0jgwYgRgkQ5BHwcQJAFRcQtaLW0lAFVWAGEAZSzFbWAAenAIZJ1iqBYABwBmKUxcfBQAc0ozWrq1C1LtABUYDmDaDEEvcRAsDWIQKABBDBY1MAIobKyoEibgrAA6PJ0iyG7ddQAmSmocKAArJCGwBABPQhJyeoMTkwqaupgWCCwyABeABEVQAHFJgd0dJw9ikoGBCJwyM5iHAUCwmiw4JsMDAkI44Sl9Phgv0yCIidoYGQsAgQTAMBhKrQeAUCrj8Y5tv41AVXCwCLRaPzWELaMCqUphmQmlgMCCAPqOFCCADWkvhUFkhU0cMKxWSBsO8mNJVN5U4jloLBQSGwUGcTIWRigFKajLgdWoCHwdRJz1IAK%2BtVa7WSYwmgmmAHaEUJhqQoHHkGgHlACLd5osAF5W6img4lIA&config=JYWwDg9gTgLgBAbwFBzgEwKYDNgDsMDCEuOA5gDQpxhQYDOGMAgjDFMAEYCuMwWAnpVQ16jAJIBjYnSHVaDGAFVcESgF84WKBBBwA5FxUS6dPUiQYAHpFjpsAQy4AbeJhz4iJYKQAUyVFDO9ABccADaVKhhehJcdDA6ALSBThh65IhwUk7QoXq0aHpwagC6VCWydAAW0DCxMHSh-qj6sfFJ1bX1enkwVjCJTqRwfZYD0Pa4pBhwNQBuGFDBowN99k5mqGqyIgqN4ZFyokoqPgCUssLyjCxsnDx8-OeXRwqS0n6HqHQS6xihAEYAHQAJheqAkaFweSqrDAjQA9Aj6CAgdUEZsWmoLuUkNikEA&css=PQKgBA6gTglgLgUzAYwK4Gc4HsC2YDCAyoWABYJQIA0YAhgHYAmYcUD6AZllDhWOqgAOg7nAB0YAGLcwCAB60cggDYIAXGBDAAUGLSZcYAN7awYLvTgBaAO4IYAc1JwNAVgAM7gNymwAAVphZQBPMEEARhZ5awAKG1J4JDllAEofMwAjWmQAawcoLFQmK2QsZW4NOHJeGIByUvKodDFKRjEAFk9atO0AXyA&options=N4IgLgTghgdgzgMwPYQLYGECucxIwZXxAC5JMBTAXyA)
