### PR TITLE
chore(unocss): add vite as devdep

### DIFF
--- a/packages/unocss/package.json
+++ b/packages/unocss/package.json
@@ -141,6 +141,7 @@
     "@unocss/vite": "workspace:*"
   },
   "devDependencies": {
-    "@unocss/webpack": "workspace:*"
+    "@unocss/webpack": "workspace:*",
+    "vite": "^4.4.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1001,13 +1001,13 @@ importers:
       '@unocss/vite':
         specifier: workspace:*
         version: link:../vite
-      vite:
-        specifier: ^2.9.0 || ^3.0.0-0 || ^4.0.0
-        version: 4.4.9(@types/node@20.5.6)(terser@5.19.2)
     devDependencies:
       '@unocss/webpack':
         specifier: workspace:*
         version: link:../webpack
+      vite:
+        specifier: ^4.4.9
+        version: 4.4.9(@types/node@20.5.6)(terser@5.19.2)
 
   packages/vite:
     dependencies:
@@ -1189,9 +1189,6 @@ packages:
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
-    peerDependenciesMeta:
-      '@algolia/client-search':
-        optional: true
     dependencies:
       '@algolia/client-search': 4.19.1
       algoliasearch: 4.19.1


### PR DESCRIPTION
add vite as devdep in the `unocss` package, otherwise the imported `Plugin` type on line 4:

https://github.com/unocss/unocss/blob/6d760ad804f191a256269a35910bcfb90114e7fe/packages/unocss/src/vite.ts#L4-L19

References the hoisted `vite` package (`shamefully-hoist=true`). The `Plugin` here is different from the `Plugin` from the `return VitePlugin` call. This difference caused a fail in [vite-ecosystem-ci](https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6069325893/job/16463574781#step:8:1157).