### PR TITLE
fix(vscode): remToPx support important

### DIFF
--- a/packages/vscode/src/utils.ts
+++ b/packages/vscode/src/utils.ts
@@ -51,8 +51,7 @@ export function addRemToPxComment(str?: string, remToPixel = 16) {
     index = end
   }
   output.push(str.slice(index))
-  const rs = output.join('')
-  return rs
+  return output.join('')
 }
 
 export async function getPrettiedCSS(uno: UnoGenerator, util: string, remToPxRatio: number) {

--- a/packages/vscode/src/utils.ts
+++ b/packages/vscode/src/utils.ts
@@ -40,17 +40,19 @@ export function addRemToPxComment(str?: string, remToPixel = 16) {
   const output: string[] = []
 
   while (index < str.length) {
-    const rem = str.slice(index).match(/-?[\d.]+rem;/)
+    const rem = str.slice(index).match(/(-?[\d.]+)rem(\s+\!important)?;/)
     if (!rem || !rem.index)
       break
-    const px = ` /* ${Number.parseFloat(rem[0].slice(0, -4)) * remToPixel}px */`
+    const px = ` /* ${Number.parseFloat(rem[1]) * remToPixel}px */`
     const end = index + rem.index + rem[0].length
+
     output.push(str.slice(index, end))
     output.push(px)
     index = end
   }
   output.push(str.slice(index))
-  return output.join('')
+  const rs = output.join('')
+  return rs
 }
 
 export async function getPrettiedCSS(uno: UnoGenerator, util: string, remToPxRatio: number) {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -114,6 +114,20 @@ it('addRemToPxComment', () => {
 
   expect(addRemToPxComment(text, 0)).eql(text)
   expect(addRemToPxComment(text, -1)).eql(text)
+
+  const importantText = `
+  /* layer: default */
+  .\!m-9 {
+    margin: 2.25rem !important;
+  }`
+
+  const importantComment = addRemToPxComment(importantText, 16)
+
+  expect(importantComment).eql(`
+  /* layer: default */
+  .\!m-9 {
+    margin: 2.25rem !important; /* 36px */
+  }`)
 })
 
 it('cartesian', () => {


### PR DESCRIPTION
This PR will fix the problem that the `px to rem preview` of the vscode extension does not support important

<img width="349" alt="image" src="https://github.com/unocss/unocss/assets/16945858/d13b8fcf-25f2-4f33-81ed-816baab887d6">
