### PR TITLE
perf(attributify-jsx): improve regular performance

### DIFF
--- a/packages/transformer-attributify-jsx/src/index.ts
+++ b/packages/transformer-attributify-jsx/src/index.ts
@@ -37,7 +37,7 @@ export interface TransformerAttributifyJsxOptions {
   exclude?: FilterPattern
 }
 
-const elementRE = /(<\w[\w:\.$-]*\s)((?:'[^>]*?'|"[^>]*?"|[\{`]([^>]|[\S])*?[\}`]|[^>]*?)*)/g
+const elementRE = /(<\w[\w:\.$-]*\s)([\s\S]*)\/?>/g
 const attributeRE = /([a-zA-Z()#][\[?a-zA-Z0-9-_:()#%\]?]*)(?:\s*=\s*((?:'[^']*')|(?:"[^"]*")|\S+))?/g
 const valuedAttributeRE = /((?!\d|-{2}|-\d)[a-zA-Z0-9\u00A0-\uFFFF-_:!%-.~<]+)=(?:["]([^"]*)["]|[']([^']*)[']|[{]((?:[`(](?:[^`)]*)[`)]|[^}])+)[}])/gms
 


### PR DESCRIPTION
## before 
```ts
const id = 1
const str = '<div flex={ >'+'.'.repeat(30)
const elementRE = /(<\w[\w:\.$-]*\s)((?:'[^>]*?'|"[^>]*?"|[\{`]([^>]|[\S])*?[\}`]|[^>]*?)*)/g
console.time()
for (const i of Array.from(str.matchAll(elementRE))){
      console.log(i)
}
console.timeEnd()      
``` 
> It will execute for a few seconds.

## after
```ts
const id = 1
const str = '<div flex={ >'+'.'.repeat(30)
const elementRE = /(<\w[\w:\.$-]*\s)([\s\S]*)\/?>/g
console.time()
for (const i of Array.from(str.matchAll(elementRE))){
      console.log(i)
}
console.timeEnd()      
``` 
``` 