### PR TITLE
chore: remove invalid link

### DIFF
--- a/docs/.vitepress/content.ts
+++ b/docs/.vitepress/content.ts
@@ -105,12 +105,6 @@ export const examples: Example[] = [
     codesandbox: true,
   },
   {
-    name: 'react',
-    path: 'examples/react',
-    icon: 'i-logos-react',
-    stackblitz: true,
-  },
-  {
     name: 'vite-lightningcss',
     path: 'examples/vite-lightningcss',
     icon: 'i-ph-lightning text-yellow',


### PR DESCRIPTION
![image](https://github.com/unocss/unocss/assets/82451257/be1be129-a499-4cb6-8935-a6e2351815ee)

react example is not present in this repository. but in https://unocss.dev/integrations/#examples it still exist.