### PR TITLE
chore(examples): adds missing dependency to sveltekit example

### DIFF
--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -16,6 +16,7 @@
     "@unocss/core": "link:../../packages/core",
     "@unocss/extractor-svelte": "link:../../packages/extractor-svelte",
     "@unocss/preset-icons": "link:../../packages/preset-icons",
+    "@unocss/preset-uno": "link:../../packages/preset-uno",
     "svelte": "^4.2.0",
     "svelte-check": "^3.5.0",
     "tslib": "^2.6.2",


### PR DESCRIPTION
- in examples/sveltekit `@unocss/preset-uno` is referenced in uno.config.ts but it is not declared as dependency