### PR TITLE
fix(core): export utils modules

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,8 @@ import type MagicString from 'magic-string'
 import type { UnoGenerator } from './generator'
 import type { BetterMap, CountableSet } from './utils'
 
+export * from './utils'
+
 export type Awaitable<T> = T | Promise<T>
 export type Arrayable<T> = T | T[]
 export type ToArray<T> = T extends (infer U)[] ? U[] : T[]


### PR DESCRIPTION
We're importing utilities from `@unocss/core`, but there are no exports from the `./utils` folder, for example, inside the autocomplete package:
```ts
// packages/autocomplete/src/create.ts
import { escapeRegExp, toArray, uniq } from '@unocss/core'
```
or inside inspector package:
```ts
// packages/inspector/src/index.ts
import { BetterMap, CountableSet } from '@unocss/core'
```

See https://github.com/unocss/unocss/issues/2977#issuecomment-1712538958