### PR TITLE
feat(eslint-plugin): Add calls support for order

### DIFF
--- a/packages/eslint-plugin/src/constants.ts
+++ b/packages/eslint-plugin/src/constants.ts
@@ -1,2 +1,3 @@
 export const CLASS_FIELDS = ['class', 'classname']
+export const CLASS_CALLEES = ['clsx']
 export const AST_NODES_WITH_QUOTES = ['Literal', 'VLiteral']

--- a/packages/eslint-plugin/src/rules/order.ts
+++ b/packages/eslint-plugin/src/rules/order.ts
@@ -1,8 +1,11 @@
 import { ESLintUtils } from '@typescript-eslint/utils'
 import type { RuleListener } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/types'
-import { AST_NODES_WITH_QUOTES, CLASS_FIELDS } from '../constants'
+import { AST_NODES_WITH_QUOTES, CLASS_CALLEES, CLASS_FIELDS } from '../constants'
 import { syncAction } from './_'
+
+const prefixWhitespace = /^\s/
+const suffixWhitespace = /\s$/
 
 export default ESLintUtils.RuleCreator(name => name)({
   name: 'order',
@@ -39,6 +42,53 @@ export default ESLintUtils.RuleCreator(name => name)({
       }
     }
 
+    function checkTemplateElement(node: TSESTree.TemplateElement) {
+      const input = node.value.cooked
+      const inputTrim = input.trim()
+      if (typeof input !== 'string' || !inputTrim)
+        return
+      const sorted = syncAction('sort', input).trim()
+      if (sorted !== inputTrim) {
+        context.report({
+          node,
+          messageId: 'invalid-order',
+          fix(fixer) {
+            const prefix = prefixWhitespace.test(input) ? 2 : 1
+            const suffix = node.tail ? 1 : suffixWhitespace.test(input) ? 3 : 2
+            return fixer.replaceTextRange([node.range[0] + prefix, node.range[1] - suffix], sorted)
+          },
+        })
+      }
+    }
+
+    function checkCalleeArgument(argument: TSESTree.CallExpressionArgument | null) {
+      switch (argument?.type) {
+        case 'Literal':
+          checkLiteral(argument)
+          break
+        case 'TemplateLiteral':
+          argument.quasis.forEach(checkTemplateElement)
+          argument.expressions.forEach(checkCalleeArgument)
+          break
+        case 'LogicalExpression':
+          checkCalleeArgument(argument.right)
+          break
+        case 'ConditionalExpression':
+          checkCalleeArgument(argument.consequent)
+          checkCalleeArgument(argument.alternate)
+          break
+        case 'ArrayExpression':
+          argument.elements.forEach(checkCalleeArgument)
+          break
+        case 'ObjectExpression':
+          argument.properties.forEach((property) => {
+            if (property.type === 'Property' && property.key.type === 'Literal')
+              checkCalleeArgument(property.key)
+          })
+          break
+      }
+    }
+
     const scriptVisitor: RuleListener = {
       JSXAttribute(node) {
         if (typeof node.name.name === 'string' && CLASS_FIELDS.includes(node.name.name.toLowerCase()) && node.value) {
@@ -51,6 +101,10 @@ export default ESLintUtils.RuleCreator(name => name)({
           if (node.value?.[0].type === 'SvelteLiteral')
             checkLiteral(node.value[0])
         }
+      },
+      CallExpression(node) {
+        if (node.callee.type === 'Identifier' && CLASS_CALLEES.includes(node.callee.name))
+          node.arguments.forEach(checkCalleeArgument)
       },
     }
 


### PR DESCRIPTION
Extend the eslint’s order rule to support call expressions, and apply it to [clsx](https://www.npmjs.com/package/clsx).