### PR TITLE
fix(eslint-plugin): Order of expression attribute

### DIFF
--- a/packages/eslint-plugin/src/rules/order.ts
+++ b/packages/eslint-plugin/src/rules/order.ts
@@ -44,6 +44,8 @@ export default ESLintUtils.RuleCreator(name => name)({
         if (typeof node.name.name === 'string' && CLASS_FIELDS.includes(node.name.name.toLowerCase()) && node.value) {
           if (node.value.type === 'Literal')
             checkLiteral(node.value)
+          else if (node.value.type === 'JSXExpressionContainer' && node.value.expression.type === 'Literal')
+            checkLiteral(node.value.expression)
         }
       },
       SvelteAttribute(node: any) {


### PR DESCRIPTION
fix #3027