### PR TITLE
fix(transformer-attributify-jsx): transform error when html element is like a atomic class

### DIFF
--- a/packages/transformer-attributify-jsx/src/index.ts
+++ b/packages/transformer-attributify-jsx/src/index.ts
@@ -38,7 +38,7 @@ export interface TransformerAttributifyJsxOptions {
 }
 
 const elementRE = /(<\w[\w:\.$-]*\s)([\s\S]*?)(?=>[\s\S]?<\/[\s\w:\.$-]*>|\/>)/g
-const attributeRE = /(?<!<)([a-zA-Z()#][\[?a-zA-Z0-9-_:()#%\]?]*)(?:\s*=\s*((?:'[^']*')|(?:"[^"]*")|\S+))?/g
+const attributeRE = /(?<!<\/?)([a-zA-Z()#][\[?a-zA-Z0-9-_:()#%\]?]*)(?:\s*=\s*((?:'[^']*')|(?:"[^"]*")|\S+))?/g
 const valuedAttributeRE = /((?!\d|-{2}|-\d)[a-zA-Z0-9\u00A0-\uFFFF-_:!%-.~<]+)=(?:["]([^"]*)["]|[']([^']*)[']|[{]((?:[`(](?:[^`)]*)[`)]|[^}])+)[}])/gms
 
 export default function transformerAttributifyJsx(options: TransformerAttributifyJsxOptions = {}): SourceCodeTransformer {

--- a/test/transformer-attributify-jsx.test.ts
+++ b/test/transformer-attributify-jsx.test.ts
@@ -43,6 +43,18 @@ const originalCode = `
 </div>
   `.trim()
 
+const tagCouldBeAttrCode = `
+<div>
+  <b text-red>Test</b>
+  <h1 text-red>Test</h1>
+  <h2 text-red>Test</h2>
+  <h3 text-red>Test</h3>
+  <h4 text-red>Test</h4>
+  <h5 text-red>Test</h5>
+  <h6 text-red>Test</h6>
+</div>
+`.trim()
+
 describe('transformerAttributifyJsx', () => {
   const uno = createGenerator({
     presets: [
@@ -146,6 +158,23 @@ describe('transformerAttributifyJsx', () => {
         expect(codeToString).not.toMatch(`${rule}=""`)
     })
   })
+
+  test('if class-like tag do not cause error', async () => {
+    const code = new MagicString(tagCouldBeAttrCode)
+    await transformerAttributifyJsx().transform(code, 'app.tsx', { uno, tokens: new Set() } as any)
+
+    expect(code.toString()).toMatchInlineSnapshot(`
+      "<div>
+        <b text-red=\\"\\">Test</b>
+        <h1 text-red=\\"\\">Test</h1>
+        <h2 text-red=\\"\\">Test</h2>
+        <h3 text-red=\\"\\">Test</h3>
+        <h4 text-red=\\"\\">Test</h4>
+        <h5 text-red=\\"\\">Test</h5>
+        <h6 text-red=\\"\\">Test</h6>
+      </div>"
+    `)
+  })
 })
 
 describe('transformerAttributifyJsxBabel', () => {
@@ -236,5 +265,22 @@ describe('transformerAttributifyJsxBabel', () => {
       else
         expect(codeToString).not.toMatch(`${rule}=""`)
     })
+  })
+
+  test('if class-like tag do not cause error', async () => {
+    const code = new MagicString(tagCouldBeAttrCode)
+    await transformerAttributifyJsx().transform(code, 'app.tsx', { uno, tokens: new Set() } as any)
+
+    expect(code.toString()).toMatchInlineSnapshot(`
+      "<div>
+        <b text-red=\\"\\">Test</b>
+        <h1 text-red=\\"\\">Test</h1>
+        <h2 text-red=\\"\\">Test</h2>
+        <h3 text-red=\\"\\">Test</h3>
+        <h4 text-red=\\"\\">Test</h4>
+        <h5 text-red=\\"\\">Test</h5>
+        <h6 text-red=\\"\\">Test</h6>
+      </div>"
+    `)
   })
 })


### PR DESCRIPTION
## Summary

This PR modifies [attributeRE](https://github.com/evanryuu/unocss/blob/main/packages/transformer-attributify-jsx/src/index.ts#L41) to solve transforming error when a class-like HTML element happens to have atomic attributes (not class names).

## Details

When the HTML element is like a class name, say `<h1>`, and the tag happens to have atomic attributes such as `text-red`, the transformer will accidentally transform the closing tag in an unexpected way.

Reproduction:
1. [Stackblitz](https://stackblitz.com/edit/vitejs-vite-k49hbr?file=uno.config.ts)
2. [My Github Repo](https://github.com/evanryuu/uno-jsx-repo)

**Code:**
<img width="232" alt="image" src="https://github.com/unocss/unocss/assets/55378595/6629b999-39d2-499f-8411-43360d4a74d1">

**Error:**
<img width="877" alt="image" src="https://github.com/unocss/unocss/assets/55378595/88aba648-bf1f-4653-b44f-936faaece756">

This PR makes the reg will not match the attribute starts with `<` or `</`