### PR TITLE
feat: improve interative docs search

### DIFF
--- a/packages/shared-docs/src/search.ts
+++ b/packages/shared-docs/src/search.ts
@@ -84,11 +84,6 @@ export function createSearch(
     if (input.match(/^rand(om)?:/))
       return sampleArray(fuseCollection, limit)
 
-    const parts = input.split(/\s/g).filter(notNull)
-    const extract = await generateForMultiple(parts)
-
-    await suggestMultiple(getPossibleSuggest(parts)).then(generateForMultiple)
-
     // css attr
     if (input.match(/^[a-zA-Z-]+:\s?[a-zA-Z0-9\s.#]+;?$/)) {
       const cssParts = input.split(':').map(str => str.trim())
@@ -102,6 +97,11 @@ export function createSearch(
         ...fuse.search(normalizedCSSAttr, { limit: limit * 2 }).map(i => i.item),
       ])
     }
+
+    const parts = input.split(/\s/g).filter(notNull)
+    const extract = await generateForMultiple(parts)
+
+    await suggestMultiple(getPossibleSuggest(parts)).then(generateForMultiple)
 
     const searchResult = uniq([
       ...fuse.search(input, { limit: limit * 2 }),


### PR DESCRIPTION
## Summary

This PR can make the search body more accurate when the input is class name (opionated😂)

## Details

### Before
Currently, in the [interactive docs](https://unocss.dev/interactive/), if I type `display: none`, the `.hidden` is not the first to show. From my personal point of view, it's a bit anti-instinct.

<img width="340" alt="image" src="https://github.com/unocss/unocss/assets/55378595/ea44890c-7591-4db6-a4ba-4b85be7f4b3d">

<img width="340" alt="image" src="https://github.com/unocss/unocss/assets/55378595/c30aa1e6-c22c-4c41-87dc-4164710f3ffe">

### After
If users input a CSS class name, I think maybe it's better to provide the exact atomic class that they need?

**P.S. It can also provide dynamic rules**

<img width="340" alt="image" src="https://github.com/unocss/unocss/assets/55378595/3a03e6e3-d539-4c46-9fec-f60815b25d99">
<img width="340" alt="image" src="https://github.com/unocss/unocss/assets/55378595/7e2d7372-9f26-4235-848d-ef1cb70d5679">
