### PR TITLE
feat(preset-mini): add justify left & right attrs

### DIFF
--- a/packages/inspector/src/categories.ts
+++ b/packages/inspector/src/categories.ts
@@ -94,6 +94,8 @@ export const staticUtilities: Record<string, string> = {
   'justify-between': 'justifyContent',
   'justify-around': 'justifyContent',
   'justify-evenly': 'justifyContent',
+  'justify-left': 'justifyContent',
+  'justify-right': 'justifyContent',
   'justify-items-auto': 'justifyItems',
   'justify-items-start': 'justifyItems',
   'justify-items-end': 'justifyItems',

--- a/packages/preset-mini/src/_rules/position.ts
+++ b/packages/preset-mini/src/_rules/position.ts
@@ -23,6 +23,8 @@ export const justifies: StaticRule[] = [
   ['justify-around', { 'justify-content': 'space-around' }],
   ['justify-evenly', { 'justify-content': 'space-evenly' }],
   ['justify-stretch', { 'justify-content': 'stretch' }],
+  ['justify-left', { 'justify-content': 'left' }],
+  ['justify-right', { 'justify-content': 'right' }],
   ...makeGlobalStaticRules('justify', 'justify-content'),
 
   // items


### PR DESCRIPTION
close: #3159 

[mozilla docs](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content#syntax)

after:
<img width="431" alt="截屏2023-09-25 17 41 38" src="https://github.com/unocss/unocss/assets/82451257/8c2cc78a-e232-47ee-8f7e-95f7a9a32d6b">
