### PR TITLE
docs: add link to /config/presets from /guide/presets

### DIFF
--- a/docs/guide/presets.md
+++ b/docs/guide/presets.md
@@ -42,3 +42,7 @@ export default defineConfig({
 ```
 
 You can check [official presets](/presets/) and [community presets](/presets/community) for more. 
+
+### Creating presets
+
+To see how you can create your own custom preset, see [Config: presets](/config/presets).


### PR DESCRIPTION
The presets guide only had docs on how to use presets so I added a link to /config/presets in a Creating presets subheading. (I was looking for it myself)

I'm not sure what the name for the link should be so feel free to change that.