### PR TITLE
feat(preset-mini): add user-valid and user-invalid pseudo selectors

### DIFF
--- a/packages/preset-mini/src/_variants/pseudo.ts
+++ b/packages/preset-mini/src/_variants/pseudo.ts
@@ -30,6 +30,8 @@ const PseudoClasses: Record<string, string> = Object.fromEntries([
   'required',
   'valid',
   'invalid',
+  'user-valid',
+  'user-invalid',
   'in-range',
   'out-of-range',
   'read-only',

--- a/packages/svelte-scoped/src/_preprocess/transformApply/getUtils.test.ts
+++ b/packages/svelte-scoped/src/_preprocess/transformApply/getUtils.test.ts
@@ -47,7 +47,7 @@ describe('getUtils', async () => {
           undefined,
           {
             "layer": undefined,
-            "sort": 22,
+            "sort": 24,
           },
           undefined,
           true,
@@ -70,7 +70,7 @@ describe('getUtils', async () => {
           undefined,
           {
             "layer": undefined,
-            "sort": 22,
+            "sort": 24,
           },
           undefined,
           true,


### PR DESCRIPTION
I added `user-valid` and `user-invalid` pseudo selectors in preset-mini pseudo.ts. No idea if it's supposed to be this easy. Is anything else required?

Tested in playground using
```html
<input required type="email" class="peer w-64 border border-solid user-valid:border-green-600 user-invalid:border-red-600"/>
      <span class="w-12 peer-focus:invisible peer-user-invalid:after:content-['❌'] 
                                             peer-user-valid:after:content-['✅']"></span>
```
in Chrome canary.

Fixes https://github.com/unocss/unocss/issues/3180