### PR TITLE
fix(variant-group): transformer variant group changes regular express…

### DIFF
--- a/packages/core/src/utils/variant-group.ts
+++ b/packages/core/src/utils/variant-group.ts
@@ -23,12 +23,23 @@ export function parseVariantGroup(str: string | MagicString, separators = ['-', 
   let content = str.toString()
   const prefixes = new Set<string>()
   const groupsByOffset = new Map<number, VariantGroup>()
-
+  const processedStr = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const isAttributor = (matchText: string, offset: number) => {
+    const reg = new RegExp(`<[\\w_\\-]+[^>\\/]*${processedStr(matchText)}[^>\\/]*>`, 'gm')
+    for (const match of content.matchAll(reg)) {
+      const index = match.index!
+      if (index < offset && (index + match[0].length > offset))
+        return true
+    }
+    return false
+  }
   do {
     hasChanged = false
     content = content.replace(
       regexClassGroup,
       (from, pre: string, sep: string, body: string, groupOffset: number) => {
+        if (!isAttributor(from, groupOffset))
+          return from
         if (!separators.includes(sep))
           return from
 


### PR DESCRIPTION
fix: #3206

I don't know if it is reasonable to filter out the matched regexClassGroup in the template in this way, or if there is a better implementation method, but this is the solution I currently think of without introducing parser.