### PR TITLE
feat(preset-mini): add default mouse media as alternative to @hover

### DIFF
--- a/packages/preset-mini/src/_theme/default.ts
+++ b/packages/preset-mini/src/_theme/default.ts
@@ -1,6 +1,6 @@
 import { colors } from './colors'
 import { fontFamily, fontSize, fontWeight, letterSpacing, lineHeight, textIndent, textShadow, textStrokeWidth, wordSpacing } from './font'
-import { borderRadius, boxShadow, breakpoints, duration, easing, lineWidth, ringWidth, spacing, verticalBreakpoints, zIndex } from './misc'
+import { borderRadius, boxShadow, breakpoints, duration, easing, lineWidth, media, ringWidth, spacing, verticalBreakpoints, zIndex } from './misc'
 import { blur, dropShadow } from './filters'
 import { containers, height, maxHeight, maxWidth, width } from './size'
 import type { Theme } from './types'
@@ -43,4 +43,5 @@ export const theme = {
   preflightBase,
   containers,
   zIndex,
+  media,
 } satisfies Theme

--- a/packages/preset-mini/src/_theme/misc.ts
+++ b/packages/preset-mini/src/_theme/misc.ts
@@ -85,3 +85,7 @@ export const ringWidth = {
 export const zIndex = {
   auto: 'auto',
 }
+
+export const media = {
+  mouse: '(hover) and (pointer: fine)',
+}

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -996,6 +996,10 @@ unocss .scope-\[unocss\]\:block{display:block;}
 @media (--cssvar){
 .media-\[\(--cssvar\)\]\:block{display:block;}
 }
+@media (hover) and (pointer: fine){
+.media-mouse\:block{display:block;}
+.group:hover .group-hover\:media-mouse\:bg-red{--un-bg-opacity:1;background-color:rgba(248,113,113,var(--un-bg-opacity));}
+}
 @media (prefers-color-scheme: dark){
 .dark\:text-xl{font-size:1.25rem;line-height:1.75rem;}
 .dark\:not-odd\:text-red:not(:nth-child(odd)){--un-text-opacity:1;color:rgba(248,113,113,var(--un-text-opacity));}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -1006,7 +1006,9 @@ export const presetMiniTargets: string[] = [
   'supports-[(display:_grid)]:block',
 
   // variants media
+  'media-mouse:block',
   'media-[(--cssvar)]:block',
+  'group-hover:media-mouse:bg-red',
 
   // variants prints
   'print:block',


### PR DESCRIPTION
Due to how tagged pseudo works (`group-x`, etc), it is difficult to weave `@hover` support.

This PR copy one of `media-x` variant default theme (`mouse`) from preset-wind so we can use `media-mouse` variant in preset-mini to add the `@hover` media query without adding the `:hover` pseudo. Note that `media-x` is separate from `group-x`, so to combine you may need to, well, combine the syntax (see test) or use shortcut. I personally think that this combination is better served via shortcut to keep the atomicity of the variant.

Reference: https://github.com/unocss/unocss/blob/5dcc8ceddb7b6acbb06be914b5f1bd3a444c8976/packages/preset-wind/src/theme.ts#L193

This should help #3076 with only preset-mini.