### PR TITLE
docs: update `svelte-coped` hooks.server.js location

### DIFF
--- a/docs/integrations/svelte-scoped.md
+++ b/docs/integrations/svelte-scoped.md
@@ -228,7 +228,7 @@ Add the `%unocss-svelte-scoped.global%` placeholder into your `<head>` tag. In S
 </head>
 ```
 
-If using SvelteKit, you also must add the following to the `transformPageChunk` hook in your `hooks.server.js` file:
+If using SvelteKit, you also must add the following to the `transformPageChunk` hook in your `src/hooks.server.js` file:
 
 ```js
 /** @type {import('@sveltejs/kit').Handle} */


### PR DESCRIPTION
I've had to refer to this page a few times, and since `hooks.server.js` is not a common file, I always forget where to put it, and have to refer to SvelteKit's docs.

My PR adds a simple change that adds the `src` folder to the code snippet. Alternatively, I suggest linking to SvelteKit docs.