### PR TITLE
test: fix svg check for vite 5

### DIFF
--- a/test/fixtures/vite-legacy/vite.config.ts
+++ b/test/fixtures/vite-legacy/vite.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
     UnoCSS(),
     Legacy(),
   ],
+  build: {
+    // Don't inline SVG to test output
+    assetsInlineLimit: 0,
+  },
 })


### PR DESCRIPTION
There's a test at https://github.com/unocss/unocss/blob/d0e101d68c9c4492e90053c09030da6690105014/test/fixtures.test.ts#L66-L67 that expects an SVG asset to be emitted. However in Vite 5, SVG assets are also inline-able so this would be inside the CSS file instead.

I updated the Vite config to fix this for now.

