### PR TITLE
fix(cli): improve error output

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,10 +48,17 @@ export async function build(_options: CliOptions) {
     }),
   )
 
-  if (!options.stdout) {
-    consola.log(green(`${name} v${version}`))
-    consola.start(`UnoCSS ${options.watch ? 'in watch mode...' : 'for production...'}`)
+  if (options.stdout && options.outFile) {
+    consola.fatal(`Cannot use --stdout and --out-file at the same time`)
+    return
   }
+
+  consola.log(green(`${name} v${version}`))
+
+  if (options.watch)
+    consola.start('UnoCSS in watch mode...')
+  else
+    consola.start('UnoCSS for production...')
 
   const debouncedBuild = debounce(
     async () => {
@@ -61,7 +68,7 @@ export async function build(_options: CliOptions) {
   )
 
   const startWatcher = async () => {
-    if (options.stdout || !options.watch)
+    if (!options.watch)
       return
     const { patterns } = options
 


### PR DESCRIPTION
This PR solves the issue: fix https://github.com/unocss/unocss/issues/3262

It does the following:

If both --stdout and --o are used, then watch will display a warning and not proceed.

Either --stdout or -o can be used or not, as the default is to create a uno.css file in the root directory.

-w remains the same.  Can be used or not.