### PR TITLE
fix(preset-mini): env may not always output numbers

### DIFF
--- a/packages/preset-mini/src/_utils/mappings.ts
+++ b/packages/preset-mini/src/_utils/mappings.ts
@@ -114,4 +114,4 @@ export const globalKeywords = [
   'unset',
 ]
 
-export const cssMathFnRE = /^(?:calc|env|clamp|min|max)\(.*\)/
+export const cssMathFnRE = /^(?:calc|clamp|min|max)\s*\(.*\)/


### PR DESCRIPTION
While most example deals with sizes, css' `env()` is more of `var()` not `calc()`