### PR TITLE
Revert "fix(webpack): escape backslash in css (#3256)"

### DIFF
--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -118,7 +118,7 @@ export default function WebpackPlugin<Theme extends object>(
                   : (result.getLayer(layer) || '')
 
                 if (!quote)
-                  return css.replaceAll(/\\/g, '\\\\\\\\')
+                  return css
 
                 // the css is in a js file, escaping
                 let escaped = JSON.stringify(css).slice(1, -1)


### PR DESCRIPTION
Revert #3256 turn out to be buggy & breaking