### PR TITLE
fix(preset-mini): remove num === 0 in px handler to fix offset utility issues

### DIFF
--- a/packages/preset-mini/src/_utils/handlers/handlers.ts
+++ b/packages/preset-mini/src/_utils/handlers/handlers.ts
@@ -106,11 +106,8 @@ export function px(str: string) {
     return
   const [, n, unit] = match
   const num = Number.parseFloat(n)
-  if (!Number.isNaN(num)) {
-    if (num === 0)
-      return '0'
+  if (!Number.isNaN(num))
     return unit ? `${round(num)}${unit}` : `${round(num)}px`
-  }
 }
 
 export function number(str: string) {

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -203,7 +203,7 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .border-x{border-left-width:1px;border-right-width:1px;}
 .border-b{border-bottom-width:1px;}
 .border-e-4{border-inline-end-width:4px;}
-.border-s-0{border-inline-start-width:0;}
+.border-s-0{border-inline-start-width:0px;}
 .border-t-2,
 .border-t-size-2{border-top-width:2px;}
 .border-inline{border-inline-start-width:1px;border-inline-end-width:1px;}


### PR DESCRIPTION
This PR removes a `num === 0` check in the px handler which returned `0` which broke a bunch of offset-utilities (`ring-offset-0`, `underline-offset-0`). This means it returns `0px` now and these utilities work again.

The `num === 0` check is still there for the rem handler so `inset-0` still gives a `0` result. (I'm not sure why this is better than 0px though)

It's possible there's a better way to fix this, in that case feel free to close this PR.

fixes https://github.com/unocss/unocss/issues/3196