### PR TITLE
fix: Not using contenthash in development mode has enabled HMR to work properly.

### DIFF
--- a/examples/vue-cli4/vue.config.js
+++ b/examples/vue-cli4/vue.config.js
@@ -1,3 +1,4 @@
+const process = require('node:process')
 const UnoCSS = require('@unocss/webpack').default
 
 module.exports = {
@@ -14,8 +15,12 @@ module.exports = {
     })
   },
   css: {
-    extract: {
-      filename: '[name].[hash:9].css',
-    },
+    extract: process.env.NODE_ENV === 'development'
+      ? {
+          filename: '[name].css',
+        }
+      : {
+          filename: '[name].[hash:9].css',
+        },
   },
 }

--- a/examples/vue-cli5/vue.config.js
+++ b/examples/vue-cli5/vue.config.js
@@ -1,7 +1,9 @@
+const process = require('node:process')
 const UnoCSS = require('@unocss/webpack').default
 
 module.exports = {
   configureWebpack: {
+    devtool: 'inline-source-map',
     plugins: [
       UnoCSS(),
     ],
@@ -17,6 +19,11 @@ module.exports = {
     })
   },
   css: {
-    extract: true,
+    extract: process.env.NODE_ENV === 'development'
+      ? {
+          filename: 'css/[name].css',
+          chunkFilename: 'css/[name].css',
+        }
+      : true,
   },
 }


### PR DESCRIPTION
https://github.com/webpack-contrib/mini-css-extract-plugin/blob/master/src/hmr/hotModuleReplacement.js#L150

Since `unocss` generates new css files with `contenthash` when files update and  `mini-css-extract-plugin` updates all css files link with query, we have to remove `contenthash` when running in development mode.

FIX: #2144