### PR TITLE
fix(preset-mini): change grid-template-cols to grid-template-columns

### DIFF
--- a/packages/preset-mini/src/_rules/grid.ts
+++ b/packages/preset-mini/src/_rules/grid.ts
@@ -74,5 +74,5 @@ export const grids: Rule<Theme>[] = [
 
   // template subgrid
   ['grid-rows-subgrid', { 'grid-template-rows': 'subgrid' }],
-  ['grid-cols-subgrid', { 'grid-template-cols': 'subgrid' }],
+  ['grid-cols-subgrid', { 'grid-template-columns': 'subgrid' }],
 ]

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -624,6 +624,8 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .grid-areas-\[prepend_content_append\]{grid-template-areas:"prepend content append";}
 .grid-areas-\[prepend_content_append\]-\[prepend_content_append\]{grid-template-areas:"prepend content append" "prepend content append";}
 .grid-areas-\$variable{grid-template-areas:var(--variable);}
+.grid-cols-subgrid{grid-template-columns:subgrid;}
+.grid-rows-subgrid{grid-template-rows:subgrid;}
 .gap-\$variable{gap:var(--variable);}
 .gap-4{gap:1rem;}
 .gap-inherit{gap:inherit;}

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -624,6 +624,8 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .grid-areas-\[prepend_content_append\]{grid-template-areas:"prepend content append";}
 .grid-areas-\[prepend_content_append\]-\[prepend_content_append\]{grid-template-areas:"prepend content append" "prepend content append";}
 .grid-areas-\$variable{grid-template-areas:var(--variable);}
+.grid-rows-subgrid{grid-template-rows:subgrid;}
+.grid-cols-subgrid{grid-template-columns:subgrid;}
 .gap-\$variable{gap:var(--variable);}
 .gap-4{gap:1rem;}
 .gap-inherit{gap:inherit;}

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -624,8 +624,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .grid-areas-\[prepend_content_append\]{grid-template-areas:"prepend content append";}
 .grid-areas-\[prepend_content_append\]-\[prepend_content_append\]{grid-template-areas:"prepend content append" "prepend content append";}
 .grid-areas-\$variable{grid-template-areas:var(--variable);}
-.grid-cols-subgrid{grid-template-columns:subgrid;}
-.grid-rows-subgrid{grid-template-rows:subgrid;}
 .gap-\$variable{gap:var(--variable);}
 .gap-4{gap:1rem;}
 .gap-inherit{gap:inherit;}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -362,6 +362,8 @@ export const presetMiniTargets: string[] = [
   'grid-areas-[prepend_content_append]',
   'grid-areas-[prepend_content_append]-[prepend_content_append]',
   'grid-areas-$variable',
+  'grid-cols-subgrid',
+  'grid-rows-subgrid',
 
   // layout
   'of-y-visible',

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -362,8 +362,6 @@ export const presetMiniTargets: string[] = [
   'grid-areas-[prepend_content_append]',
   'grid-areas-[prepend_content_append]-[prepend_content_append]',
   'grid-areas-$variable',
-  'grid-cols-subgrid',
-  'grid-rows-subgrid',
 
   // layout
   'of-y-visible',


### PR DESCRIPTION
I noticed I made a mistake in https://github.com/unocss/unocss/pull/3284 by writing `grid-template-cols` in the rule instead of `grid-template-columns` 😱

This PR fixes that so the resulting CSS is valid. Would probably be helpful to have some tests for these too but I have no idea where to add them.