### PR TITLE
docs: update Vite integration

### DIFF
--- a/docs/.vitepress/content.ts
+++ b/docs/.vitepress/content.ts
@@ -52,13 +52,19 @@ export const examples: Example[] = [
   {
     name: 'vite-solid',
     path: 'examples/vite-solid',
-    icon: 'i-logos-solidjs-icon',
+    icons: [
+      'i-logos-vitejs',
+      'i-logos-solidjs-icon',
+    ],
     stackblitz: true,
   },
   {
     name: 'vue-cli4',
     path: 'examples/vue-cli4',
-    icon: 'i-logos-vue',
+    icons: [
+      'i-logos-webpack',
+      'i-logos-vue',
+    ],
     stackblitz: true,
   },
   {
@@ -79,7 +85,10 @@ export const examples: Example[] = [
   {
     name: 'vite-elm',
     path: 'examples/vite-elm',
-    icon: 'i-logos-elm',
+    icons: [
+      'i-logos-vitejs',
+      'i-logos-elm',
+    ],
     // stackblitz: true,
   },
   {
@@ -94,7 +103,10 @@ export const examples: Example[] = [
   {
     name: 'vue-cli5',
     path: 'examples/vue-cli5',
-    icon: 'i-logos-vue',
+    icons: [
+      'i-logos-webpack',
+      'i-logos-vue',
+    ],
     stackblitz: true,
   },
   {
@@ -107,14 +119,20 @@ export const examples: Example[] = [
   {
     name: 'vite-lightningcss',
     path: 'examples/vite-lightningcss',
-    icon: 'i-ph-lightning text-yellow',
+    icons: [
+      'i-logos-vitejs',
+      'i-ph-lightning text-yellow',
+    ],
     // lightingcss is not supported by stackblitz yet
     // stackblitz: true,
   },
   {
     name: 'vite-lit',
     path: 'examples/vite-lit',
-    icon: 'i-logos-lit-icon',
+    icons: [
+      'i-logos-vitejs',
+      'i-logos-lit-icon',
+    ],
     stackblitz: true,
   },
   {
@@ -141,7 +159,10 @@ export const examples: Example[] = [
   {
     name: 'vite-preact',
     path: 'examples/vite-preact',
-    icon: 'i-logos-preact',
+    icons: [
+      'i-logos-vitejs',
+      'i-logos-preact',
+    ],
     stackblitz: true,
   },
   {
@@ -171,7 +192,10 @@ export const examples: Example[] = [
   {
     name: 'vite-pug',
     path: 'examples/vite-pug',
-    icon: 'i-logos-pug',
+    icons: [
+      'i-logos-vitejs',
+      'i-logos-pug',
+    ],
     stackblitz: true,
   },
   {

--- a/docs/.vitepress/theme/components/ContentExample.vue
+++ b/docs/.vitepress/theme/components/ContentExample.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import type { Example } from '../../content'
+
+defineProps<{
+  item: Example
+  integrations?: boolean
+}>()
+</script>
+
+<template>
+  <div
+    h-20 text-center text-inherit
+    flex="~ items-center gap-4"
+    class="Link"
+    :class="integrations ? 'ps-4' : 'w-80 justify-center'"
+  >
+    <div v-if="item.icon" :class="item.icon" w-8 h-8 flex-none />
+    <div v-else-if="item.icons" w-8 h-14 flex-none flex="~ wrap items-center justify-center">
+      <div v-for="icon of item.icons" :key="icon" :class="icon" w-5 h-5 />
+    </div>
+    <div flex="~ col" w-50 text-left>
+      <span text-sm font-500 text-truncate>{{ item.name }}</span>
+      <div py1 text-lg flex="~ gap-3">
+        <a
+          class="text-inherit! op50 hover:op100"
+          flex="~ items-center gap-0.5"
+          :href="`https://github.com/unocss/unocss/tree/main/examples/${item.name}`" target="_blank"
+        >
+          <div i-carbon-logo-github />
+          <span text-xs>Source</span>
+        </a>
+        <a
+          v-if="item.stackblitz || item.codesandbox"
+          class="text-inherit! op50 hover:op100"
+          flex="~ items-center gap-0.5"
+          :href="item.stackblitz
+            ? `https://stackblitz.com/fork/github/unocss/unocss/tree/main/examples/${item.name}`
+            : `https://codesandbox.io/s/github/unocss/unocss/tree/main/examples/${item.name}`"
+          target="_blank"
+        >
+          <div i-carbon-executable-program />
+          <span text-xs>Play online</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.Link {
+  color: inherit !important;
+  text-decoration: none !important;
+  border: 1px solid var(--vp-c-bg-soft);
+  border-radius: 12px;
+  background-color: var(--vp-c-bg-soft);
+  transition: border-color 0.25s, background-color 0.25s;
+}
+</style>

--- a/docs/.vitepress/theme/components/ContentExamples.vue
+++ b/docs/.vitepress/theme/components/ContentExamples.vue
@@ -4,51 +4,10 @@ import { examples } from '../../content'
 
 <template>
   <div flex="~ wrap gap-2">
-    <div
-      v-for="item of examples" :key="item.name" class="Link"
-      w-80 h-20 text-center text-inherit
-      flex="~ items-center justify-center gap-4"
-    >
-      <div v-if="item.icon" :class="item.icon" w-8 h-8 flex-none />
-      <div v-else-if="item.icons" w-8 h-14 flex-none flex="~ wrap items-center justify-center">
-        <div v-for="icon of item.icons" :key="icon" :class="icon" w-5 h-5 />
-      </div>
-      <div flex="~ col" w-50 text-left>
-        <span text-sm font-500 text-truncate>{{ item.name }}</span>
-        <div py1 text-lg flex="~ gap-3">
-          <a
-            class="text-inherit! op50 hover:op100"
-            flex="~ items-center gap-0.5"
-            :href="`https://github.com/unocss/unocss/tree/main/examples/${item.name}`" target="_blank"
-          >
-            <div i-carbon-logo-github />
-            <span text-xs>Source</span>
-          </a>
-          <a
-            v-if="item.stackblitz || item.codesandbox"
-            class="text-inherit! op50 hover:op100"
-            flex="~ items-center gap-0.5"
-            :href="item.stackblitz
-              ? `https://stackblitz.com/fork/github/unocss/unocss/tree/main/examples/${item.name}`
-              : `https://codesandbox.io/s/github/unocss/unocss/tree/main/examples/${item.name}`"
-            target="_blank"
-          >
-            <div i-carbon-executable-program />
-            <span text-xs>Play online</span>
-          </a>
-        </div>
-      </div>
-    </div>
+    <ContentExample
+      v-for="item of examples"
+      :key="item.name"
+      :item="item"
+    />
   </div>
 </template>
-
-<style scoped>
-.Link {
-  color: inherit !important;
-  text-decoration: none !important;
-  border: 1px solid var(--vp-c-bg-soft);
-  border-radius: 12px;
-  background-color: var(--vp-c-bg-soft);
-  transition: border-color 0.25s, background-color 0.25s;
-}
-</style>

--- a/docs/components.d.ts
+++ b/docs/components.d.ts
@@ -7,6 +7,7 @@ export {}
 
 declare module 'vue' {
   export interface GlobalComponents {
+    ContentExample: typeof import('./.vitepress/theme/components/ContentExample.vue')['default']
     ContentExamples: typeof import('./.vitepress/theme/components/ContentExamples.vue')['default']
     ContentIntegrations: typeof import('./.vitepress/theme/components/ContentIntegrations.vue')['default']
     HomePage: typeof import('./.vitepress/theme/components/HomePage.vue')['default']

--- a/docs/integrations/vite.md
+++ b/docs/integrations/vite.md
@@ -4,6 +4,15 @@ description: The Vite plugin for UnoCSS (@unocss/vite).
 outline: deep
 ---
 
+<script setup lang="ts">
+import { examples } from '../.vitepress/content'
+
+const playgrounds = examples.reduce((acc, cur) => {
+  acc[cur.name] = cur
+  return acc
+}, {})
+</script>
+
 # Vite Plugin
 
 The Vite plugin ships with the `unocss` package.
@@ -105,6 +114,11 @@ Please use it with caution, under the hood we use [`MutationObserver`](https://d
 
 Some UI/App frameworks have some caveats that must be fixed to make it work, if you're using one of the following frameworks, just apply the suggestions.
 
+### VanillaJS / TypeScript
+
+
+When using VanillaJS or TypeScript, you need to add `js` and `ts` files extensions to allow UnoCSS read and parse the content, by default `js` and `ts` files are excluded, check [Extracting from Build Tools Pipeline](/guide/extracting#extracting-from-build-tools-pipeline) section.
+
 ### React
 
 If you're using `@vitejs/plugin-react`:
@@ -141,6 +155,8 @@ export default {
 
 You have a `React` example project on [examples/vite-react](https://github.com/unocss/unocss/tree/main/examples/vite-react) directory  using both plugins, check the scripts on `package.json` and its Vite configuration file.
 
+<ContentExample :item="playgrounds['vite-react']"  class="Link" integrations />
+
 ### Preact
 
 If you're using `@preact/preset-vite`:
@@ -175,7 +191,9 @@ export default {
 
 If you're using `@unocss/preset-attributify` you should remove `tsc` from the `build` script.
 
-You have a `Preact` example project on [examples/vite-preact](https://github.com/unocss/unocss/tree/main/examples/vite-preact) directory  using both plugins, check the scripts on `package.json` and its Vite configuration file.
+You have a `Preact` example project on [examples/vite-preact](https://github.com/unocss/unocss/tree/main/examples/vite-preact) directory using both plugins, check the scripts on `package.json` and its Vite configuration file.
+
+<ContentExample :item="playgrounds['vite-preact']"  class="Link" integrations />
 
 ### Svelte
 
@@ -204,7 +222,7 @@ export default {
 }
 ```
 
-You have a `Vite + Svelte` example project on [examples/vite-svelte](https://github.com/unocss/unocss/tree/main/examples/vite-svelte) directory.
+<ContentExample :item="playgrounds['vite-svelte']"  class="Link" integrations />
 
 ### Sveltekit
 
@@ -232,7 +250,11 @@ const config = {
 }
 ```
 
-You have a `SvelteKit` example project in [examples/sveltekit](https://github.com/unocss/unocss/tree/main/examples/sveltekit) directory.
+<ContentExample :item="playgrounds['sveltekit']"  class="Link mb-4" integrations />
+
+<ContentExample :item="playgrounds['sveltekit-preprocess']"  class="Link mb-4" integrations />
+
+<ContentExample :item="playgrounds['sveltekit-scoped']"  class="Link" integrations />
 
 ### Web Components
 
@@ -335,9 +357,11 @@ template.innerHTML = `
 </div>
 `
 ```
+<ContentExample :item="playgrounds['vite-lit']"  class="Link" integrations />
 
 ### Solid
 
+You need to add the `vite-plugin-solid` plugin after UnoCSS's plugin.
 
 ```ts
 // vite.config.js
@@ -346,15 +370,15 @@ import UnoCSS from 'unocss/vite'
 
 export default {
   plugins: [
-    solidPlugin(),
     UnoCSS({
       /* options */
     }),
+    solidPlugin(),
   ],
 }
 ```
 
-You have a `Vite + Solid` example project on [examples/vite-solid](https://github.com/unocss/unocss/tree/main/examples/vite-solid) directory.
+<ContentExample :item="playgrounds['vite-solid']"  class="Link" integrations />
 
 ### Elm
 
@@ -374,7 +398,7 @@ export default defineConfig({
 })
 ```
 
-You have a `Vite + Elm` example project on [examples/vite-elm](https://github.com/unocss/unocss/tree/main/examples/vite-elm) directory.
+<ContentExample :item="playgrounds['vite-elm']"  class="Link" integrations />
 
 ## License
 

--- a/docs/integrations/vite.md
+++ b/docs/integrations/vite.md
@@ -116,7 +116,6 @@ Some UI/App frameworks have some caveats that must be fixed to make it work, if 
 
 ### VanillaJS / TypeScript
 
-
 When using VanillaJS or TypeScript, you need to add `js` and `ts` files extensions to allow UnoCSS read and parse the content, by default `js` and `ts` files are excluded, check [Extracting from Build Tools Pipeline](/guide/extracting#extracting-from-build-tools-pipeline) section.
 
 ### React

--- a/examples/vite-solid/src/App.tsx
+++ b/examples/vite-solid/src/App.tsx
@@ -4,19 +4,19 @@ import { createSignal } from 'solid-js'
 const App: Component = () => {
   const [count, setCount] = createSignal(0)
   return (
-    <div className="text-center">
-      <header className="bg-#282c34 min-h-100vh flex flex-col items-center justify-center color-white">
-        <div className="logo" />
-        <h1 className="mt-2em animate-bounce-alt animate-duration-2s">Hello Vite + Solid!</h1>
+    <div class="text-center">
+      <header class="bg-#282c34 min-h-100vh flex flex-col items-center justify-center color-white">
+        <div class="logo" />
+        <h1 class="mt-2em animate-bounce-alt animate-duration-2s">Hello Vite + Solid!</h1>
         <p>
           <button
-            className="bg-blue-400 hover:bg-blue-500 text-sm text-white font-mono font-light py-2 px-4 rounded border-2 border-blue-200 dark:bg-blue-500 dark:hover:bg-blue-600"
+            class="bg-blue-400 hover:bg-blue-500 text-sm text-white font-mono font-light py-2 px-4 rounded border-2 border-blue-200 dark:bg-blue-500 dark:hover:bg-blue-600"
             type="button"
             onClick={() => setCount(count => count + 1)}
           >
             count is:
             {' '}
-            {count}
+            {count()}
           </button>
 
           <button
@@ -31,7 +31,7 @@ const App: Component = () => {
           >
             count is:
             {' '}
-            {count}
+            {count()}
           </button>
 
         </p>
@@ -44,7 +44,7 @@ const App: Component = () => {
         </p>
         <p>
           <a
-            className="color-#4f88c6"
+            class="color-#4f88c6"
             href="https://www.solidjs.com/"
             target="_blank"
             rel="noopener noreferrer"
@@ -53,7 +53,7 @@ const App: Component = () => {
           </a>
           {' | '}
           <a
-            className="color-#4f88c6"
+            class="color-#4f88c6"
             href="https://vitejs.dev/guide/features.html"
             target="_blank"
             rel="noopener noreferrer"

--- a/examples/vite-solid/vite.config.ts
+++ b/examples/vite-solid/vite.config.ts
@@ -7,7 +7,6 @@ import presetAttributify from '@unocss/preset-attributify'
 
 export default defineConfig({
   plugins: [
-    solidPlugin(),
     UnoCSS({
       shortcuts: [
         { logo: 'i-logos-solidjs-icon w-6em h-6em transform transition-800 hover:rotate-360' },
@@ -23,6 +22,7 @@ export default defineConfig({
         }),
       ],
     }),
+    solidPlugin(),
   ],
   build: {
     target: 'esnext',

--- a/playground/src/auto-imports.d.ts
+++ b/playground/src/auto-imports.d.ts
@@ -338,7 +338,7 @@ declare global {
 // for type re-export
 declare global {
   // @ts-ignore
-  export type { Component, ComponentPublicInstance, ComputedRef, InjectionKey, PropType, Ref, VNode, WritableComputedRef } from 'vue'
+  export type { Component, ComponentPublicInstance, ComputedRef, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, VNode, WritableComputedRef } from 'vue'
 }
 // for vue template auto import
 import { UnwrapRef } from 'vue'


### PR DESCRIPTION
This PR includes:
- add ContentExample to allow use it in Vite integration: ContentExamples updated properly
- included missing vite and webpack icons in the content module
- add ContentExample in Vite integration per framework
- add VanillaJS / TypeScript section to Vite integration to include js/ts in the pipeline: link to **Extracting from Build Tools Pipeline**
- updated Solid example, latest version doesn't support `className` and the `count` access was wrong (it is a Solid state, use the function): updated also Vite configuration file, `vite-plugin-solid` needs to be registered after UnoCSS plugin, `shortcuts` not working
- update Solid entry in Vite integrations to change the plugin order