### PR TITLE
fix(vscode): avoid register functions without config files

### DIFF
--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -38,9 +38,11 @@ export async function activate(ext: ExtensionContext) {
     ? await rootRegisterManual(ext, root, projectPath)
     : await rootRegisterAuto(ext, typeof root === 'string' ? root : projectPath, config)
 
-  registerAutoComplete(ctx, ext)
-  registerAnnotations(ctx, status, ext)
-  registerSelectionStyle(ctx)
+  if (await ctx.loadContextInDirectory(ctx.cwd)) {
+    registerAutoComplete(ctx, ext)
+    registerAnnotations(ctx, status, ext)
+    registerSelectionStyle(ctx)
+  }
 
   ext.subscriptions.push(
     commands.registerCommand('unocss.reload', async () => {

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -1,15 +1,12 @@
 import path, { dirname } from 'path'
-import type { ExtensionContext, WorkspaceConfiguration } from 'vscode'
+import type { ExtensionContext, StatusBarItem, WorkspaceConfiguration } from 'vscode'
 import { StatusBarAlignment, commands, window, workspace } from 'vscode'
 import { findUp } from 'find-up'
 import type { FilterPattern } from '@rollup/pluginutils'
 import { createFilter } from '@rollup/pluginutils'
 import { version } from '../package.json'
 import { log } from './log'
-import { registerAnnotations } from './annotation'
-import { registerAutoComplete } from './autocomplete'
 import { ContextLoader } from './contextLoader'
-import { registerSelectionStyle } from './selectionStyle'
 import { isRejected } from './utils'
 import { defaultPipelineExclude, defaultPipelineInclude } from './integration'
 
@@ -35,14 +32,8 @@ export async function activate(ext: ExtensionContext) {
   const root = config.get<string | string[]>('root')
 
   const ctx = (Array.isArray(root) && root.length)
-    ? await rootRegisterManual(ext, root, projectPath)
-    : await rootRegisterAuto(ext, typeof root === 'string' ? root : projectPath, config)
-
-  if (await ctx.loadContextInDirectory(ctx.cwd)) {
-    registerAutoComplete(ctx, ext)
-    registerAnnotations(ctx, status, ext)
-    registerSelectionStyle(ctx)
-  }
+    ? await rootRegisterManual(ext, root, projectPath, status)
+    : await rootRegisterAuto(ext, typeof root === 'string' ? root : projectPath, config, status)
 
   ext.subscriptions.push(
     commands.registerCommand('unocss.reload', async () => {
@@ -54,17 +45,18 @@ export async function activate(ext: ExtensionContext) {
 }
 
 async function rootRegisterManual(
-  _ext: ExtensionContext,
+  ext: ExtensionContext,
   root: string[],
   projectPath: string,
+  status: StatusBarItem,
 ) {
   log.appendLine('📂 Manual roots search mode.' + `\n${root.map(i => `  - ${i}`).join('\n')}`)
 
   const roots = root.map(dir => path.resolve(projectPath, dir))
 
   const ctx = roots.length === 1
-    ? new ContextLoader(roots[0])
-    : new ContextLoader(projectPath)
+    ? new ContextLoader(roots[0], ext, status)
+    : new ContextLoader(projectPath, ext, status)
 
   await ctx.ready
 
@@ -84,6 +76,7 @@ async function rootRegisterAuto(
   ext: ExtensionContext,
   root: string,
   config: WorkspaceConfiguration,
+  status: StatusBarItem,
 ) {
   log.appendLine('📂 Auto roots search mode.')
 
@@ -94,7 +87,7 @@ async function rootRegisterAuto(
   const exclude: FilterPattern = _exclude || [/[\/](node_modules|dist|\.temp|\.cache|\.vscode)[\/]/, ...defaultPipelineExclude]
   const filter = createFilter(include, exclude)
 
-  const ctx = new ContextLoader(root)
+  const ctx = new ContextLoader(root, ext, status)
   await ctx.ready
 
   const cacheFileLookUp = new Set<string>()


### PR DESCRIPTION
https://github.com/unocss/unocss/commit/64b3461b3d241521d02cb4d1d87a75e4e8aa3451#diff-d56e4c8975b25ab91eed38d6ea0406f9f1668a415cd116d334929ea8d28d1276L21

https://github.com/unocss/unocss/commit/64b3461b3d241521d02cb4d1d87a75e4e8aa3451#diff-d56e4c8975b25ab91eed38d6ea0406f9f1668a415cd116d334929ea8d28d1276R41

It should determine if the configuration file exists before registering functions.


![image](https://github.com/unocss/unocss/assets/21942252/d573a28f-1f55-48e5-8a9e-3f6b638014fb)
