### PR TITLE
feat(preset-mini, preset-wind): Use separate theme for some rule colors

### DIFF
--- a/packages/inspector/src/analyzer.ts
+++ b/packages/inspector/src/analyzer.ts
@@ -48,7 +48,7 @@ export async function analyzer(modules: BetterMap<string, string>, ctx: UnocssPl
       const body = baseSelector
         .replace(/^ring-offset|outline-solid|outline-dotted/, 'head')
         .replace(/^\w+-/, '')
-      const parsedColor = parseColor(body, ctx.uno.config.theme)
+      const parsedColor = parseColor(body, ctx.uno.config.theme, 'colors')
 
       if (parsedColor?.color && !ignoredColors.includes(parsedColor?.color)) {
         const existing = colors.find(c => c.name === parsedColor.name && c.no === parsedColor.no)

--- a/packages/preset-mini/src/_rules/behaviors.ts
+++ b/packages/preset-mini/src/_rules/behaviors.ts
@@ -7,7 +7,7 @@ export const outline: Rule<Theme>[] = [
   [/^outline-(?:width-|size-)?(.+)$/, ([, d], { theme }) => ({ 'outline-width': theme.lineWidth?.[d] ?? h.bracket.cssvar.global.px(d) }), { autocomplete: 'outline-(width|size)-<num>' }],
 
   // color
-  [/^outline-(?:color-)?(.+)$/, colorResolver('outline-color', 'outline-color'), { autocomplete: 'outline-$colors' }],
+  [/^outline-(?:color-)?(.+)$/, colorResolver('outline-color', 'outline-color', 'borderColor'), { autocomplete: 'outline-$colors' }],
 
   // offset
   [/^outline-offset-(.+)$/, ([, d], { theme }) => ({ 'outline-offset': theme.lineWidth?.[d] ?? h.bracket.cssvar.global.px(d) }), { autocomplete: 'outline-(offset)-<num>' }],

--- a/packages/preset-mini/src/_rules/border.ts
+++ b/packages/preset-mini/src/_rules/border.ts
@@ -51,7 +51,7 @@ export const borders: Rule[] = [
 
 function borderColorResolver(direction: string) {
   return ([, body]: string[], theme: Theme): CSSObject | undefined => {
-    const data = parseColor(body, theme)
+    const data = parseColor(body, theme, 'borderColor')
 
     if (!data)
       return
@@ -104,7 +104,7 @@ function handlerBorderSize([, a = '', b]: string[], { theme }: RuleContext<Theme
 }
 
 function handlerBorderColor([, a = '', c]: string[], { theme }: RuleContext<Theme>): CSSObject | undefined {
-  if (a in directionMap && hasParseableColor(c, theme)) {
+  if (a in directionMap && hasParseableColor(c, theme, 'borderColor')) {
     return Object.assign(
       {},
       ...directionMap[a].map(i => borderColorResolver(i)(['', c], theme)),

--- a/packages/preset-mini/src/_rules/color.ts
+++ b/packages/preset-mini/src/_rules/color.ts
@@ -13,15 +13,15 @@ export const opacity: Rule[] = [
  * @example c-red color-red5 text-red-300
  */
 export const textColors: Rule[] = [
-  [/^(?:color|c)-(.+)$/, colorResolver('color', 'text'), { autocomplete: '(color|c)-$colors' }],
+  [/^(?:color|c)-(.+)$/, colorResolver('color', 'text', 'textColor'), { autocomplete: '(color|c)-$colors' }],
   // auto detection and fallback to font-size if the content looks like a size
-  [/^text-(.+)$/, colorResolver('color', 'text', css => !css.color?.toString().match(numberWithUnitRE)), { autocomplete: 'text-$colors' }],
+  [/^text-(.+)$/, colorResolver('color', 'text', 'textColor', css => !css.color?.toString().match(numberWithUnitRE)), { autocomplete: 'text-$colors' }],
   [/^(?:text|color|c)-(.+)$/, ([, v]) => globalKeywords.includes(v) ? { color: v } : undefined, { autocomplete: `(text|color|c)-(${globalKeywords.join('|')})` }],
   [/^(?:text|color|c)-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-text-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: '(text|color|c)-(op|opacity)-<percent>' }],
 ]
 
 export const bgColors: Rule[] = [
-  [/^bg-(.+)$/, (...args) => isSize(args[0][1]) ? undefined : colorResolver('background-color', 'bg')(...args), { autocomplete: 'bg-$colors' }],
+  [/^bg-(.+)$/, (...args) => isSize(args[0][1]) ? undefined : colorResolver('background-color', 'bg', 'backgroundColor')(...args), { autocomplete: 'bg-$colors' }],
   [/^bg-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-bg-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: 'bg-(op|opacity)-<percent>' }],
 ]
 

--- a/packages/preset-mini/src/_rules/decoration.ts
+++ b/packages/preset-mini/src/_rules/decoration.ts
@@ -13,7 +13,7 @@ export const textDecorations: Rule<Theme>[] = [
 
   // colors
   [/^(?:underline|decoration)-(.+)$/, (match, ctx) => {
-    const result = colorResolver('text-decoration-color', 'line')(match, ctx) as CSSObject | undefined
+    const result = colorResolver('text-decoration-color', 'line', 'borderColor')(match, ctx) as CSSObject | undefined
     if (result) {
       return {
         '-webkit-text-decoration-color': result['text-decoration-color'],

--- a/packages/preset-mini/src/_rules/ring.ts
+++ b/packages/preset-mini/src/_rules/ring.ts
@@ -32,11 +32,11 @@ export const rings: Rule<Theme>[] = [
   [/^ring-offset-(?:width-|size-)?(.+)$/, ([, d], { theme }) => ({ '--un-ring-offset-width': theme.lineWidth?.[d] ?? h.bracket.cssvar.px(d) }), { autocomplete: 'ring-offset-(width|size)-$lineWidth' }],
 
   // colors
-  [/^ring-(.+)$/, colorResolver('--un-ring-color', 'ring'), { autocomplete: 'ring-$colors' }],
+  [/^ring-(.+)$/, colorResolver('--un-ring-color', 'ring', 'borderColor'), { autocomplete: 'ring-$colors' }],
   [/^ring-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-ring-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: 'ring-(op|opacity)-<percent>' }],
 
   // offset color
-  [/^ring-offset-(.+)$/, colorResolver('--un-ring-offset-color', 'ring-offset'), { autocomplete: 'ring-offset-$colors' }],
+  [/^ring-offset-(.+)$/, colorResolver('--un-ring-offset-color', 'ring-offset', 'borderColor'), { autocomplete: 'ring-offset-$colors' }],
   [/^ring-offset-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-ring-offset-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: 'ring-offset-(op|opacity)-<percent>' }],
 
   // style

--- a/packages/preset-mini/src/_rules/shadow.ts
+++ b/packages/preset-mini/src/_rules/shadow.ts
@@ -18,13 +18,13 @@ export const boxShadows: Rule<Theme>[] = [
     const v = theme.boxShadow?.[d || 'DEFAULT']
     const c = d ? h.bracket.cssvar(d) : undefined
 
-    if ((v != null || c != null) && !hasParseableColor(c, theme)) {
+    if ((v != null || c != null) && !hasParseableColor(c, theme, 'shadowColor')) {
       return {
         '--un-shadow': colorableShadows((v || c)!, '--un-shadow-color').join(','),
         'box-shadow': 'var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow)',
       }
     }
-    return colorResolver('--un-shadow-color', 'shadow')(match, context)
+    return colorResolver('--un-shadow-color', 'shadow', 'shadowColor')(match, context)
   }, { autocomplete: ['shadow-$colors', 'shadow-$boxShadow'] }],
   [/^shadow-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-shadow-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: 'shadow-(op|opacity)-<percent>' }],
 

--- a/packages/preset-mini/src/_rules/svg.ts
+++ b/packages/preset-mini/src/_rules/svg.ts
@@ -4,7 +4,7 @@ import { colorResolver, h } from '../utils'
 
 export const svgUtilities: Rule<Theme>[] = [
   // fills
-  [/^fill-(.+)$/, colorResolver('fill', 'fill'), { autocomplete: 'fill-$colors' }],
+  [/^fill-(.+)$/, colorResolver('fill', 'fill', 'backgroundColor'), { autocomplete: 'fill-$colors' }],
   [/^fill-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-fill-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: 'fill-(op|opacity)-<percent>' }],
   ['fill-none', { fill: 'none' }],
 
@@ -16,7 +16,7 @@ export const svgUtilities: Rule<Theme>[] = [
   [/^stroke-offset-(.+)$/, ([, s], { theme }) => ({ 'stroke-dashoffset': theme.lineWidth?.[s] ?? h.bracket.cssvar.px.numberWithUnit(s) }), { autocomplete: 'stroke-offset-$lineWidth' }],
 
   // stroke colors
-  [/^stroke-(.+)$/, colorResolver('stroke', 'stroke'), { autocomplete: 'stroke-$colors' }],
+  [/^stroke-(.+)$/, colorResolver('stroke', 'stroke', 'borderColor'), { autocomplete: 'stroke-$colors' }],
   [/^stroke-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-stroke-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: 'stroke-(op|opacity)-<percent>' }],
 
   // line cap

--- a/packages/preset-mini/src/_rules/typography.ts
+++ b/packages/preset-mini/src/_rules/typography.ts
@@ -120,7 +120,7 @@ export const textStrokes: Rule<Theme>[] = [
   [/^text-stroke(?:-(.+))?$/, ([, s], { theme }) => ({ '-webkit-text-stroke-width': theme.textStrokeWidth?.[s || 'DEFAULT'] || h.bracket.cssvar.px(s) }), { autocomplete: 'text-stroke-$textStrokeWidth' }],
 
   // colors
-  [/^text-stroke-(.+)$/, colorResolver('-webkit-text-stroke-color', 'text-stroke'), { autocomplete: 'text-stroke-$colors' }],
+  [/^text-stroke-(.+)$/, colorResolver('-webkit-text-stroke-color', 'text-stroke', 'borderColor'), { autocomplete: 'text-stroke-$colors' }],
   [/^text-stroke-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-text-stroke-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: 'text-stroke-(op|opacity)-<percent>' }],
 ]
 
@@ -137,6 +137,6 @@ export const textShadows: Rule<Theme>[] = [
   }, { autocomplete: 'text-shadow-$textShadow' }],
 
   // colors
-  [/^text-shadow-color-(.+)$/, colorResolver('--un-text-shadow-color', 'text-shadow'), { autocomplete: 'text-shadow-color-$colors' }],
+  [/^text-shadow-color-(.+)$/, colorResolver('--un-text-shadow-color', 'text-shadow', 'shadowColor'), { autocomplete: 'text-shadow-color-$colors' }],
   [/^text-shadow-color-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-text-shadow-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: 'text-shadow-color-(op|opacity)-<percent>' }],
 ]

--- a/packages/preset-mini/src/_theme/types.ts
+++ b/packages/preset-mini/src/_theme/types.ts
@@ -29,6 +29,11 @@ export interface Theme {
   breakpoints?: Record<string, string>
   verticalBreakpoints?: Record<string, string>
   colors?: Colors
+  borderColor?: Colors
+  backgroundColor?: Colors
+  textColor?: Colors
+  shadowColor?: Colors
+  accentColor?: Colors
   fontFamily?: Record<string, string>
   fontSize?: Record<string, string | [string, string | CSSObject] | [string, string, string]>
   fontWeight?: Record<string, string>

--- a/packages/preset-mini/src/_utils/utilities.ts
+++ b/packages/preset-mini/src/_utils/utilities.ts
@@ -49,7 +49,7 @@ function getThemeColorForKey(theme: Theme, colors: string[], key: ThemeColorKeys
 /**
  * Obtain color from theme by camel-casing colors.
  */
-function getThemeColor(theme: Theme, colors: string[], key: ThemeColorKeys) {
+function getThemeColor(theme: Theme, colors: string[], key?: ThemeColorKeys) {
   return getThemeColorForKey(theme, colors, key) || getThemeColorForKey(theme, colors, 'colors')
 }
 
@@ -83,7 +83,7 @@ export function splitShorthand(body: string, type: string) {
  * @param theme - {@link Theme} object.
  * @return object if string is parseable.
  */
-export function parseColor(body: string, theme: Theme, key: ThemeColorKeys): ParsedColorValue | undefined {
+export function parseColor(body: string, theme: Theme, key?: ThemeColorKeys): ParsedColorValue | undefined {
   const [main, opacity] = splitShorthand(body, 'color')
 
   const colors = main
@@ -177,7 +177,7 @@ export function parseColor(body: string, theme: Theme, key: ThemeColorKeys): Par
  * @param [shouldPass] - Function to decide whether to pass the css.
  * @return object.
  */
-export function colorResolver(property: string, varName: string, key: ThemeColorKeys, shouldPass?: (css: CSSObject) => boolean): DynamicMatcher {
+export function colorResolver(property: string, varName: string, key?: ThemeColorKeys, shouldPass?: (css: CSSObject) => boolean): DynamicMatcher {
   return ([, body]: string[], { theme }: RuleContext<Theme>): CSSObject | undefined => {
     const data = parseColor(body, theme, key)
 

--- a/packages/preset-mini/src/_utils/utilities.ts
+++ b/packages/preset-mini/src/_utils/utilities.ts
@@ -22,11 +22,10 @@ export function directionSize(propertyPrefix: string): DynamicMatcher {
   }
 }
 
-/**
- * Obtain color from theme by camel-casing colors.
- */
-function getThemeColor(theme: Theme, colors: string[]) {
-  let obj: Theme['colors'] | string = theme.colors
+type ThemeColorKeys = 'colors' | 'borderColor' | 'backgroundColor' | 'textColor' | 'shadowColor' | 'accentColor'
+
+function getThemeColorForKey(theme: Theme, colors: string[], key: ThemeColorKeys = 'colors') {
+  let obj = theme[key] as Theme['colors'] | string
   let index = -1
 
   for (const c of colors) {
@@ -45,6 +44,13 @@ function getThemeColor(theme: Theme, colors: string[]) {
   }
 
   return obj
+}
+
+/**
+ * Obtain color from theme by camel-casing colors.
+ */
+function getThemeColor(theme: Theme, colors: string[], key: ThemeColorKeys) {
+  return getThemeColorForKey(theme, colors, key) || getThemeColorForKey(theme, colors, 'colors')
 }
 
 /**
@@ -77,7 +83,7 @@ export function splitShorthand(body: string, type: string) {
  * @param theme - {@link Theme} object.
  * @return object if string is parseable.
  */
-export function parseColor(body: string, theme: Theme): ParsedColorValue | undefined {
+export function parseColor(body: string, theme: Theme, key: ThemeColorKeys): ParsedColorValue | undefined {
   const [main, opacity] = splitShorthand(body, 'color')
 
   const colors = main
@@ -105,7 +111,7 @@ export function parseColor(body: string, theme: Theme): ParsedColorValue | undef
   color = color || bracket
 
   if (!color) {
-    const colorData = getThemeColor(theme, [main])
+    const colorData = getThemeColor(theme, [main], key)
     if (typeof colorData === 'string')
       color = colorData
   }
@@ -116,17 +122,17 @@ export function parseColor(body: string, theme: Theme): ParsedColorValue | undef
     const [scale] = colors.slice(-1)
     if (scale.match(/^\d+$/)) {
       no = scale
-      colorData = getThemeColor(theme, colors.slice(0, -1))
+      colorData = getThemeColor(theme, colors.slice(0, -1), key)
       if (!colorData || typeof colorData === 'string')
         color = undefined
       else
         color = colorData[no] as string
     }
     else {
-      colorData = getThemeColor(theme, colors)
+      colorData = getThemeColor(theme, colors, key)
       if (!colorData && colors.length <= 2) {
         [, no = no] = colors
-        colorData = getThemeColor(theme, [name])
+        colorData = getThemeColor(theme, [name], key)
       }
       if (typeof colorData === 'string')
         color = colorData
@@ -171,9 +177,9 @@ export function parseColor(body: string, theme: Theme): ParsedColorValue | undef
  * @param [shouldPass] - Function to decide whether to pass the css.
  * @return object.
  */
-export function colorResolver(property: string, varName: string, shouldPass?: (css: CSSObject) => boolean): DynamicMatcher {
+export function colorResolver(property: string, varName: string, key: ThemeColorKeys, shouldPass?: (css: CSSObject) => boolean): DynamicMatcher {
   return ([, body]: string[], { theme }: RuleContext<Theme>): CSSObject | undefined => {
-    const data = parseColor(body, theme)
+    const data = parseColor(body, theme, key)
 
     if (!data)
       return
@@ -215,8 +221,8 @@ export function colorableShadows(shadows: string | string[], colorVar: string) {
   return colored
 }
 
-export function hasParseableColor(color: string | undefined, theme: Theme) {
-  return color != null && !!parseColor(color, theme)?.color
+export function hasParseableColor(color: string | undefined, theme: Theme, key: ThemeColorKeys) {
+  return color != null && !!parseColor(color, theme, key)?.color
 }
 
 export function resolveBreakpoints({ theme, generator }: Readonly<VariantContext<Theme>>, key: 'breakpoints' | 'verticalBreakpoints' = 'breakpoints') {

--- a/packages/preset-wind/src/rules/background.ts
+++ b/packages/preset-wind/src/rules/background.ts
@@ -23,7 +23,7 @@ function bgGradientColorValue(mode: string, cssColor: CSSColorValue | undefined,
 
 function bgGradientColorResolver() {
   return ([, mode, body]: string[], { theme }: RuleContext<Theme>) => {
-    const data = parseColor(body, theme)
+    const data = parseColor(body, theme, 'backgroundColor')
 
     if (!data)
       return

--- a/packages/preset-wind/src/rules/behaviors.ts
+++ b/packages/preset-wind/src/rules/behaviors.ts
@@ -44,12 +44,12 @@ export const listStyle: Rule[] = [
 ]
 
 export const accents: Rule[] = [
-  [/^accent-(.+)$/, colorResolver('accent-color', 'accent'), { autocomplete: 'accent-$colors' }],
+  [/^accent-(.+)$/, colorResolver('accent-color', 'accent', 'accentColor'), { autocomplete: 'accent-$colors' }],
   [/^accent-op(?:acity)?-?(.+)$/, ([, d]) => ({ '--un-accent-opacity': h.bracket.percent(d) }), { autocomplete: ['accent-(op|opacity)', 'accent-(op|opacity)-<percent>'] }],
 ]
 
 export const carets: Rule[] = [
-  [/^caret-(.+)$/, colorResolver('caret-color', 'caret'), { autocomplete: 'caret-$colors' }],
+  [/^caret-(.+)$/, colorResolver('caret-color', 'caret', 'textColor'), { autocomplete: 'caret-$colors' }],
   [/^caret-op(?:acity)?-?(.+)$/, ([, d]) => ({ '--un-caret-opacity': h.bracket.percent(d) }), { autocomplete: ['caret-(op|opacity)', 'caret-(op|opacity)-<percent>'] }],
 ]
 

--- a/packages/preset-wind/src/rules/divide.ts
+++ b/packages/preset-wind/src/rules/divide.ts
@@ -13,7 +13,7 @@ export const divides: Rule[] = [
   [/^divide-(block|inline)-reverse$/, ([, d]) => ({ [`--un-divide-${d}-reverse`]: 1 })],
 
   // color & opacity
-  [/^divide-(.+)$/, colorResolver('border-color', 'divide'), { autocomplete: 'divide-$colors' }],
+  [/^divide-(.+)$/, colorResolver('border-color', 'divide', 'borderColor'), { autocomplete: 'divide-$colors' }],
   [/^divide-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-divide-opacity': h.bracket.percent(opacity) }), { autocomplete: ['divide-(op|opacity)', 'divide-(op|opacity)-<percent>'] }],
 
   // styles

--- a/packages/preset-wind/src/rules/filters.ts
+++ b/packages/preset-wind/src/rules/filters.ts
@@ -102,7 +102,7 @@ export const filters: Rule<Theme>[] = [
       'drop-shadow-color-(op|opacity)-<percent>',
     ],
   }],
-  [/^(?:filter-)?drop-shadow-color-(.+)$/, colorResolver('--un-drop-shadow-color', 'drop-shadow')],
+  [/^(?:filter-)?drop-shadow-color-(.+)$/, colorResolver('--un-drop-shadow-color', 'drop-shadow', 'shadowColor')],
   [/^(?:filter-)?drop-shadow-color-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-drop-shadow-opacity': h.bracket.percent(opacity) })],
   [/^(?:(backdrop-)|filter-)?grayscale(?:-(.+))?$/, toFilter('grayscale', percentWithDefault), { autocomplete: ['(backdrop|filter)-grayscale', '(backdrop|filter)-grayscale-<percent>', 'grayscale-<percent>'] }],
   [/^(?:(backdrop-)|filter-)?hue-rotate-(.+)$/, toFilter('hue-rotate', s => h.bracket.cssvar.degree(s))],

--- a/packages/preset-wind/src/rules/placeholder.ts
+++ b/packages/preset-wind/src/rules/placeholder.ts
@@ -4,6 +4,6 @@ import { colorResolver, h } from '@unocss/preset-mini/utils'
 export const placeholders: Rule[] = [
   // The prefix `$ ` is intentional. This rule is not to be matched directly from user-generated token.
   // See variants/placeholder.
-  [/^\$ placeholder-(.+)$/, colorResolver('color', 'placeholder'), { autocomplete: 'placeholder-$colors' }],
+  [/^\$ placeholder-(.+)$/, colorResolver('color', 'placeholder', 'accentColor'), { autocomplete: 'placeholder-$colors' }],
   [/^\$ placeholder-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-placeholder-opacity': h.bracket.percent(opacity) }), { autocomplete: ['placeholder-(op|opacity)', 'placeholder-(op|opacity)-<percent>'] }],
 ]

--- a/packages/preset-wind/src/variants/placeholder.ts
+++ b/packages/preset-wind/src/variants/placeholder.ts
@@ -5,7 +5,7 @@ export const placeholderModifier: VariantFunction = (input: string, { theme }) =
   const m = input.match(/^(.*)\b(placeholder-)(.+)$/)
   if (m) {
     const [, pre = '', p, body] = m
-    if (hasParseableColor(body, theme) || hasOpacityValue(body)) {
+    if (hasParseableColor(body, theme, 'accentColor') || hasOpacityValue(body)) {
       return {
         // Append `placeholder-$ ` (with space!) to the rule to be matched.
         // The `placeholder-` is added for placeholder variant processing, and

--- a/test/preset-mini.test.ts
+++ b/test/preset-mini.test.ts
@@ -353,4 +353,31 @@ describe('preset-mini', () => {
         .text-sm{font-size:0.875rem;line-height:1.25rem;}"
       `)
   })
+
+  it('override colors differently', async () => {
+    const uno = createGenerator({
+      presets: [
+        presetMini(),
+      ],
+      theme: {
+        colors: {
+          blue: {
+            400: 'rgb(0 0 400)',
+          },
+        },
+        textColor: {
+          blue: {
+            400: 'rgb(0 0 700)',
+          },
+        },
+      },
+    })
+
+    expect((await uno.generate('bg-blue-400 text-blue-400', { preflights: false })).css)
+      .toMatchInlineSnapshot(`
+        "/* layer: default */
+        .bg-blue-400{--un-bg-opacity:1;background-color:rgb(0 0 400 / var(--un-bg-opacity));}
+        .text-blue-400{--un-text-opacity:1;color:rgb(0 0 700 / var(--un-text-opacity));}"
+      `)
+  })
 })


### PR DESCRIPTION
Close #3329 

Not all rule get their own theme, but they mostly fall back into a mostly closest property (ex. ring-x: borderColor -> colors). Please let me know if those should be their own color instead (ring-x: ringColor -> colors), or have multiple fallbacks (ring: ringColor -> borderColor -> colors).

Also, netlify is failling on the docs' vitepress. Upgrading should fix the issue