### PR TITLE
feat(preset-mini): add text-pretty css property

### DIFF
--- a/packages/preset-mini/src/_rules/static.ts
+++ b/packages/preset-mini/src/_rules/static.ts
@@ -99,6 +99,7 @@ export const textWraps: Rule[] = [
   ['text-wrap', { 'text-wrap': 'wrap' }],
   ['text-nowrap', { 'text-wrap': 'nowrap' }],
   ['text-balance', { 'text-wrap': 'balance' }],
+  ['text-pretty', { 'text-wrap': 'pretty' }],
 ]
 
 export const textOverflows: Rule[] = [

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -983,6 +983,7 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .text-wrap{text-wrap:wrap;}
 .text-nowrap{text-wrap:nowrap;}
 .text-balance{text-wrap:balance;}
+.text-pretty{text-wrap:pretty;}
 @container (min-width: 10.5rem){
 .\@\[10\.5rem\]-text-red{--un-text-opacity:1;color:rgb(248 113 113 / var(--un-text-opacity));}
 }

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -668,6 +668,7 @@ export const presetMiniTargets: string[] = [
   'text-wrap',
   'text-nowrap',
   'text-balance',
+  'text-pretty',
   'case-upper', // !
   'case-normal', // !
   'case-inherit', // !


### PR DESCRIPTION
## Description:
This PR adds the `.text-pretty` utility to UnoCSS, implementing [text-wrap: pretty](https://developer.chrome.com/blog/css-text-wrap-pretty/);. This feature, supported in Chrome from version 117 as per [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap) and [CanIUse](https://caniuse.com/?search=text-pretty), allows for aesthetically pleasing text wrapping and avoids lingering words.

## Changes:
- New `.text-pretty` class with text-wrap: pretty;.
