### PR TITLE
fix: style comparison error when hotUpdate

### DIFF
--- a/packages/vite/src/modes/vue-scoped.ts
+++ b/packages/vite/src/modes/vue-scoped.ts
@@ -30,14 +30,5 @@ export function VueScopedPlugin({ uno, ready }: UnocssPluginContext): Plugin {
         return
       return transformSFC(code)
     },
-    handleHotUpdate(ctx) {
-      const read = ctx.read
-      if (filter(ctx.file)) {
-        ctx.read = async () => {
-          const code = await read()
-          return await transformSFC(code) || code
-        }
-      }
-    },
   }
 }


### PR DESCRIPTION
FIXED: #3358

I think it need not transform code when hotUpdate. File content comparison when hotUpdate should compare raw code, not transformed code. The transformed code include `unocss:vue-scoped`'s generated code and raw code, generated code is not chaged.

There is a comment from `@vitejs/plugin-vue`
`packages/plugin-vue/src/main.ts`
![image](https://github.com/unocss/unocss/assets/31237954/c8a3cf67-f82b-4bea-b608-7db591188bef)
