### PR TITLE
fix(inspector): codemirror matched utilities miss highlight

### DIFF
--- a/packages/inspector/client/components/ModuleInfo.vue
+++ b/packages/inspector/client/components/ModuleInfo.vue
@@ -75,7 +75,7 @@ const formatted = useCSSPrettify(computed(() => mod.value?.css), isPrettify)
       <Splitpanes>
         <Pane size="50">
           <CodeMirror
-            h-full :model-value="mod.code" :read-only="true" :mode="mode" :matched="mod.matched"
+            h-full :model-value="mod.code" :read-only="true" :mode="mode" :matched="(mod.matched || []).map(i => i.name)"
             class="scrolls module-scrolls" :style="style"
           />
         </Pane>


### PR DESCRIPTION
Before: <img width="1305" alt="image" src="https://github.com/unocss/unocss/assets/42139754/7a9a8f64-7bce-4f67-b61f-9f6c7d42a27b">

After: 
<img width="464" alt="image" src="https://github.com/unocss/unocss/assets/42139754/067d33d8-3ba9-40cb-863f-a14eb872bd62">
