### PR TITLE
fix(vscode): registerUnocss cache rules

### DIFF
--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -97,26 +97,23 @@ async function rootRegister(
     if (cacheFileLookUp.has(url))
       return
 
-    if (!filter(url)) {
-      cacheFileLookUp.add(url)
+    if (!filter(url))
       return
-    }
-
-    if ([...rootCache].some(root => url.startsWith(root))) {
-      // root has been created
-      cacheFileLookUp.add(url)
-      return
-    }
-
-    const configUrl = await findUp(configNames, { cwd: url })
 
     cacheFileLookUp.add(url)
+
+    // root has been created
+    if ([...rootCache].some(root => url.startsWith(root)))
+      return
+
+    const configUrl = await findUp(configNames, { cwd: url })
 
     if (!configUrl)
       return
 
     const cwd = path.dirname(configUrl)
-    rootCache.add(cwd)
+    // Prevent sub-repositories from having the same naming prefix
+    rootCache.add(`${cwd}/`)
 
     await ctx.loadContextInDirectory(cwd)
   }


### PR DESCRIPTION
close: #3426

The original logic is to add all directories with `package.json` to the rootCache, and the outermost ones will also be added. In this way, when matching paths, the matching path of switching sub-repositories will always hit the outermost root path, causing the registration of other sub-repositories to be skipped. Now only the root path where `uno.config` is located is added to the rootCache

![屏幕录制2023-12-07 12 02 10](https://github.com/unocss/unocss/assets/57086651/7ed911dc-4371-4160-ae58-849e598541bd)
