### PR TITLE
docs: fix typo in astro.md

### DIFF
--- a/docs/integrations/astro.md
+++ b/docs/integrations/astro.md
@@ -24,7 +24,7 @@ The UnoCSS integration for [Astro](https://astro.build/): `@unocss/astro`. Check
 ```ts
 // astro.config.ts
 import { defineConfig } from 'astro/config'
-import UnoCSS from 'unocss/astro'
+import UnoCSS from '@unocss/astro'
 
 export default defineConfig({
   integrations: [


### PR DESCRIPTION
_Cannot find module 'unocss/astro'_