### PR TITLE
chore: don't use name as placeholder for doc url in eslint plugin rules

### DIFF
--- a/packages/eslint-plugin/src/rules/blocklist.ts
+++ b/packages/eslint-plugin/src/rules/blocklist.ts
@@ -5,8 +5,7 @@ import { CLASS_FIELDS } from '../constants'
 import { syncAction } from './_'
 import { IGNORE_ATTRIBUTES } from './order-attributify'
 
-export default ESLintUtils.RuleCreator(name => name)({
-  name: 'blocklist',
+export default ESLintUtils.RuleCreator.withoutDocs({
   meta: {
     type: 'problem',
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/order-attributify.ts
+++ b/packages/eslint-plugin/src/rules/order-attributify.ts
@@ -6,8 +6,7 @@ import { syncAction } from './_'
 
 export const IGNORE_ATTRIBUTES = ['style', 'class', 'classname', 'value']
 
-export default ESLintUtils.RuleCreator(name => name)({
-  name: 'order-attributify',
+export default ESLintUtils.RuleCreator.withoutDocs({
   meta: {
     type: 'layout',
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/order.ts
+++ b/packages/eslint-plugin/src/rules/order.ts
@@ -4,8 +4,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import { AST_NODES_WITH_QUOTES, CLASS_FIELDS } from '../constants'
 import { syncAction } from './_'
 
-export default ESLintUtils.RuleCreator(name => name)({
-  name: 'order',
+export default ESLintUtils.RuleCreator.withoutDocs({
   meta: {
     type: 'layout',
     fixable: 'code',


### PR DESCRIPTION
this stops eslint language server from sending an invalid url which some editors like helix won't except

fixes: https://github.com/helix-editor/helix/issues/7143