### PR TITLE
feat(vscode): add rem to px preview on selection style

### DIFF
--- a/packages/vscode/src/configuration.ts
+++ b/packages/vscode/src/configuration.ts
@@ -91,7 +91,7 @@ export function useConfigurations(ext: ExtensionContext) {
       remToPxPreview: false,
       remToPxRatio: 16,
       underline: true,
-      selectionStyle: true
+      selectionStyle: true,
     },
     alias: {
       matchType: 'autocomplete.matchType',

--- a/packages/vscode/src/configuration.ts
+++ b/packages/vscode/src/configuration.ts
@@ -91,6 +91,7 @@ export function useConfigurations(ext: ExtensionContext) {
       remToPxPreview: false,
       remToPxRatio: 16,
       underline: true,
+      selectionStyle: true
     },
     alias: {
       matchType: 'autocomplete.matchType',

--- a/packages/vscode/src/contextLoader.ts
+++ b/packages/vscode/src/contextLoader.ts
@@ -255,7 +255,7 @@ export class ContextLoader {
       return
     registerAutoComplete(this, this.ext)
     registerAnnotations(this, this.status, this.ext)
-    registerSelectionStyle(this)
+    registerSelectionStyle(this, this.ext)
     this._isRegistered = true
   }
 }

--- a/packages/vscode/src/selectionStyle.ts
+++ b/packages/vscode/src/selectionStyle.ts
@@ -1,21 +1,22 @@
 import { MarkdownString, Position, Range, window, workspace } from 'vscode'
 import parserCSS from 'prettier/parser-postcss'
 import prettier from 'prettier/standalone'
-import type { TextEditorSelectionChangeEvent } from 'vscode'
+import type { ExtensionContext, TextEditorSelectionChangeEvent } from 'vscode'
 import { TwoKeyMap, regexScopePlaceholder } from '@unocss/core'
 import { log } from './log'
-import { throttle } from './utils'
+import { addRemToPxComment, throttle } from './utils'
 import type { ContextLoader } from './contextLoader'
 import { getMatchedPositionsFromCode } from './integration'
+import { useConfigurations } from './configuration'
 
-export async function registerSelectionStyle(contextLoader: ContextLoader) {
-  const hasSelectionStyle = (): boolean => workspace.getConfiguration().get('unocss.selectionStyle') ?? true
+export async function registerSelectionStyle(contextLoader: ContextLoader, ext: ExtensionContext) {
+  const {configuration} = useConfigurations(ext)
 
   const integrationDecoration = window.createTextEditorDecorationType({})
 
   async function selectionStyle(editor: TextEditorSelectionChangeEvent) {
     try {
-      if (!hasSelectionStyle())
+      if (!configuration.selectionStyle)
         return reset()
 
       const doc = editor.textEditor.document
@@ -38,6 +39,10 @@ export async function registerSelectionStyle(contextLoader: ContextLoader) {
       if (!ctx)
         return reset()
 
+      const remToPxRatio = configuration.remToPxPreview
+        ? configuration.remToPxRatio
+        : -1
+
       const result = await getMatchedPositionsFromCode(ctx.uno, code)
       if (result.length <= 1)
         return reset()
@@ -55,6 +60,7 @@ export async function registerSelectionStyle(contextLoader: ContextLoader) {
           const tokens = await ctx.uno.parseToken(name, classNamePlaceholder) || []
           tokens.forEach(([, className, cssText, media]) => {
             if (className && cssText) {
+              cssText = addRemToPxComment(cssText, remToPxRatio)
               const selector = className
                 .replace(`.${classNamePlaceholder}`, '&')
                 .replace(regexScopePlaceholder, ' ')

--- a/packages/vscode/src/selectionStyle.ts
+++ b/packages/vscode/src/selectionStyle.ts
@@ -1,4 +1,4 @@
-import { MarkdownString, Position, Range, window, workspace } from 'vscode'
+import { MarkdownString, Position, Range, window } from 'vscode'
 import parserCSS from 'prettier/parser-postcss'
 import prettier from 'prettier/standalone'
 import type { ExtensionContext, TextEditorSelectionChangeEvent } from 'vscode'
@@ -10,7 +10,7 @@ import { getMatchedPositionsFromCode } from './integration'
 import { useConfigurations } from './configuration'
 
 export async function registerSelectionStyle(contextLoader: ContextLoader, ext: ExtensionContext) {
-  const {configuration} = useConfigurations(ext)
+  const { configuration } = useConfigurations(ext)
 
   const integrationDecoration = window.createTextEditorDecorationType({})
 


### PR DESCRIPTION
A little improvement  (**rem to px preview**) to `vscode selection style` 


![image](https://github.com/unocss/unocss/assets/70888488/41e95d22-0e88-449c-9097-3ecca70f0562)
