### PR TITLE
chore: update theme.md for #3221

### DIFF
--- a/docs/config/theme.md
+++ b/docs/config/theme.md
@@ -10,6 +10,11 @@ UnoCSS also supports the theming system that you might be familiar with in Tailw
 
 ## Usage
 
+::: warning
+Since [v0.57.0](https://github.com/unocss/unocss/releases/tag/v0.57.0), UnoCSS does not support the legacy comma syntax for `rgb()` and `hsl()` any more.
+Make sure that all specified `theme` value use spaces.
+:::
+
 <!--eslint-skip-->
 
 ```ts


### PR DESCRIPTION
Adds a warning to the docs regarding #3221 

When I upgraded, it took me a while to dig through the commits to find out why my page is suddenly broken (especially since the commit in the CHANGELOG is really not helpful if you do not know how the Tailwind standard is).

So I figured a small warning in the docs can't hurt