### PR TITLE
doc(attributify): point transformer-attributify-jsx link to doc page

### DIFF
--- a/docs/presets/attributify.md
+++ b/docs/presets/attributify.md
@@ -107,7 +107,7 @@ now can be
 ```
 
 ::: info
-Note: If you are using JSX, `<div foo>` might be transformed to `<div foo={true}>` which will make the generated CSS from UnoCSS fail to match the attributes. To solve this, you might want to try [`transformer-attributify-jsx`](https://github.com/unocss/unocss/tree/main/packages/transformer-attributify-jsx) along with this preset.
+Note: If you are using JSX, `<div foo>` might be transformed to `<div foo={true}>` which will make the generated CSS from UnoCSS fail to match the attributes. To solve this, you might want to try [`transformer-attributify-jsx`](/transformers/attributify-jsx) along with this preset.
 :::
 
 ## Properties conflicts


### PR DESCRIPTION
In https://unocss.dev/presets/attributify, make the "transformer-attributify-jsx" link point to https://unocss.dev/transformers/attributify-jsx instead of the github source code