### PR TITLE
fix(webpack): HMR not work on Windows

### DIFF
--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -1,4 +1,5 @@
 import process from 'node:process'
+import { isAbsolute, normalize } from 'node:path'
 import type { UserConfig, UserConfigDefaults } from '@unocss/core'
 import type { ResolvedUnpluginOptions, UnpluginOptions } from 'unplugin'
 import { createUnplugin } from 'unplugin'
@@ -155,7 +156,10 @@ export default function WebpackPlugin<Theme extends object>(
       lastTokenSize = tokens.size
       Array.from(plugin.__vfsModules)
         .forEach((id) => {
-          const path = decodeURIComponent(id.slice(plugin.__virtualModulePrefix.length))
+          let path = decodeURIComponent(id.slice(plugin.__virtualModulePrefix.length))
+          // unplugin changes the id in the `load` hook, follow it
+          // https://github.com/unjs/unplugin/pull/145/files#diff-2b106437404a793ee5b8f3823344656ce880f698d3d8cb6a7cf785e36fb4bf5cR27
+          path = normalizeAbsolutePath(path)
           const layer = resolveLayer(path)
           if (!layer)
             return
@@ -181,4 +185,12 @@ function getLayer(id: string) {
       layer = resolveLayer(entry)
   }
   return layer
+}
+
+// https://github.com/unjs/unplugin/pull/145/files#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R13-R19
+function normalizeAbsolutePath(path: string) {
+  if (isAbsolute(path))
+    return normalize(path)
+  else
+    return path
 }


### PR DESCRIPTION
### Describe

---

Unplugin will also normalize absolute path since [0.9.0](https://github.com/unjs/unplugin/pull/145/files#diff-2b106437404a793ee5b8f3823344656ce880f698d3d8cb6a7cf785e36fb4bf5cR27) .

ref:

- https://github.com/unocss/unocss/pull/2296

### Reproduction

---

- On **Windows** .

- Use [vue-cli5](https://github.com/unocss/unocss/tree/main/examples/vue-cli5) with default [css.extract](https://cli.vuejs.org/config/#css-extract) ( `false` ) .

  ```diff
  - css: {
  -   extract: process.env.NODE_ENV === 'development'
  -     ? {
  -         filename: 'css/[name].css',
  -         chunkFilename: 'css/[name].css',
  -       }
  -     : true,
  - },
  ```

You can see it when debugging:

- The **path** in [updateModules](https://github.com/unocss/unocss/blob/08c1d16484ad506b2e477a04fe0d0bea993e5259/packages/webpack/src/index.ts#L168C15-L168C15) is `/__uno.css` .

- The **id** in [load](https://github.com/unocss/unocss/blob/08c1d16484ad506b2e477a04fe0d0bea993e5259/packages/webpack/src/index.ts#L97) is `\__uno.css` which use **backslash** , so the **hash** is always `undefined` .

![image](https://github.com/unocss/unocss/assets/13103906/47a7b54c-5d53-413b-adb3-415b8e3a33a7)

### PS

---

This `normalizeAbsolutePath` is really bad, it only works on absolute paths on Windows ( but the `/foo/bar` is not strictly a Windows absolute path ) , and is meaningless for other situations.

Now some places use `normalizeAbsolutePath` for conversion, and some places are missing, which makes it very confusing. This is very unfriendly to **Windows users** , because some inexplicable problems always occur due to missing conversions in some places, and it is very difficult to troubleshoot the problem.

My opinion: if all places where paths are used are converted to slashes or relative paths relative to the project root, then if you see backslashes, you can quickly realize that there is a problem here.
