### PR TITLE
docs: update `content` source comment(also docs)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -736,7 +736,7 @@ export interface PluginOptions {
    *
    * Supported sources:
    * - `filesystem` - extract from file system
-   * - `plain` - extract from plain inline text
+   * - `inline` - extract from plain inline text
    * - `pipeline` - extract from build tools' transformation pipeline, such as Vite and Webpack
    *
    * The usage extracted from each source will be **merged** together.


### PR DESCRIPTION
Since `plain` has been marked as `deprecated` and replaced by `inline`,  the comment should be updated (which also affects the documentation) to avoid confusion.

https://unocss.dev/config/#content
<img width="854" alt="image" src="https://github.com/unocss/unocss/assets/32707098/5c6f0a44-7c0e-4b80-8242-30078f97b291">
