### PR TITLE
fix(attributify): add `position` type for jsx

### DIFF
--- a/packages/preset-attributify/src/jsx.ts
+++ b/packages/preset-attributify/src/jsx.ts
@@ -109,6 +109,7 @@ export type SeparateEnabled =
   | 'p'
   | 'place'
   | 'pos'
+  | 'position'
   | 'ring'
   | 'select'
   | 'shadow'


### PR DESCRIPTION
Generally `position="absolute"` makes better sense than `pos="absolute"` if user wants to use key-value paired attributify mode.
It's currently forced to key-value pair because of #3471 