### PR TITLE
fix(attributify): add some missing types for jsx

### DIFF
--- a/packages/preset-attributify/src/jsx.ts
+++ b/packages/preset-attributify/src/jsx.ts
@@ -8,6 +8,8 @@ export type TwoStringsCompositionSuffix =
   | 'l'
   | 't'
   | 'a'
+  | 'x'
+  | 'y'
 
 /** Some words can compose with two strings to become a complete unocss rule such as ha, mr, mb */
 export type TwoStringsComposition = `${TwoStringsCompositionPrefix}${TwoStringsCompositionSuffix}` | 'ha' | 'wa'
@@ -113,6 +115,7 @@ export type SeparateEnabled =
   | 'ring'
   | 'select'
   | 'shadow'
+  | 'size'
   | 'space'
   | 'table'
   | 'text'


### PR DESCRIPTION
Add `size="..."` and `px` / `py` , `mx` \ `my`