### PR TITLE
chore: update iconify utils package

### DIFF
--- a/packages/preset-icons/package.json
+++ b/packages/preset-icons/package.json
@@ -51,7 +51,7 @@
     "stub": "unbuild --stub"
   },
   "dependencies": {
-    "@iconify/utils": "^2.1.18",
+    "@iconify/utils": "^2.1.20",
     "@unocss/core": "workspace:*",
     "ofetch": "^1.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -787,8 +787,8 @@ importers:
   packages/preset-icons:
     dependencies:
       '@iconify/utils':
-        specifier: ^2.1.18
-        version: 2.1.18
+        specifier: ^2.1.20
+        version: 2.1.20
       '@unocss/core':
         specifier: workspace:*
         version: link:../core
@@ -3596,8 +3596,8 @@ packages:
   /@iconify/types@2.0.0:
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  /@iconify/utils@2.1.18:
-    resolution: {integrity: sha512-gmykhiCUWIqTHLcBPpvsEanXuc+jbG7Hg43zldmgLAtSVAt63j9tqEfpXF5ML2+BiYLiBcTbdfktSxcCDVQC8A==}
+  /@iconify/utils@2.1.20:
+    resolution: {integrity: sha512-t8TeKlYK/5i9yTY9VAGAE4P0qQHd/0vH+VSRO+bdpxlt8wqB6f2I0/IrciRsdeFZPMoL8IICgP7lgl2ZtbG8Tw==}
     dependencies:
       '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.7.7


### PR DESCRIPTION
To include new node icon loader helper: `createExternalPackageIconLoader`