### PR TITLE
feat(preset-mini): allow shorter syntax for grid-cols utilities (#3533)

### DIFF
--- a/packages/preset-mini/src/_rules/grid.ts
+++ b/packages/preset-mini/src/_rules/grid.ts
@@ -58,8 +58,8 @@ export const grids: Rule<Theme>[] = [
   [/^grid-(rows|cols)-(.+)$/, ([, c, v], { theme }) => ({
     [`grid-template-${rowCol(c)}`]: theme[`gridTemplate${rowColTheme(c)}`]?.[v] ?? h.bracket.cssvar(v),
   })],
-  [/^grid-(rows|cols)-minmax-([\w.-]+)$/, ([, c, d]) => ({ [`grid-template-${rowCol(c)}`]: `repeat(auto-fill,minmax(${d},1fr))` })],
-  [/^grid-(rows|cols)-(\d+)$/, ([, c, d]) => ({ [`grid-template-${rowCol(c)}`]: `repeat(${d},minmax(0,1fr))` }), { autocomplete: ['grid-(rows|cols)-<num>', 'grid-(rows|cols)-none'] }],
+  [/^(?:grid-)?(rows|cols)-minmax-([\w.-]+)$/, ([, c, d]) => ({ [`grid-template-${rowCol(c)}`]: `repeat(auto-fill,minmax(${d},1fr))` })],
+  [/^(?:grid-)?(rows|cols)-(\d+)$/, ([, c, d]) => ({ [`grid-template-${rowCol(c)}`]: `repeat(${d},minmax(0,1fr))` }), { autocomplete: ['grid-(rows|cols)-<num>', 'grid-(rows|cols)-none'] }],
 
   // areas
   [/^grid-area(s)?-(.+)$/, ([, s, v]) => {


### PR DESCRIPTION
Closes https://github.com/unocss/unocss/issues/3533
Makes `grid-` prefix optional when specifying `grid-cols-[val]` utility.
Before: grid-cols-2
After: cols-2
