### PR TITLE
fix(preset-wind): handle pseudo selector correctly when using `important` string option

### DIFF
--- a/packages/preset-wind/src/index.ts
+++ b/packages/preset-wind/src/index.ts
@@ -19,7 +19,9 @@ export interface PresetWindOptions extends PresetMiniOptions {
    *
    * This can be really useful when using UnoCSS with existing CSS that has high specificity selectors.
    *
-   * You can also set `important` to a selector like `#app` instead, which will generate `#app .m-1 { ... }`
+   * You can also set `important` to a selector like `#app` instead, which will generate `#app :is(.m-1) { ... }`
+   *
+   * Also check out the compatibility with [:is()](https://caniuse.com/?search=%3Ais())
    *
    * @default false
    */

--- a/packages/preset-wind/src/postprocessors/important.ts
+++ b/packages/preset-wind/src/postprocessors/important.ts
@@ -9,6 +9,10 @@ export function important(option: PresetWindOptions['important']): Postprocessor
     if (selector.startsWith(':is(') && selector.endsWith(')'))
       return selector
 
+    // handle pseudo
+    if (selector.includes('::'))
+      return selector.replace(/(.*)(::.*)/, ':is($1)$2')
+
     return `:is(${selector})`
   }
 

--- a/test/assets/output/preset-wind-important-string.css
+++ b/test/assets/output/preset-wind-important-string.css
@@ -1,5 +1,7 @@
 /* layer: default */
+#app :is(.after\:m-4)::after{margin:1rem;}
 #app :is(.important\:scale-100){--un-scale-x:1 !important;--un-scale-y:1 !important;transform:translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z)) rotate(var(--un-rotate)) rotateX(var(--un-rotate-x)) rotateY(var(--un-rotate-y)) rotateZ(var(--un-rotate-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) !important;}
 #app :is(.dark .dark\:bg-blue){--un-bg-opacity:1;background-color:rgb(96 165 250 / var(--un-bg-opacity));}
+#app :is(.selection\:bg-yellow)::selection{--un-bg-opacity:1;background-color:rgb(250 204 21 / var(--un-bg-opacity));}
 #app :is(.text-red){--un-text-opacity:1;color:rgb(248 113 113 / var(--un-text-opacity));}
 #app :is(.text-opacity-50){--un-text-opacity:0.5;}

--- a/test/preset-wind.test.ts
+++ b/test/preset-wind.test.ts
@@ -175,6 +175,8 @@ describe('preset-wind', () => {
         'text-red',
         'important:scale-100',
         'dark:bg-blue',
+        'after:m-4',
+        'selection:bg-yellow',
       ].join(' '), { preflights: false })
 
       await expect(css).toMatchFileSnapshot('./assets/output/preset-wind-important-string.css')


### PR DESCRIPTION
related: https://github.com/unocss/unocss/pull/3484
fix: https://github.com/unocss/unocss/issues/3474