### PR TITLE
feat(preset-mini): support for css property with the theme()

### DIFF
--- a/packages/preset-mini/src/_rules/variables.ts
+++ b/packages/preset-mini/src/_rules/variables.ts
@@ -1,5 +1,5 @@
 import type { Rule } from '@unocss/core'
-import { h, hasThemeFn, transformThemeFn } from '../utils'
+import { h } from '../utils'
 
 const variablesAbbrMap: Record<string, string> = {
   backface: 'backface-visibility',
@@ -26,7 +26,7 @@ export const cssVariables: Rule[] = [
 ]
 
 export const cssProperty: Rule[] = [
-  [/^\[(.*)\]$/, ([_, body], { theme }) => {
+  [/^\[(.*)\]$/, ([_, body]) => {
     if (!body.includes(':'))
       return
 
@@ -34,13 +34,7 @@ export const cssProperty: Rule[] = [
     const value = rest.join(':')
 
     if (!isURI(body) && /^[a-z-]+$/.test(prop) && isValidCSSBody(value)) {
-      let parsed
-
-      if (hasThemeFn(value))
-        parsed = transformThemeFn(value, theme)
-
-      if (!parsed || parsed === value)
-        parsed = h.bracket(`[${value}]`)
+      const parsed = h.bracket(`[${value}]`)
 
       if (parsed)
         return { [prop]: parsed }

--- a/packages/preset-mini/src/_variants/default.ts
+++ b/packages/preset-mini/src/_variants/default.ts
@@ -5,7 +5,7 @@ import { variantBreakpoints } from './breakpoints'
 import { variantCombinators } from './combinators'
 import { variantColorsMediaOrClass } from './dark'
 import { variantLanguageDirections } from './directions'
-import { variantCssLayer, variantInternalLayer, variantScope, variantSelector, variantVariables } from './misc'
+import { variantCssLayer, variantInternalLayer, variantScope, variantSelector, variantTheme, variantVariables } from './misc'
 import { variantNegative } from './negative'
 import { variantImportant } from './important'
 import { variantCustomMedia, variantPrint } from './media'
@@ -43,5 +43,7 @@ export function variants(options: PresetMiniOptions): Variant<Theme>[] {
     variantContainerQuery,
     variantVariables,
     ...variantTaggedDataAttributes,
+
+    variantTheme,
   ]
 }

--- a/packages/preset-mini/src/_variants/misc.ts
+++ b/packages/preset-mini/src/_variants/misc.ts
@@ -1,5 +1,5 @@
 import type { Variant } from '@unocss/core'
-import { getBracket, h, variantGetBracket, variantGetParameter } from '../utils'
+import { getBracket, h, hasThemeFn, transformThemeFn, variantGetBracket, variantGetParameter } from '../utils'
 
 export const variantSelector: Variant = {
   name: 'selector',
@@ -116,4 +116,23 @@ export const variantVariables: Variant = {
     }
   },
   multiPass: true,
+}
+
+export const variantTheme: Variant = {
+  name: 'theme-variables',
+  match(matcher, ctx) {
+    if (!hasThemeFn(matcher))
+      return
+
+    return {
+      matcher,
+      handle(input, next) {
+        return next({
+          ...input,
+          //  entries: [ [ '--css-spacing', '28px' ] ],
+          entries: JSON.parse(transformThemeFn(JSON.stringify(input.entries), ctx.theme)),
+        })
+      },
+    }
+  },
 }

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -131,6 +131,7 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .disabled\:op50:disabled{opacity:0.5;}
 .placeholder-opacity-60::placeholder{opacity:0.6;}
 .\[\&\[data-active\=\"true\"\]\]\:bg-red[data-active="true"]{--un-bg-opacity:1;background-color:rgb(248 113 113 / var(--un-bg-opacity));}
+.bg-\[--css-spacing\,theme\(spacing\.sm\)\]{background-color:var(--css-spacing,0.875rem);}
 .bg-\[--test-variable\],
 .bg-\$test-variable{background-color:var(--test-variable);}
 .bg-\[\#153\]\/10,
@@ -374,6 +375,7 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .text-\[color\:var\(--color-x\)\]\:\[trick\]{color:var(--color-x);}
 .text-\[color\:var\(--color\)\],
 .text-\[var\(--color\)\]{color:var(--color);}
+.text-\[theme\(spacing\.sm\)\]{color:0.875rem;}
 .text-black\/10{color:rgb(0 0 0 / 0.1);}
 .text-red-100,
 .text-red100{--un-text-opacity:1;color:rgb(254 226 226 / var(--un-text-opacity));}
@@ -415,6 +417,7 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .c-\[\#44557733\]\/10,
 .c-\#44557733\/10,
 .c-hex-44557733\/10{color:rgb(68 85 119 / 0.1);}
+.c-\[theme\(colors\.red\.500\/50\%\)\]{color:rgb(239 68 68 / 50%);}
 .c-\$color-variable,
 .c-\$color-variable\/\$opacity-variable,
 .c-\$color-variable\/10{color:var(--color-variable);}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -974,6 +974,9 @@ export const presetMiniTargets: string[] = [
   '[--css-variable-color:theme(colors.red.500/50%)]',
   '[--css-variable-color:theme(colors.green.500),theme(colors.blue.500)]',
   '[--css-spacing:theme(spacing.sm)]',
+  'bg-[--css-spacing,theme(spacing.sm)]',
+  'text-[theme(spacing.sm)]',
+  'c-[theme(colors.red.500/50%)]',
 
   // variants
   'active:scale-4',


### PR DESCRIPTION
Inspiration comes from https://github.com/unocss/unocss/pull/3204

not limited to [], now can support this
```
'bg-[--css-spacing,theme(spacing.sm)]',
'text-[theme(spacing.sm)]',
'c-[theme(colors.red.500/50%)]',
```
