### PR TITLE
fix: import of the example with nextjs is corrected

### DIFF
--- a/examples/next/shims.d.ts
+++ b/examples/next/shims.d.ts
@@ -1,6 +1,6 @@
 // This File is only needed if you use Attributify
 // Learn more: https://unocss.dev/presets/attributify
-import type { AttributifyAttributes } from '@unocss/preset-attributify'
+import type { AttributifyAttributes } from 'unocss/preset-attributify'
 
 declare module 'react' {
   interface HTMLAttributes<T> extends AttributifyAttributes {}


### PR DESCRIPTION
Hello team of Unocss,

I have taken the trouble to correct a problem regarding the import of the `@unocss/preset-attributify` module, since in the nextjs project that package is not installed, which in my opinion can be confusing... So based on the Un Css documentation you can also use the `preset-attributify` extension from the main `unocss` package.

example: 

*before*:

```ts

import type { AttributifyAttributes } from '@unocss/preset-attributify'

declare module 'react' {
  interface HTMLAttributes<T> extends AttributifyAttributes {}
}

```

*after*:

```ts

import type { AttributifyAttributes } from 'unocss/preset-attributify'

declare module 'react' {
  interface HTMLAttributes<T> extends AttributifyAttributes {}
}
```

Thanks for your time 🙏