### PR TITLE
chore(webpack): use processAssets hooks for webpack 5 instead of optimizeAssets as of deprecation

### DIFF
--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -104,7 +104,11 @@ export default function WebpackPlugin<Theme extends object>(
       webpack(compiler) {
         // replace the placeholders
         compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
-          compilation.hooks.optimizeAssets.tapPromise(PLUGIN_NAME, async () => {
+          const optimizeAssetsHook
+          = /* webpack 5 & 6 */ compilation.hooks.processAssets
+          || /* webpack 4 */ compilation.hooks.optimizeAssets
+
+          optimizeAssetsHook.tapPromise(PLUGIN_NAME, async () => {
             const files = Object.keys(compilation.assets)
 
             await flushTasks()


### PR DESCRIPTION
1. `optimizeAssets` was deprecated in favour of `processAssets`. thus prefer `processAssets` to `optimizeAssets` if available.
2. rspack only implements `processAssets`

related: https://github.com/web-infra-dev/rspack/issues/4938
