### PR TITLE
docs(directives): avoid requiring quotes in `--at-apply` causes misun…

### DIFF
--- a/docs/transformers/directives.md
+++ b/docs/transformers/directives.md
@@ -41,7 +41,7 @@ export default defineConfig({
 
 ```css
 .custom-div {
-  @apply text-center my-0 font-medium;
+  @apply text-center my-0 font-medium hover:font-bold;
 }
 ```
 
@@ -53,6 +53,9 @@ Will be transformed to:
   margin-bottom: 0rem;
   text-align: center;
   font-weight: 500;
+}
+.custom-div:hover {
+  font-weight: 700;
 }
 ```
 
@@ -66,7 +69,7 @@ To be compatible with vanilla CSS, you can use CSS custom properties to replace 
 }
 ```
 
-To use rules with `:`, you will have to quote the value:
+To use rules with `:`, you will have to quote the value (not required when using `@apply`):
 
 ```css
 .custom-div {

--- a/docs/transformers/directives.md
+++ b/docs/transformers/directives.md
@@ -41,7 +41,7 @@ export default defineConfig({
 
 ```css
 .custom-div {
-  @apply text-center my-0 font-medium hover:font-bold;
+  @apply text-center my-0 font-medium;
 }
 ```
 
@@ -53,9 +53,6 @@ Will be transformed to:
   margin-bottom: 0rem;
   text-align: center;
   font-weight: 500;
-}
-.custom-div:hover {
-  font-weight: 700;
 }
 ```
 
@@ -69,14 +66,6 @@ To be compatible with vanilla CSS, you can use CSS custom properties to replace 
 }
 ```
 
-To use rules with `:`, you will have to quote the value (not required when using `@apply`):
-
-```css
-.custom-div {
-  --at-apply: "hover:text-red";
-}
-```
-
 This feature is enabled by default with a few aliases, that you can configure or disable via:
 
 ```js
@@ -87,6 +76,20 @@ transformerDirectives({
   // applyVariable: false
 })
 ```
+
+#### Adding quotes
+
+To use rules with `:`, you will have to quote the whole value:
+
+```css
+.custom-div {
+  --at-apply: "hover:text-red hover:font-bold";
+  /* or */
+  @apply 'hover:text-red hover:font-bold';
+}
+```
+
+Using quotes after `@apply` is optional, to meet the behavior of some formatters.
 
 ### `@screen`
 

--- a/packages/transformer-directives/src/apply.ts
+++ b/packages/transformer-directives/src/apply.ts
@@ -24,18 +24,18 @@ export async function parseApply({ code, uno, offset, applyVariable }: Transform
   const calcOffset = (pos: number) => offset ? pos + offset : pos
 
   let body: string | undefined
-  if (childNode.type === 'Atrule' && childNode.name === 'apply' && childNode.prelude && childNode.prelude.type === 'Raw') {
+  if (childNode.type === 'Atrule' && childNode.name === 'apply' && childNode.prelude && childNode.prelude.type === 'Raw')
     body = childNode.prelude.value.trim()
-  }
-  else if (childNode!.type === 'Declaration' && applyVariable.includes(childNode.property) && childNode.value.type === 'Raw') {
+
+  else if (childNode!.type === 'Declaration' && applyVariable.includes(childNode.property) && childNode.value.type === 'Raw')
     body = childNode.value.value.trim()
-    // remove quotes
-    if (/^(['"]).*\1$/.test(body))
-      body = body.slice(1, -1)
-  }
 
   if (!body)
     return
+
+  // remove quotes
+  if (/^(['"]).*\1$/.test(body))
+    body = body.slice(1, -1)
 
   const classNames = expandVariantGroup(body)
     .split(/\s+/g)

--- a/test/transformer-directives.test.ts
+++ b/test/transformer-directives.test.ts
@@ -1,12 +1,12 @@
 import { readFile } from 'node:fs/promises'
-import { describe, expect, it } from 'vitest'
-import { transformDirectives } from '@unocss/transformer-directives'
 import type { UnoGenerator } from '@unocss/core'
 import { createGenerator } from '@unocss/core'
 import presetUno from '@unocss/preset-uno'
-import prettier from 'prettier/standalone'
-import parserCSS from 'prettier/parser-postcss'
+import { transformDirectives } from '@unocss/transformer-directives'
 import MagicString from 'magic-string'
+import parserCSS from 'prettier/parser-postcss'
+import prettier from 'prettier/standalone'
+import { describe, expect, it } from 'vitest'
 
 describe('transformer-directives', () => {
   const uno = createGenerator({
@@ -60,7 +60,10 @@ describe('transformer-directives', () => {
 
   it('basic', async () => {
     const result = await transform(
-      '.btn { @apply rounded text-lg font-mono; }',
+      `.btn {
+        @apply rounded text-lg;
+        @apply 'font-mono';
+      }`,
     )
     await expect(result)
       .toMatchInlineSnapshot(`


### PR DESCRIPTION
In issue #3574 a user has used `@apply 'hover:bg-red'`  (for exmaple) in which the quotes are actually not required. ONLY `--at-appy` needs them. The doc should be fixed to avoid this misunderstanding.