### PR TITLE
fix(preset-mini): handle arbitrary gradients correctly

### DIFF
--- a/packages/preset-mini/src/_rules/color.ts
+++ b/packages/preset-mini/src/_rules/color.ts
@@ -11,6 +11,7 @@ export const opacity: Rule[] = [
 const bgUrlRE = /^\[url\(.+\)\]$/
 const bgLengthRE = /^\[length:.+\]$/
 const bgPositionRE = /^\[position:.+\]$/
+const bgGradientRE = /^\[(linear|conic|radial)-gradient\(.+\)\]$/
 export const bgColors: Rule[] = [
   [/^bg-(.+)$/, (...args) => {
     const d = args[0][1]
@@ -20,6 +21,8 @@ export const bgColors: Rule[] = [
       return { 'background-size': h.bracketOfLength(d)!.split(' ').map(e => h.fraction.auto.px.cssvar(e) ?? e).join(' ') }
     if ((isSize(d) || bgPositionRE.test(d)) && h.bracketOfPosition(d) != null)
       return { 'background-position': h.bracketOfPosition(d)!.split(' ').map(e => h.position.fraction.auto.px.cssvar(e) ?? e).join(' ') }
+    if (bgGradientRE.test(d))
+      return { 'background-image': h.bracket(d) }
     return colorResolver('background-color', 'bg', 'backgroundColor')(...args)
   }, { autocomplete: 'bg-$colors' }],
   [/^bg-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-bg-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: 'bg-(op|opacity)-<percent>' }],

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -142,14 +142,17 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .bg-\[10vw\]{background-position:10vw;}
 .bg-\[calc\(10\%\+10px\)\]{background-position:calc(10% + 10px);}
 .bg-\[calc\(10vw\+10px\)\]{background-position:calc(10vw + 10px);}
+.bg-\[conic-gradient\(red\,blue\)\]{background-image:conic-gradient(red,blue);}
 .bg-\[length\:--variable\]{background-size:var(--variable);}
 .bg-\[length\:1\/2_20rem\]{background-size:50% 20rem;}
 .bg-\[length\:10_20rem\]{background-size:10px 20rem;}
+.bg-\[linear-gradient\(45deg\,\#0072ff\,\#00d2e8\,\#04fd8f\,\#70fd6c\)\]{background-image:linear-gradient(45deg,#0072ff,#00d2e8,#04fd8f,#70fd6c);}
 .bg-\[position\:--variable\]{background-position:var(--variable);}
 .bg-\[position\:1\/2_20rem\]{background-position:50% 20rem;}
 .bg-\[position\:10_20rem\]{background-position:10px 20rem;}
 .bg-\[position\:bottom_left_10\%\]{background-position:bottom left 10%;}
 .bg-\[position\:top_right_1\/3\]{background-position:top right 33.3333333333%;}
+.bg-\[radial-gradient\(red\,blue\)\]{background-image:radial-gradient(red,blue);}
 .bg-\[rgb\(4_5_6\/0\.7\)\]\/\[calc\(100\/3\)\]{background-color:rgb(4 5 6 / calc(100 / 3));}
 .bg-\[rgba\(1\,2\,3\,0\.5\)\]{--un-bg-opacity:0.5;background-color:rgba(1, 2, 3, var(--un-bg-opacity));}
 .bg-\[rgba\(4_5_6\/0\.7\)\]{--un-bg-opacity:0.7;background-color:rgba(4, 5, 6, var(--un-bg-opacity));}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -282,6 +282,11 @@ export const presetMiniTargets: string[] = [
   'bg-[position:bottom_left_10%]',
   'bg-[position:top_right_1/3]',
 
+  // arbitrary gradients
+  'bg-[linear-gradient(45deg,#0072ff,#00d2e8,#04fd8f,#70fd6c)]',
+  'bg-[conic-gradient(red,blue)]',
+  'bg-[radial-gradient(red,blue)]',
+
   // color - ring
   'ring-red2',
   'ring-red2/5',


### PR DESCRIPTION
This PR makes arbitrary gradients in bg-[] work by returning background-image instead of background-color when linear-gradient/conic-gradient/radial-gradient are detected.

fixes unocss#3581

before:
![brave-2024-03-01-16-44-brave_dLkrF2n6Fx](https://github.com/unocss/unocss/assets/110549389/98464c37-8e87-4ff9-891c-45bc3d1cd09e)

after:
![brave-2024-03-01-16-44-brave_DvVctQOvej](https://github.com/unocss/unocss/assets/110549389/109a815c-34b9-45be-960c-d9fc6c9e9eae)

```
<div class="bg-[linear-gradient(45deg,#0072ff,#00d2e8,#04fd8f,#70fd6c)] border-1 h-64 w-64 flex items-center text-center"></div>

<div class="bg-[conic-gradient(red,blue)] border-1 h-64 w-64 flex items-center text-center"></div>

<div class="bg-[radial-gradient(red,blue)] border-1 h-64 w-64 flex items-center text-center"></div>
```
