### PR TITLE
feat(preset-mini): add popover-open pseudo variant

### DIFF
--- a/packages/preset-mini/src/_variants/pseudo.ts
+++ b/packages/preset-mini/src/_variants/pseudo.ts
@@ -48,6 +48,7 @@ const PseudoClasses: Record<string, string> = Object.fromEntries([
   'active',
   'enabled',
   'disabled',
+  'popover-open',
 
   // tree-structural
   'root',


### PR DESCRIPTION
This PR adds a variant `popover-open` to add support for the experimental popover-open pseudo class. This can then be used to have two animations, one that plays when the popover is opened and one that is played when it is closed. (and more)

For transitions to work correctly when using opacity and so on support for @starting-style will have to be added somehow: https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style

fixes #3605

example:
![popover-open](https://github.com/unocss/unocss/assets/110549389/aee467c7-1020-42c2-b1a3-40ae50ff236e)

```
<button popovertarget="my-styled-popover">Open styled Popover</button>

<div class="m-0 top-20 p-4 mx-auto animate-[custom-slide-out_0.4s_ease] 
  popover-open:animate-[custom-slide-in_0.4s_ease]
  backdrop:bg-blue-900 transition-all" 
  popover id="my-styled-popover">Greetings, one and all! (styled popover)</div>
```

custom CSS:
```
@keyframes custom-slide-in{from{display:block;transform:translate3d(0,-100%,0);opacity:0%}to{transform:translate3d(0,0,0);opacity:100%}}
@keyframes custom-slide-out{from{display:block;transform:translate3d(0,0,0);opacity:100%}to{transform:translate3d(0,-100%,0);opacity:0%}}
```
