### PR TITLE
fix(vscode): completion color

### DIFF
--- a/packages/vscode/src/utils.ts
+++ b/packages/vscode/src/utils.ts
@@ -145,7 +145,10 @@ export function getColorString(str: string) {
   // if (!(new TinyColor(colorString).isValid))
   //   return
 
-  return colorString
+  if (/\/\)/.test(colorString))
+    colorString = colorString.replace(/ \/\)/g, '/ 1)')
+
+  return convertToRGBA(colorString)
 }
 
 export function isSubdir(parent: string, child: string) {
@@ -159,4 +162,21 @@ export function isFulfilled<T>(result: PromiseSettledResult<T>): result is Promi
 
 export function isRejected(result: PromiseSettledResult<unknown>): result is PromiseRejectedResult {
   return result.status === 'rejected'
+}
+
+export function convertToRGBA(rgbColor: string) {
+  const match = rgbColor.match(/rgb\((\d+)\s+(\d+)\s+(\d+)\s*\/\s*([\d.]+)\)/)
+
+  if (match) {
+    const r = Number.parseInt(match[1])
+    const g = Number.parseInt(match[2])
+    const b = Number.parseInt(match[3])
+    const alpha = Number.parseFloat(match[4])
+
+    const rgbaColor = `rgba(${r}, ${g}, ${b}, ${alpha})`
+
+    return rgbaColor
+  }
+
+  return rgbColor
 }


### PR DESCRIPTION
At present, vscode does not seem to support the use of rgb (r g b / a) form. I think it can be temporarily converted to rgba form and give color tips. If vscode supports it later, it will be removed.

![image](https://github.com/unocss/unocss/assets/57086651/d353baec-1f43-4054-bb76-fca9c5a14ef3)

![image](https://github.com/unocss/unocss/assets/57086651/b658d65f-d990-455f-b82a-3188a6bee73c)

![image](https://github.com/unocss/unocss/assets/57086651/51b2c0cf-4ca3-4799-85ef-f16c7e9b33be)
