### PR TITLE
fix: cli will now reload config more than once (or twice)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -82,6 +82,8 @@ export async function build(_options: CliOptions) {
 
       if (configSources.includes(absolutePath)) {
         await ctx.reloadConfig()
+        if (configSources.length)
+          watcher.add(configSources)
         consola.info(`${cyan(basename(file))} changed, setting new config`)
       }
       else {


### PR DESCRIPTION
Before this commit config reloading stopped after first reload (archlinux) or after second reload (ubuntu 22.04).