### PR TITLE
docs(sveltekit): Fix broken vitePreprocess imports in example SvelteKit projects 

### DIFF
--- a/docs/integrations/svelte-scoped.md
+++ b/docs/integrations/svelte-scoped.md
@@ -274,7 +274,7 @@ Add `@unocss/svelte-scoped/preprocess` to your Svelte config:
 ```ts
 // svelte.config.js
 import adapter from '@sveltejs/adapter-auto'
-import { vitePreprocess } from '@sveltejs/kit/vite'
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 import UnoCSS from '@unocss/svelte-scoped/preprocess'
 
 const config = {

--- a/examples/sveltekit-preprocess/package.json
+++ b/examples/sveltekit-preprocess/package.json
@@ -28,6 +28,7 @@
     "@sveltejs/adapter-auto": "^3.1.1",
     "@sveltejs/kit": "^2.5.4",
     "@sveltejs/package": "^2.3.0",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@unocss/core": "link:../../packages/core",
     "@unocss/preset-icons": "link:../../packages/preset-icons",
     "@unocss/svelte-scoped": "link:../../packages/svelte-scoped",

--- a/examples/sveltekit-preprocess/svelte.config.js
+++ b/examples/sveltekit-preprocess/svelte.config.js
@@ -1,5 +1,5 @@
 import adapter from '@sveltejs/adapter-auto'
-import { vitePreprocess } from '@sveltejs/kit/vite'
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 import UnoCSS from '@unocss/svelte-scoped/preprocess'
 
 /** @type {import('@sveltejs/kit').Config} */

--- a/examples/sveltekit-scoped/package.json
+++ b/examples/sveltekit-scoped/package.json
@@ -14,6 +14,7 @@
     "@julr/unocss-preset-forms": "^0.1.0",
     "@sveltejs/adapter-auto": "^3.1.1",
     "@sveltejs/kit": "^2.5.4",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@unocss/core": "link:../../packages/core",
     "@unocss/preset-icons": "link:../../packages/preset-icons",
     "@unocss/svelte-scoped": "link:../../packages/svelte-scoped",

--- a/examples/sveltekit-scoped/svelte.config.js
+++ b/examples/sveltekit-scoped/svelte.config.js
@@ -1,4 +1,4 @@
-import { vitePreprocess } from '@sveltejs/kit/vite'
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 import adapter from '@sveltejs/adapter-auto'
 
 /** @type {import('@sveltejs/kit').Config} */

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -13,6 +13,7 @@
     "@iconify/utils": "^2.1.22",
     "@sveltejs/adapter-auto": "^3.1.1",
     "@sveltejs/kit": "^2.5.4",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@unocss/core": "link:../../packages/core",
     "@unocss/extractor-svelte": "link:../../packages/extractor-svelte",
     "@unocss/preset-icons": "link:../../packages/preset-icons",

--- a/examples/sveltekit/svelte.config.js
+++ b/examples/sveltekit/svelte.config.js
@@ -1,5 +1,5 @@
 import adapter from '@sveltejs/adapter-auto'
-import { vitePreprocess } from '@sveltejs/kit/vite'
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
SvelteKit 2 no longer exports `vitePreprocess` so it has to be exported directly from `@sveltejs/vite-plugin-svelte`.