### PR TITLE
fix(postcss): move to ESM first + dual ESM/CJS + missing `@unocss/postcss/esm` subpackage export

### DIFF
--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@unocss/postcss",
+  "type": "module",
   "version": "0.59.0-beta.1",
   "description": "PostCSS plugin for UnoCSS",
   "author": "sibbng <sibbngheid@gmail.com>",
@@ -18,13 +19,31 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./esm": {
+      "types": "./dist/esm.d.mts",
+      "default": "./dist/esm.mjs"
     }
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*",
+        "./*"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Part of https://github.com/unocss/unocss/issues/3675

![imagen](https://github.com/unocss/unocss/assets/6311119/9064dca4-11c6-49b4-9e54-a32e164917ba)
