### PR TITLE
fix(webpack): correctly output CSS string

### DIFF
--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -130,6 +130,7 @@ export default function WebpackPlugin<Theme extends object>(
                 return
 
               let code = compilation.assets[file].source().toString()
+              let escapeCss: ReturnType<typeof getCssEscaperForJsContent>
               let replaced = false
               code = code.replace(HASH_PLACEHOLDER_RE, '')
               code = code.replace(LAYER_PLACEHOLDER_RE, (_, layer, escapeView) => {
@@ -139,7 +140,7 @@ export default function WebpackPlugin<Theme extends object>(
                     .map(i => resolveLayer(i)).filter((i): i is string => !!i))
                   : (result.getLayer(layer) || '')
 
-                const escapeCss = getCssEscaperForJsContent(escapeView)
+                escapeCss = escapeCss ?? getCssEscaperForJsContent(escapeView)
 
                 return escapeCss(css)
               })


### PR DESCRIPTION
fix: #3652 

Repeated calls to the `getCssEscaperForJsContent` function result in multiple escapes of special characters, leading to errors when Webpack invokes the `eval` function.

The incorrect output is:
`.after\\\:content-empty::after{content:\\"\\";}`

And the correct output should be:
`.after\:content-empty::after{content:\"\";}`