### PR TITLE
chore: include `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
When submitting PR 3717 after running tests on my local (I know I can fix it using git commands...):

![imagen](https://github.com/unocss/unocss/assets/6311119/bd089803-0f11-4387-8caa-10455f7848d9)
