### PR TITLE
fix(preset-mini): use `borderRadius` from theme to autosuggest `rounded` values

### DIFF
--- a/packages/preset-mini/src/_rules/border.ts
+++ b/packages/preset-mini/src/_rules/border.ts
@@ -35,7 +35,7 @@ export const borders: Rule[] = [
   [/^(?:border|b)-([bi][se])-op(?:acity)?-?(.+)$/, handlerBorderOpacity],
 
   // radius
-  [/^(?:border-|b-)?(?:rounded|rd)()(?:-(.+))?$/, handlerRounded, { autocomplete: ['(border|b)-(rounded|rd)', '(border|b)-(rounded|rd)-<num>', '(rounded|rd)', '(rounded|rd)-<num>'] }],
+  [/^(?:border-|b-)?(?:rounded|rd)()(?:-(.+))?$/, handlerRounded, { autocomplete: ['(border|b)-(rounded|rd)', '(border|b)-(rounded|rd)-$borderRadius', '(rounded|rd)', '(rounded|rd)-$borderRadius'] }],
   [/^(?:border-|b-)?(?:rounded|rd)-([rltbse])(?:-(.+))?$/, handlerRounded],
   [/^(?:border-|b-)?(?:rounded|rd)-([rltb]{2})(?:-(.+))?$/, handlerRounded],
   [/^(?:border-|b-)?(?:rounded|rd)-([bise][se])(?:-(.+))?$/, handlerRounded],


### PR DESCRIPTION
Currently we get some arbitrary numbers in autocomplete for `rounded` which disregards what user puts into `borderRadius` in `theme`.

It also does not suggest default values that are set in the default theme:
https://github.com/unocss/unocss/blob/main/packages/preset-mini/src/_theme/misc.ts#L49

https://github.com/unocss/unocss/blob/main/packages/preset-mini/src/_rules/border.ts#L127

With the change from this PR, autocomplete will now suggest proper values, both default and those overridden by the user.

Since this only targets `autocomplete` it's backwards compatible, both `number` and `predefined` values still work, although `autocomplete` will now only suggest the latter.