### PR TITLE
feat(preset-mini): support using kebab-case for fontSize

### DIFF
--- a/packages/preset-mini/src/_rules/typography.ts
+++ b/packages/preset-mini/src/_rules/typography.ts
@@ -129,12 +129,16 @@ export const textShadows: Rule<Theme>[] = [
   [/^text-shadow-color-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-text-shadow-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: 'text-shadow-color-(op|opacity)-<percent>' }],
 ]
 
+function toCamelCase(s: string) {
+  return s.replace(/-(\w)/g, (_, c) => c.toUpperCase())
+}
+
 function handleThemeByKey(s: string, theme: Theme, key: 'lineHeight' | 'letterSpacing') {
   return theme[key]?.[s] || h.bracket.cssvar.global.rem(s)
 }
 
 function handleSize([, s]: string[], { theme }: RuleContext<Theme>): CSSObject | undefined {
-  const themed = toArray(theme.fontSize?.[s]) as [string, string | CSSObject]
+  const themed = toArray(theme.fontSize?.[toCamelCase(s)]) as [string, string | CSSObject]
   const size = themed?.[0] ?? h.bracket.cssvar.global.rem(s)
   if (size != null)
     return { 'font-size': size }
@@ -152,8 +156,8 @@ function handleText([, s = 'base']: string[], { theme }: RuleContext<Theme>): CS
     return
 
   const [size, leading] = split
-  const sizePairs = toArray(theme.fontSize?.[size]) as [string, string | CSSObject, string?]
-  const lineHeight = leading ? handleThemeByKey(leading, theme, 'lineHeight') : undefined
+  const sizePairs = toArray(theme.fontSize?.[toCamelCase(size)]) as [string, string | CSSObject, string?]
+  const lineHeight = leading ? handleThemeByKey(toCamelCase(leading), theme, 'lineHeight') : undefined
 
   if (sizePairs?.[0]) {
     const [fontSize, height, letterSpacing] = sizePairs

--- a/test/preset-mini.test.ts
+++ b/test/preset-mini.test.ts
@@ -443,4 +443,33 @@ describe('preset-mini', () => {
     .border-opacity-50{--un-border-opacity:0.5;}"
   `)
   })
+
+  it('use fontSize by camel-case', async () => {
+    const uno = createGenerator({
+      presets: [
+        presetMini(),
+      ],
+      theme: {
+        fontSize: {
+          bodySmall: '1rem',
+          titleMedium: ['2rem', '1.5em'],
+        },
+      },
+    })
+
+    const { css } = await uno.generate([
+      'text-bodySmall',
+      'text-body-small',
+      'text-title-medium',
+      'text-body-small:1.5em',
+    ].join(' '), { preflights: false })
+
+    expect(css).toMatchInlineSnapshot(`
+    "/* layer: default */
+    .text-body-small,
+    .text-bodySmall{font-size:1rem;line-height:1;}
+    .text-body-small\\:1\\.5em{font-size:1rem;line-height:1.5em;}
+    .text-title-medium{font-size:2rem;line-height:1.5em;}"
+  `)
+  })
 })


### PR DESCRIPTION
Using kebab-case just like a color theme.

```
theme: {
  fontSize: {
    bodySmall: '1rem',
    titleMedium: ['2rem', '1.5em'],
  }
}
```

before: `text-bodySmall`
now: `text-body-small` | `text-body-small:15em`