### PR TITLE
chore: fix the example of `vite-react`

### DIFF
--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-react",
+  "type": "module",
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Open the example of `vite-react` on [stackblitz](https://stackblitz.com/edit/unocss-unocss-y7gcng?file=package.json), the project throw an error: 

![image](https://github.com/unocss/unocss/assets/45257542/e604490f-22e2-450b-8dd0-c4b09ce1cb74)