### PR TITLE
fix(vite): move @import before other rules

### DIFF
--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -17,6 +17,7 @@ import {
 } from '../../integration'
 import type { VitePluginConfig } from '../../types'
 import { setupContentExtractor } from '../../../../shared-integration/src/content'
+import { LAYER_IMPORTS } from '../../../../core/src/constants'
 
 // https://github.com/vitejs/vite/blob/main/packages/plugin-legacy/src/index.ts#L742-L744
 function isLegacyChunk(chunk: RenderedChunk, options: NormalizedOutputOptions) {
@@ -218,9 +219,10 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
         }
         const result = await generateAll()
         const mappedVfsLayer = Array.from(vfsLayers).map(layer => layer === LAYER_MARK_ALL ? layer : layer.replace(/^_/, ''))
-        const cssWithLayers = Array.from(vfsLayers).map(layer => `#--unocss-layer-start--${layer}--{start:${layer}} ${
+        const importStatements = result.getLayer(LAYER_IMPORTS)
+        const cssWithLayers = Array.from(vfsLayers).map(layer => `${importStatements ?? ''}#--unocss-layer-start--${layer}--{start:${layer}} ${
             layer === LAYER_MARK_ALL
-            ? result.getLayers(undefined, mappedVfsLayer)
+            ? result.getLayers(undefined, [...mappedVfsLayer, LAYER_IMPORTS])
             : (result.getLayer(layer.replace(/^_/, '')) || '')
           } #--unocss-layer-end--${layer}--{end:${layer}}`).join('')
 

--- a/packages/vite/src/modes/global/dev.ts
+++ b/packages/vite/src/modes/global/dev.ts
@@ -161,7 +161,7 @@ export function GlobalModeDevPlugin({ uno, tokens, tasks, flushTasks, affectedMo
         const { hash, css } = await generateCSS(layer)
         return {
           // add hash to the chunk of CSS that it will send back to client to check if there is new CSS generated
-          code: `__uno_hash_${hash}{--:'';}${css}`,
+          code: `${css}__uno_hash_${hash}{--:'';}`,
           map: { mappings: '' },
         }
       },


### PR DESCRIPTION
fix #3609 

The reason is that the `@import` statement is wrapped in a layer, causing it not to precede all `CSS` rules.

I have conducted tests locally and have not yet found any issues. If it may cause other problems, I would appreciate your guidance.