### PR TITLE
fix(cjs)!: remove `.default` suffix from d.ts and d.cts files

### DIFF
--- a/packages/unocss/astro.d.ts
+++ b/packages/unocss/astro.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/astro'
-export { default } from './dist/astro'

--- a/packages/unocss/index.d.ts
+++ b/packages/unocss/index.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/index'
-export { default } from './dist/index'

--- a/packages/unocss/package.json
+++ b/packages/unocss/package.json
@@ -94,9 +94,16 @@
   },
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",
-  "types": "index.d.ts",
+  "types": "dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*",
+        "./*"
+      ]
+    }
+  },
   "files": [
-    "*.d.ts",
     "dist"
   ],
   "engines": {

--- a/packages/unocss/postcss.d.ts
+++ b/packages/unocss/postcss.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/postcss'
-export { default } from './dist/postcss'

--- a/packages/unocss/preset-attributify.d.ts
+++ b/packages/unocss/preset-attributify.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/preset-attributify'
-export { default } from './dist/preset-attributify'

--- a/packages/unocss/preset-icons.d.ts
+++ b/packages/unocss/preset-icons.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/preset-icons'
-export { default } from './dist/preset-icons'

--- a/packages/unocss/preset-mini.d.ts
+++ b/packages/unocss/preset-mini.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/preset-mini'
-export { default } from './dist/preset-mini'

--- a/packages/unocss/preset-tagify.d.ts
+++ b/packages/unocss/preset-tagify.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/preset-tagify'
-export { default } from './dist/preset-tagify'

--- a/packages/unocss/preset-typography.d.ts
+++ b/packages/unocss/preset-typography.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/preset-typography'
-export { default } from './dist/preset-typography'

--- a/packages/unocss/preset-uno.d.ts
+++ b/packages/unocss/preset-uno.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/preset-uno'
-export { default } from './dist/preset-uno'

--- a/packages/unocss/preset-web-fonts.d.ts
+++ b/packages/unocss/preset-web-fonts.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/preset-web-fonts'
-export { default } from './dist/preset-web-fonts'

--- a/packages/unocss/preset-wind.d.ts
+++ b/packages/unocss/preset-wind.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/preset-wind'
-export { default } from './dist/preset-wind'

--- a/packages/unocss/vite.d.ts
+++ b/packages/unocss/vite.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/vite'
-export { default } from './dist/vite'

--- a/packages/unocss/webpack.d.ts
+++ b/packages/unocss/webpack.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/webpack'
-export { default } from './dist/webpack'

--- a/scripts/dist-verify.ts
+++ b/scripts/dist-verify.ts
@@ -3,21 +3,26 @@ import process from 'node:process'
 import fg from 'fast-glob'
 
 export async function verifyDist() {
-  const cjsFiles = await fg('packages/*/dist/**/*.cjs', {
+  const cjsFiles = await fg(['packages/*/dist/**/*.d.ts', 'packages/*/dist/**/*.d.cts'], {
     ignore: ['**/node_modules/**'],
   })
+  // const cjsFiles = await fg('packages/*/dist/**/*.cjs', {
+  //   ignore: ['**/node_modules/**'],
+  // })
 
-  console.log(`${cjsFiles.length} cjs files found`)
+  console.log(`${cjsFiles.length} dts files found`)
+  // console.log(`${cjsFiles.length} cjs files found`)
   console.log(cjsFiles.map(i => ` - ${i}`).join('\n'))
 
   const forbidden = [
     // Make sure no CJS is importing UnoCSS packages as they are ESM only
     /require\(['"]@?unocss(\/core)?['"]\)/,
     // Use `exports.default` instead, should be patched by postbuild.ts
-    'module.exports',
+    // 'module.exports',
   ]
 
-  const exportsDefault = 'exports.default'
+  const exportsDefault = 'as default'
+  // const exportsDefault = 'exports.default'
 
   let error = false
   await Promise.all(cjsFiles.map(async (file) => {

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { verifyDist } from './dist-verify'
 
-function patchCjs(cjsModulePath: string, name: string) {
+function _patchCjs(cjsModulePath: string, name: string) {
   const cjsModule = readFileSync(cjsModulePath, 'utf-8')
   writeFileSync(
     cjsModulePath,
@@ -13,17 +13,73 @@ function patchCjs(cjsModulePath: string, name: string) {
   )
 }
 
+function patchCjsDts(cjsModulePath: string, name: string, useName = false) {
+  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
+  writeFileSync(
+    cjsModulePath,
+    cjsModule
+      .replace(`export { ${name} as default };`, `export = ${useName ? name : '_default'};`),
+    { encoding: 'utf-8' },
+  )
+}
+
+function patchPostcssCjsDts(cjsModulePath: string) {
+  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
+  writeFileSync(
+    cjsModulePath,
+    cjsModule
+      .replace(`export { type UnoPostcssPluginOptions, unocss as default };`, `export = unocss;\nexport { type UnoPostcssPluginOptions };`),
+    { encoding: 'utf-8' },
+  )
+}
+
+function patchWebpackCjsDts(cjsModulePath: string) {
+  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
+  writeFileSync(
+    cjsModulePath,
+    cjsModule
+      .replace(`export { type WebpackPluginOptions, WebpackPlugin as default, defineConfig };`, `export = WebpackPlugin;\nexport { type WebpackPluginOptions, defineConfig };`),
+    { encoding: 'utf-8' },
+  )
+}
+
+function patchPostcss2CjsDts(cjsModulePath: string) {
+  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
+  writeFileSync(
+    cjsModulePath,
+    cjsModule
+      .replace(`export { default } from '@unocss/postcss';`, `export = postcss;`),
+    { encoding: 'utf-8' },
+  )
+}
+
 // @unocss/eslint-config
-patchCjs(resolve('./packages/eslint-config/dist/flat.cjs'), 'flat')
-patchCjs(resolve('./packages/eslint-config/dist/index.cjs'), 'index')
+patchCjsDts(resolve('./packages/eslint-config/dist/flat.d.ts'), '_default')
+patchCjsDts(resolve('./packages/eslint-config/dist/flat.d.cts'), '_default')
+patchCjsDts(resolve('./packages/eslint-config/dist/index.d.ts'), '_default')
+patchCjsDts(resolve('./packages/eslint-config/dist/index.d.cts'), '_default')
+// patchCjs(resolve('./packages/eslint-config/dist/flat.cjs'), 'flat')
+// patchCjs(resolve('./packages/eslint-config/dist/index.cjs'), 'index')
 
 // @unocss/eslint-plugin
-patchCjs(resolve('./packages/eslint-plugin/dist/index.cjs'), 'index')
+patchCjsDts(resolve('./packages/eslint-plugin/dist/index.d.ts'), '_default')
+patchCjsDts(resolve('./packages/eslint-plugin/dist/index.d.cts'), '_default')
+// patchCjs(resolve('./packages/eslint-plugin/dist/index.cjs'), 'index')
 
 // @unocss/postcss
-patchCjs(resolve('./packages/postcss/dist/index.cjs'), 'unocss')
+patchPostcssCjsDts(resolve('./packages/postcss/dist/index.d.ts'))
+patchPostcssCjsDts(resolve('./packages/postcss/dist/index.d.cts'))
+// patchCjs(resolve('./packages/postcss/dist/index.cjs'), 'unocss')
+
+// @unocss/webpack
+patchWebpackCjsDts(resolve('./packages/webpack/dist/index.d.ts'))
+patchWebpackCjsDts(resolve('./packages/webpack/dist/index.d.cts'))
 
 // unocss
-patchCjs(resolve('./packages/unocss/dist/postcss.cjs'), 'postcss__default')
+patchPostcss2CjsDts(resolve('./packages/unocss/dist/postcss.d.ts'))
+patchPostcss2CjsDts(resolve('./packages/unocss/dist/postcss.d.cts'))
+patchCjsDts(resolve('./packages/unocss/dist/webpack.d.ts'), 'UnocssWebpackPlugin', true)
+patchCjsDts(resolve('./packages/unocss/dist/webpack.d.cts'), 'UnocssWebpackPlugin', true)
+// patchCjs(resolve('./packages/unocss/dist/postcss.cjs'), 'postcss__default')
 
 await verifyDist()

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -2,84 +2,78 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { verifyDist } from './dist-verify'
 
-function _patchCjs(cjsModulePath: string, name: string) {
-  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
-  writeFileSync(
-    cjsModulePath,
-    cjsModule
-      .replace(`'use strict';`, `'use strict';Object.defineProperty(exports, '__esModule', {value: true});`)
-      .replace(`module.exports = ${name};`, `exports.default = ${name};`),
-    { encoding: 'utf-8' },
-  )
+const regexp = /export\s*\{\s*(.*)\s*};/
+
+function parseExports(dtsModulePath: string, defaultExport: string, content: string) {
+  const exportAsDefault = `${defaultExport} as default`
+  const entries = content.split('\n').reduce((acc, line) => {
+    // skip LF if last line
+    if (acc.content.length && acc.content.at(-1) === '\n' && line.trim().length === 0)
+      return acc
+
+    const match = line.match(regexp)
+    if (match?.length && match[0].includes(exportAsDefault)) {
+      const exportsArray = match[1].split(',').map(e => e.trim())
+      const removeImport = `${defaultExport} as default`
+      // Filtering out the default export
+      const nonDefaultExports = exportsArray.filter(item => item !== removeImport).map(e => e.trim())
+      acc.matched = true
+      acc.content = nonDefaultExports.length > 0
+        ? `${acc.content}\nexport = ${defaultExport};\nexport { ${nonDefaultExports.join(', ')} };\n`
+        : `${acc.content}\nexport = ${defaultExport};\n`
+    }
+    else {
+      // avoid adding LF at first line
+      acc.content = acc.content.length > 0
+        ? `${acc.content}\n${line}`
+        : line
+    }
+
+    return acc
+  }, { content: '', matched: false })
+
+  if (entries.matched)
+    return entries.content
+  else
+    throw new Error(`UPPS, no match found for ${defaultExport} in ${dtsModulePath}!`)
 }
 
-function patchCjsDts(cjsModulePath: string, name: string, useName = false) {
-  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
-  writeFileSync(
-    cjsModulePath,
-    cjsModule
-      .replace(`export { ${name} as default };`, `export = ${useName ? name : '_default'};`),
-    { encoding: 'utf-8' },
-  )
+function patchDefaultCjsExport(dtsModuleName: string, defaultExport: string = '_default') {
+  for (const path of [`${dtsModuleName}.d.ts`, `${dtsModuleName}.d.cts`]) {
+    writeFileSync(
+      path,
+      parseExports(path, defaultExport, readFileSync(path, 'utf-8')),
+      { encoding: 'utf-8' },
+    )
+  }
 }
 
-function patchPostcssCjsDts(cjsModulePath: string) {
-  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
-  writeFileSync(
-    cjsModulePath,
-    cjsModule
-      .replace(`export { type UnoPostcssPluginOptions, unocss as default };`, `export = unocss;\nexport { type UnoPostcssPluginOptions };`),
-    { encoding: 'utf-8' },
-  )
-}
-
-function patchWebpackCjsDts(cjsModulePath: string) {
-  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
-  writeFileSync(
-    cjsModulePath,
-    cjsModule
-      .replace(`export { type WebpackPluginOptions, WebpackPlugin as default, defineConfig };`, `export = WebpackPlugin;\nexport { type WebpackPluginOptions, defineConfig };`),
-    { encoding: 'utf-8' },
-  )
-}
-
-function patchPostcss2CjsDts(cjsModulePath: string) {
-  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
-  writeFileSync(
-    cjsModulePath,
-    cjsModule
-      .replace(`export { default } from '@unocss/postcss';`, `export = postcss;`),
-    { encoding: 'utf-8' },
-  )
+function patchUnoCSSPostcssCjsExport(dtsModuleName: string) {
+  for (const path of [`${dtsModuleName}.d.ts`, `${dtsModuleName}.d.cts`]) {
+    const content = readFileSync(path, 'utf-8')
+    writeFileSync(
+      path,
+      content.replace('export { default } from \'@unocss/postcss\';', '\nexport = postcss;'),
+      { encoding: 'utf-8' },
+    )
+  }
 }
 
 // @unocss/eslint-config
-patchCjsDts(resolve('./packages/eslint-config/dist/flat.d.ts'), '_default')
-patchCjsDts(resolve('./packages/eslint-config/dist/flat.d.cts'), '_default')
-patchCjsDts(resolve('./packages/eslint-config/dist/index.d.ts'), '_default')
-patchCjsDts(resolve('./packages/eslint-config/dist/index.d.cts'), '_default')
-// patchCjs(resolve('./packages/eslint-config/dist/flat.cjs'), 'flat')
-// patchCjs(resolve('./packages/eslint-config/dist/index.cjs'), 'index')
+patchDefaultCjsExport(resolve('./packages/eslint-config/dist/flat'))
+patchDefaultCjsExport(resolve('./packages/eslint-config/dist/index'))
 
 // @unocss/eslint-plugin
-patchCjsDts(resolve('./packages/eslint-plugin/dist/index.d.ts'), '_default')
-patchCjsDts(resolve('./packages/eslint-plugin/dist/index.d.cts'), '_default')
-// patchCjs(resolve('./packages/eslint-plugin/dist/index.cjs'), 'index')
+patchDefaultCjsExport(resolve('./packages/eslint-plugin/dist/index'))
 
 // @unocss/postcss
-patchPostcssCjsDts(resolve('./packages/postcss/dist/index.d.ts'))
-patchPostcssCjsDts(resolve('./packages/postcss/dist/index.d.cts'))
-// patchCjs(resolve('./packages/postcss/dist/index.cjs'), 'unocss')
+patchDefaultCjsExport(resolve('./packages/postcss/dist/index'), 'unocss')
 
 // @unocss/webpack
-patchWebpackCjsDts(resolve('./packages/webpack/dist/index.d.ts'))
-patchWebpackCjsDts(resolve('./packages/webpack/dist/index.d.cts'))
+patchDefaultCjsExport(resolve('./packages/webpack/dist/index'), 'WebpackPlugin')
 
 // unocss
-patchPostcss2CjsDts(resolve('./packages/unocss/dist/postcss.d.ts'))
-patchPostcss2CjsDts(resolve('./packages/unocss/dist/postcss.d.cts'))
-patchCjsDts(resolve('./packages/unocss/dist/webpack.d.ts'), 'UnocssWebpackPlugin', true)
-patchCjsDts(resolve('./packages/unocss/dist/webpack.d.cts'), 'UnocssWebpackPlugin', true)
-// patchCjs(resolve('./packages/unocss/dist/postcss.cjs'), 'postcss__default')
+patchUnoCSSPostcssCjsExport(resolve('./packages/unocss/dist/postcss'))
+patchDefaultCjsExport(resolve('./packages/unocss/dist/webpack'), 'UnocssWebpackPlugin')
 
 await verifyDist()


### PR DESCRIPTION
This PR will revert changes in `.cjs` files, patching `d.ts` and `d.cts` instead.

I need to check a few packages, rn next example working with these changes (postcss).

(Maybe we can patch only postcss packages, there is no way yet to configure `postcss` plugin in Next and Webpack (?) with `.default` suffix: `unocss/postcss` and `@unocss/postcss`)

The `dist-verify.ts` script is wrong (in this PR)...

/cc @kwaa

We also have some problems when using old ESLint: check #3751