### PR TITLE
feat(preset-px-to-viewport): add px-to-viewport support

### DIFF
--- a/alias.ts
+++ b/alias.ts
@@ -17,6 +17,7 @@ export const alias: Record<string, string> = {
   '@unocss/preset-attributify': r('./packages/preset-attributify/src/'),
   '@unocss/preset-icons': r('./packages/preset-icons/src/'),
   '@unocss/preset-mini': r('./packages/preset-mini/src/'),
+  '@unocss/preset-px-to-viewport': r('./packages/preset-px-to-viewport/src/'),
   '@unocss/preset-rem-to-px': r('./packages/preset-rem-to-px/src/'),
   '@unocss/preset-tagify': r('./packages/preset-tagify/src/'),
   '@unocss/preset-typography': r('./packages/preset-typography/src/'),

--- a/packages/preset-px-to-viewport/README.md
+++ b/packages/preset-px-to-viewport/README.md
@@ -1,0 +1,11 @@
+# @unocss/preset-px-to-viewport
+
+Coverts px to viewport for utils.
+
+## Documentation
+
+<!-- todo -->
+
+## License
+
+MIT License &copy; 2022-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages/preset-px-to-viewport/build.config.ts
+++ b/packages/preset-px-to-viewport/build.config.ts
@@ -1,0 +1,9 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  entries: [
+    'src/index',
+  ],
+  clean: true,
+  declaration: true,
+})

--- a/packages/preset-px-to-viewport/package.json
+++ b/packages/preset-px-to-viewport/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@unocss/preset-px-to-viewport",
+  "type": "module",
+  "version": "0.59.4",
+  "description": "Convert all px to viewport in utils",
+  "author": "Anthony Fu <anthonyfu117@hotmail.com>",
+  "license": "MIT",
+  "funding": "https://github.com/sponsors/antfu",
+  "homepage": "https://github.com/unocss/unocss/tree/main/packages/preset-px-to-viewport#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/unocss/unocss",
+    "directory": "packages/preset-px-to-viewport"
+  },
+  "bugs": {
+    "url": "https://github.com/unocss/unocss/issues"
+  },
+  "keywords": [
+    "unocss",
+    "unocss-preset"
+  ],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "unbuild",
+    "stub": "unbuild --stub"
+  },
+  "dependencies": {
+    "@unocss/core": "workspace:*"
+  }
+}

--- a/packages/preset-px-to-viewport/src/index.ts
+++ b/packages/preset-px-to-viewport/src/index.ts
@@ -1,0 +1,41 @@
+import { definePreset } from '@unocss/core'
+
+const pxRE = /(-?[\.\d]+)px/g
+
+export interface PxToViewportOptions {
+  /**
+   * design width
+   */
+  baseWidth: number
+}
+
+export default definePreset((options: PxToViewportOptions = {
+  // iphone se
+  baseWidth: 375,
+}) => {
+  const basicWidthUnit = options.baseWidth / 100
+  return {
+    name: '@unocss/preset-px-to-viewport',
+    postprocess: (util) => {
+      util.entries.forEach((i) => {
+        const value = i[1]
+        /**
+         * issue:
+         *      selector '.w-[\d]px' and '[w-[\d]px]' conflit
+         *      css generate abnormal when change template in dev
+         * temporary plan:
+         *      match twice
+         */
+        if (typeof value !== 'string')
+          return
+        // No.1
+        if (pxRE.test(value))
+          i[1] = value.replace(pxRE, (_, p1) => `${p1 / basicWidthUnit}vmin`)
+
+        // No.2
+        if (pxRE.test(util.selector))
+          i[1] = value.replace(pxRE, (_, p1) => `${p1 / basicWidthUnit}vmin`)
+      })
+    },
+  }
+})

--- a/packages/runtime/src/presets/preset-px-to-viewport.ts
+++ b/packages/runtime/src/presets/preset-px-to-viewport.ts
@@ -1,0 +1,8 @@
+import type { PxToViewportOptions } from '@unocss/preset-px-to-viewport'
+import presetPxToViewPort from '@unocss/preset-px-to-viewport'
+import type { RuntimeContext } from '..'
+
+window.__unocss_runtime = window.__unocss_runtime ?? {} as RuntimeContext
+window.__unocss_runtime.presets = Object.assign(window.__unocss_runtime?.presets ?? {}, {
+  presetPxToViewPort: (options: PxToViewportOptions) => presetPxToViewPort(options),
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -788,6 +788,12 @@ importers:
         specifier: workspace:*
         version: link:../rule-utils
 
+  packages/preset-px-to-viewport:
+    dependencies:
+      '@unocss/core':
+        specifier: workspace:*
+        version: link:../core
+
   packages/preset-rem-to-px:
     dependencies:
       '@unocss/core':
@@ -2825,30 +2831,35 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-glibc@2.4.1':
     resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.4.1':
     resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.4.1':
     resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.4.1':
     resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.4.1':
     resolution: {integrity: sha512-/ZR0RxqxU/xxDGzbzosMjh4W6NdYFMqq2nvo2b8SLi7rsl/4jkL8S5stIikorNkdR50oVDvqb/3JT05WM+CRRA==}
@@ -2999,36 +3010,43 @@ packages:
     resolution: {integrity: sha512-Eci2us9VTHm1eSyn5/eEpaC7eP/mp5n46gTRB3Aar3BgSvDQGJZuicyq6TsH4HngNBgVqC5sDYxOzTExSU+NjA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.14.3':
     resolution: {integrity: sha512-UrBoMLCq4E92/LCqlh+blpqMz5h1tJttPIniwUgOFJyjWI1qrtrDhhpHPuFxULlUmjFHfloWdixtDhSxJt5iKw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.14.3':
     resolution: {integrity: sha512-5aRjvsS8q1nWN8AoRfrq5+9IflC3P1leMoy4r2WjXyFqf3qcqsxRCfxtZIV58tCxd+Yv7WELPcO9mY9aeQyAmw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.14.3':
     resolution: {integrity: sha512-sk/Qh1j2/RJSX7FhEpJn8n0ndxy/uf0kI/9Zc4b1ELhqULVdTfN6HL31CDaTChiBAOgLcsJ1sgVZjWv8XNEsAQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.14.3':
     resolution: {integrity: sha512-jOO/PEaDitOmY9TgkxF/TQIjXySQe5KVYB57H/8LRP/ux0ZoO8cSHCX17asMSv3ruwslXW/TLBcxyaUzGRHcqg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.14.3':
     resolution: {integrity: sha512-8ybV4Xjy59xLMyWo3GCfEGqtKV5M5gCSrZlxkPGvEPCGDLNla7v48S662HSGwRd6/2cSneMQWiv+QzcttLrrOA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.14.3':
     resolution: {integrity: sha512-s+xf1I46trOY10OqAtZ5Rm6lzHre/UiLA1J2uOhCFXWkbZrJRkYBPO6FhvGfHmdtQ3Bx793MNa7LvoWFAm93bg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.14.3':
     resolution: {integrity: sha512-+4h2WrGOYsOumDQ5S2sYNyhVfrue+9tc9XcLWLh+Kw3UOxAvrfOrSMFon60KspcDdytkNDh7K2Vs6eMaYImAZg==}

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -10,34 +10,3 @@ exports[`cli > builds uno.css 1`] = `
 .max-w-screen-md{max-width:768px;}
 .p-4{padding:1rem;}"
 `;
-
-exports[`cli > supports directives transformer 1`] = `""`;
-
-exports[`cli > supports directives transformer 2`] = `".btn-center{@apply text-center my-0 font-medium;}"`;
-
-exports[`cli > supports unocss.config.js 1`] = `
-"/* layer: shortcuts */
-.box{margin-left:auto;margin-right:auto;max-width:80rem;border-radius:0.375rem;--un-bg-opacity:1;background-color:rgb(243 244 246 / var(--un-bg-opacity));padding:1rem;--un-shadow:var(--un-shadow-inset) 0 1px 2px 0 var(--un-shadow-color, rgb(0 0 0 / 0.05));box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}"
-`;
-
-exports[`cli > supports updating source files with transformed utilities ('directives transformer') 1`] = `""`;
-
-exports[`cli > supports updating source files with transformed utilities ('directives transformer') 2`] = `".btn-center{margin-top:0;margin-bottom:0;text-align:center;font-weight:500;}"`;
-
-exports[`cli > supports updating source files with transformed utilities ('variant group transformer') 1`] = `
-"/* layer: default */
-.border-red{--un-border-opacity:1;border-color:rgb(248 113 113 / var(--un-border-opacity));}
-.border-solid{border-style:solid;}
-.p-4{padding:1rem;}"
-`;
-
-exports[`cli > supports updating source files with transformed utilities ('variant group transformer') 2`] = `"<div class="p-4 border-solid border-red"></div>"`;
-
-exports[`cli > supports variantGroup transformer 1`] = `
-"/* layer: default */
-.border-red{--un-border-opacity:1;border-color:rgb(248 113 113 / var(--un-border-opacity));}
-.border-solid{border-style:solid;}
-.p-4{padding:1rem;}"
-`;
-
-exports[`cli > supports variantGroup transformer 2`] = `"<div class="p-4 border-(solid red)"></div>"`;

--- a/test/preset-px-to-viewport.test.ts
+++ b/test/preset-px-to-viewport.test.ts
@@ -1,0 +1,129 @@
+import { createGenerator } from '@unocss/core'
+import { describe, expect, it } from 'vitest'
+import presetPxToViewport from '@unocss/preset-px-to-viewport'
+import presetMini from '@unocss/preset-mini'
+
+describe('px-to-viewport', () => {
+  const uno = createGenerator({
+    presets: [
+      presetMini(),
+      presetPxToViewport(),
+    ],
+  })
+
+  it('should works', async () => {
+    expect((await uno.generate(
+      new Set([
+        'top-3.75px',
+        'basis-3.75px',
+        'gap-3.75px',
+        'm-3.75px',
+        'mx-3.75px',
+        '-p-3.75px',
+        'w-3.75px',
+        'm-w-3.75px',
+        'max-w-3.75px',
+        'h-3.75px',
+        'm-h-3.75px',
+        'max-h-3.75px',
+        'size-3.75px',
+        'text-3.75px',
+        'leading-3.75px',
+        'underline-offset-3.75px',
+        'indent-3.75px',
+        'rounded-3.75px',
+        'border-3.75px',
+        'divide-x-3.75px',
+        'outline-3.75px',
+        'outline-offset-3.75px',
+        'ring-3.75px',
+        'blur-3.75px',
+        'backdrop-blur-3.75px',
+        'translate-x-3.75px',
+      ]),
+      { preflights: false },
+    )).css)
+      .toMatchInlineSnapshot(`
+        "/* layer: default */
+        .-p-3\\.75px{padding:-1vmin;}
+        .m-3\\.75px{margin:1vmin;}
+        .mx-3\\.75px{margin-left:1vmin;margin-right:1vmin;}
+        .border-3\\.75px{border-width:1vmin;}
+        .rounded-3\\.75px{border-radius:1vmin;}
+        .text-3\\.75px{font-size:1vmin;}
+        .leading-3\\.75px{line-height:1vmin;}
+        .indent-3\\.75px{text-indent:1vmin;}
+        .underline-offset-3\\.75px{text-underline-offset:1vmin;}
+        .ring-3\\.75px{--un-ring-width:1vmin;--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(var(--un-ring-width) + var(--un-ring-offset-width)) var(--un-ring-color);box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}
+        .basis-3\\.75px{flex-basis:1vmin;}
+        .gap-3\\.75px{gap:1vmin;}
+        .size-3\\.75px{width:1vmin;height:1vmin;}
+        .h-3\\.75px{height:1vmin;}
+        .max-h-3\\.75px{max-height:1vmin;}
+        .max-w-3\\.75px{max-width:1vmin;}
+        .w-3\\.75px{width:1vmin;}
+        .outline-3\\.75px{outline-width:1vmin;}
+        .outline-offset-3\\.75px{outline-offset:1vmin;}
+        .top-3\\.75px{top:1vmin;}
+        .translate-x-3\\.75px{--un-translate-x:1vmin;transform:translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z)) rotate(var(--un-rotate)) rotateX(var(--un-rotate-x)) rotateY(var(--un-rotate-y)) rotateZ(var(--un-rotate-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z));}"
+      `)
+  })
+
+  it('important prefix should works', async () => {
+    expect((await uno.generate(
+      new Set([
+        '!top-3.75px',
+        '!basis-3.75px',
+        '!gap-3.75px',
+        '!m-3.75px',
+        '!mx-3.75px',
+        '!-p-3.75px',
+        '!w-3.75px',
+        '!m-w-3.75px',
+        '!max-w-3.75px',
+        '!h-3.75px',
+        '!m-h-3.75px',
+        '!max-h-3.75px',
+        '!size-3.75px',
+        '!text-3.75px',
+        '!leading-3.75px',
+        '!underline-offset-3.75px',
+        '!indent-3.75px',
+        '!rounded-3.75px',
+        '!border-3.75px',
+        '!divide-x-3.75px',
+        '!outline-3.75px',
+        '!outline-offset-3.75px',
+        '!ring-3.75px',
+        '!blur-3.75px',
+        '!backdrop-blur-3.75px',
+        '!translate-x-3.75px',
+      ]),
+      { preflights: false },
+    )).css)
+      .toMatchInlineSnapshot(`
+        "/* layer: default */
+        .\\!-p-3\\.75px{padding:-1vmin !important;}
+        .\\!m-3\\.75px{margin:1vmin !important;}
+        .\\!mx-3\\.75px{margin-left:1vmin !important;margin-right:1vmin !important;}
+        .\\!border-3\\.75px{border-width:1vmin !important;}
+        .\\!rounded-3\\.75px{border-radius:1vmin !important;}
+        .\\!text-3\\.75px{font-size:1vmin !important;}
+        .\\!leading-3\\.75px{line-height:1vmin !important;}
+        .\\!indent-3\\.75px{text-indent:1vmin !important;}
+        .\\!underline-offset-3\\.75px{text-underline-offset:1vmin !important;}
+        .\\!ring-3\\.75px{--un-ring-width:1vmin !important;--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color) !important;--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(var(--un-ring-width) + var(--un-ring-offset-width)) var(--un-ring-color) !important;box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow) !important;}
+        .\\!basis-3\\.75px{flex-basis:1vmin !important;}
+        .\\!gap-3\\.75px{gap:1vmin !important;}
+        .\\!size-3\\.75px{width:1vmin !important;height:1vmin !important;}
+        .\\!h-3\\.75px{height:1vmin !important;}
+        .\\!max-h-3\\.75px{max-height:1vmin !important;}
+        .\\!max-w-3\\.75px{max-width:1vmin !important;}
+        .\\!w-3\\.75px{width:1vmin !important;}
+        .\\!outline-3\\.75px{outline-width:1vmin !important;}
+        .\\!outline-offset-3\\.75px{outline-offset:1vmin !important;}
+        .\\!top-3\\.75px{top:1vmin !important;}
+        .\\!translate-x-3\\.75px{--un-translate-x:1vmin !important;transform:translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z)) rotate(var(--un-rotate)) rotateX(var(--un-rotate-x)) rotateY(var(--un-rotate-y)) rotateZ(var(--un-rotate-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) !important;}"
+      `)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
       "@unocss/preset-mini/rules": ["./packages/preset-mini/src/rules.ts"],
       "@unocss/preset-mini/utils": ["./packages/preset-mini/src/utils.ts"],
       "@unocss/preset-mini/variants": ["./packages/preset-mini/src/variants.ts"],
+      "@unocss/preset-px-to-viewport": ["./packages/preset-px-to-viewport/src/index.ts"],
       "@unocss/preset-rem-to-px": ["./packages/preset-rem-to-px/src/index.ts"],
       "@unocss/preset-tagify": ["./packages/preset-tagify/src/index.ts"],
       "@unocss/preset-legacy-compat": ["./packages/preset-legacy-compat/src/index.ts"],


### PR DESCRIPTION
This PR is implemented for mobile terminal adaptation. You only need to set the corresponding width of the design draft (there is a default width: 375) to convert 'px' into ’vmin‘.

Usage:
```
  <span inline-block w-3.75px h-3.75px text-3.75px -p-3.75px m-3.75px absolute top-3.75px>
    Text
  </span>
```

Generate:
```
{
.w-3.75px{width:1vmin;}
.h-3.75px{height:1vmin;}
.text-3.75px{font-size:1vmin;}
.-p-3.75px{padding:-1vmin;}
.m-3.75px{margin:1vmin;}
.top-3.75px{top:1vmin;}
}
```