### PR TITLE
fix(shared-integration): getCssEscaperForJsContent replace conflict

### DIFF
--- a/packages/shared-integration/src/layers.ts
+++ b/packages/shared-integration/src/layers.ts
@@ -49,7 +49,7 @@ export function getCssEscaperForJsContent(view: string) {
   //                     111    2222222
   const escapeViewRe = /(\\*)\\(["'`\\])/g
   view.trim().replace(escapeViewRe, (_, bs, char) => {
-    prefix[char] = bs
+    prefix[char] = bs.replace(/\\\\/g, '\\')
     return ''
   })
   return (css: string) => css.replace(/["'`\\]/g, (v) => {


### PR DESCRIPTION
close: #3758
This change can fix the string style conflict problem caused by hot update, but the preset-typography style is not loaded for the first time, and the style takes effect only after hot update. It seems to be another bug.