### PR TITLE
Include unocss package in postcss installation command

### DIFF
--- a/docs/integrations/postcss.md
+++ b/docs/integrations/postcss.md
@@ -17,13 +17,13 @@ This package is in an experimental state right now. It doesn't follow semver, an
 
 ::: code-group
   ```bash [pnpm]
-  pnpm add -D @unocss/postcss
+  pnpm add -D unocss @unocss/postcss
   ```
   ```bash [yarn]
-  yarn add -D @unocss/postcss
+  yarn add -D unocss @unocss/postcss
   ```
   ```bash [npm]
-  npm install -D @unocss/postcss
+  npm install -D unocss @unocss/postcss
   ```
 :::
 


### PR DESCRIPTION
The unocss dependency is necessary to run with PostCSS, but this is not clearly stated in the documentation.