### PR TITLE
docs: add install tip

### DIFF
--- a/docs/transformers/attributify-jsx.md
+++ b/docs/transformers/attributify-jsx.md
@@ -76,6 +76,14 @@ export default defineConfig({
 })
 ```
 
+::: tip
+This preset is included in the `unocss` package, you can also import it from there:
+
+```ts
+import { transformerAttributifyJsx } from 'unocss'
+```
+:::
+
 ## Caveats
 
 ::: warning


### PR DESCRIPTION
It is possible to import this transformer directly from unocss. It is not needed to install separately.

If this is approved, I can add this tip to the other transformers that are included with unocss as well.