### PR TITLE
feat: nuxt layers support

### DIFF
--- a/examples/nuxt3-layers/.npmrc
+++ b/examples/nuxt3-layers/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/examples/nuxt3-layers/.stackblitz.mjs
+++ b/examples/nuxt3-layers/.stackblitz.mjs
@@ -1,0 +1,14 @@
+import fs from 'node:fs'
+
+updateDependencyLinksToLatest('./package.json')
+
+function updateDependencyLinksToLatest(filename) {
+  try {
+    const contents = fs.readFileSync(filename, 'utf-8')
+    const updatedContent = contents.replace(/"link:.{3,}"/gi, '"latest"')
+    fs.writeFileSync(filename, updatedContent)
+  }
+  catch (err) {
+    console.error(err)
+  }
+}

--- a/examples/nuxt3-layers/app.vue
+++ b/examples/nuxt3-layers/app.vue
@@ -1,0 +1,15 @@
+<template>
+  <main class=" text-center px-12 py-20 foo">
+    <span text="5xl hover:red blue  " cursor="default">Hello Nuxt 3</span>
+    <br>
+    <div i-carbon-car text-4xl inline-block />
+    <br>
+    <button btn>
+      Button
+    </button>
+  </main>
+</template>
+
+<style>
+@import '@unocss/reset/tailwind.css';
+</style>

--- a/examples/nuxt3-layers/app.vue
+++ b/examples/nuxt3-layers/app.vue
@@ -1,6 +1,6 @@
 <template>
-  <main class=" text-center px-12 py-20 foo">
-    <span text="5xl hover:red blue  " cursor="default">Hello Nuxt 3</span>
+  <main class="py-20 px-12 text-center foo">
+    <span text="blue 5xl hover:red" cursor="default">Hello Nuxt 3</span>
     <br>
     <div i-carbon-car text-4xl inline-block />
     <br>

--- a/examples/nuxt3-layers/base/nuxt.config.ts
+++ b/examples/nuxt3-layers/base/nuxt.config.ts
@@ -1,0 +1,1 @@
+export default defineNuxtConfig({})

--- a/examples/nuxt3-layers/base/uno.config.ts
+++ b/examples/nuxt3-layers/base/uno.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'unocss'
+
+export default defineConfig({
+  rules: [
+    ['foo', { margin: '1px' }],
+  ],
+})

--- a/examples/nuxt3-layers/nuxt.config.ts
+++ b/examples/nuxt3-layers/nuxt.config.ts
@@ -1,0 +1,12 @@
+export default defineNuxtConfig({
+  extends: ['./ui', './base'],
+  modules: [
+    '@unocss/nuxt',
+  ],
+  unocss: {
+    nuxtLayers: true,
+    shortcuts: [
+      ['btn', 'px-4 py-1 rounded inline-block bg-teal-600 text-white cursor-pointer hover:bg-teal-700 disabled:cursor-default disabled:bg-gray-600 disabled:opacity-50'],
+    ],
+  },
+})

--- a/examples/nuxt3-layers/package.json
+++ b/examples/nuxt3-layers/package.json
@@ -1,0 +1,25 @@
+{
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "postinstall": "nuxi prepare",
+    "build": "nuxi build",
+    "dev": "nuxi dev",
+    "preview": "nuxi preview",
+    "lint": "eslint .",
+    "lint:fix": "nr lint --fix"
+  },
+  "devDependencies": {
+    "@iconify-json/carbon": "^1.1.33",
+    "@unocss/core": "link:../../packages/core",
+    "@unocss/eslint-plugin": "link:../../packages/eslint-plugin",
+    "@unocss/nuxt": "link:../../packages/nuxt",
+    "@unocss/reset": "link:../../packages/reset",
+    "nuxt": "^3.11.2",
+    "unocss": "link:../../packages/unocss"
+  },
+  "stackblitz": {
+    "installDependencies": false,
+    "startCommand": "node .stackblitz.mjs && npm install && npm run dev"
+  }
+}

--- a/examples/nuxt3-layers/ui/nuxt.config.ts
+++ b/examples/nuxt3-layers/ui/nuxt.config.ts
@@ -1,0 +1,1 @@
+export default defineNuxtConfig({})

--- a/examples/nuxt3-layers/ui/uno.config.ts
+++ b/examples/nuxt3-layers/ui/uno.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'unocss'
+
+export default defineConfig({
+  rules: [
+    ['bar', { margin: '2px' }],
+  ],
+})

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -97,7 +97,7 @@ export default mergeConfigs([${configPaths.map((_, index) => `cfg${index}`).join
 
     async function loadUnoConfig() {
       const { config: unoConfig } = await loadConfig<UserConfig>(process.cwd(), {
-        configFile: options.configFile,
+        configFile: options.nuxtLayers ? resolve(nuxt.options.buildDir, 'uno.config.mjs') : options.configFile,
       }, [], options)
 
       await nuxt.callHook('unocss:config', unoConfig)

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import process from 'node:process'
-import { addComponentsDir, addPluginTemplate, defineNuxtModule, extendWebpackConfig, isNuxt2, isNuxt3 } from '@nuxt/kit'
+import { addComponentsDir, addPluginTemplate, addTemplate, defineNuxtModule, extendWebpackConfig, findPath, isNuxt2, isNuxt3 } from '@nuxt/kit'
 import WebpackPlugin from '@unocss/webpack'
 import type { VitePluginConfig } from '@unocss/vite'
 import VitePlugin from '@unocss/vite'
@@ -26,6 +26,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
     preflight: false,
     components: true,
     disableNuxtInlineStyle: true,
+    nuxtLayers: false,
 
     // presets
     uno: true,
@@ -73,30 +74,58 @@ export default defineNuxtModule<UnocssNuxtOptions>({
       })
     }
 
-    const { config: unoConfig } = await loadConfig<UserConfig>(process.cwd(), {
-      configFile: options.configFile,
-    }, [], options)
+    if (options.nuxtLayers) {
+      addTemplate({
+        filename: 'uno.config.mjs',
+        async getContents() {
+          const configPaths = (await Promise.all(nuxt.options._layers.map(layer =>
+            findPath(options.configFile || ['uno.config', 'unocss.config'], { cwd: layer.config.srcDir }),
+          )))
+            .filter(Boolean)
+            .reverse() as string[]
 
-    await nuxt.callHook('unocss:config', unoConfig)
+          return (
+`import { mergeConfigs } from '@unocss/core'
+${configPaths.map((path, index) => `import cfg${index} from '${path}'`.trimStart()).join('\n').trimEnd()}
 
-    if (
-      isNuxt3()
-      && nuxt.options.builder === '@nuxt/vite-builder'
-      && nuxt.options.postcss.plugins.cssnano
-      && unoConfig.transformers?.some(t => t.name === '@unocss/transformer-directives' && t.enforce !== 'pre')
-    ) {
-      const preset = nuxt.options.postcss.plugins.cssnano.preset
-      nuxt.options.postcss.plugins.cssnano = {
-        preset: [preset?.[0] || 'default', Object.assign(
-          { mergeRules: false, normalizeWhitespace: false, discardComments: false },
-          preset?.[1],
-        )],
-      }
+export default mergeConfigs([${configPaths.map((_, index) => `cfg${index}`).join(', ')}])
+`)
+        },
+        write: true,
+      })
     }
 
-    nuxt.hook('vite:extend', ({ config }) => {
+    async function loadUnoConfig() {
+      const { config: unoConfig } = await loadConfig<UserConfig>(process.cwd(), {
+        configFile: options.configFile,
+      }, [], options)
+
+      await nuxt.callHook('unocss:config', unoConfig)
+
+      if (
+        isNuxt3()
+        && nuxt.options.builder === '@nuxt/vite-builder'
+        && nuxt.options.postcss.plugins.cssnano
+        && unoConfig.transformers?.some(t => t.name === '@unocss/transformer-directives' && t.enforce !== 'pre')
+      ) {
+        const preset = nuxt.options.postcss.plugins.cssnano.preset
+        nuxt.options.postcss.plugins.cssnano = {
+          preset: [preset?.[0] || 'default', Object.assign(
+            { mergeRules: false, normalizeWhitespace: false, discardComments: false },
+            preset?.[1],
+          )],
+        }
+      }
+
+      return unoConfig
+    }
+
+    nuxt.hook('vite:extend', async ({ config }) => {
+      const unoConfig = await loadUnoConfig()
       config.plugins = config.plugins || []
-      config.plugins.unshift(...VitePlugin({ mode: options.mode }, unoConfig))
+      config.plugins.unshift(...VitePlugin({
+        mode: options.mode,
+      }, unoConfig))
     })
 
     if (nuxt.options.dev) {
@@ -125,7 +154,8 @@ export default defineNuxtModule<UnocssNuxtOptions>({
       })
     }
 
-    extendWebpackConfig((config) => {
+    extendWebpackConfig(async (config) => {
+      const unoConfig = await loadUnoConfig()
       config.plugins = config.plugins || []
       config.plugins.unshift(WebpackPlugin({}, unoConfig))
     })

--- a/packages/nuxt/src/types.ts
+++ b/packages/nuxt/src/types.ts
@@ -38,6 +38,13 @@ export interface UnocssNuxtOptions extends UserConfig {
   disableNuxtInlineStyle?: boolean
 
   /**
+   * Automatically merge UnoCSS configs from Nuxt layers.
+   *
+   * @default false
+   */
+  nuxtLayers?: boolean
+
+  /**
    * Adjust the position of the `uno.css` injection. (Depends on `mode`)
    *
    * @default 'first'


### PR DESCRIPTION
Closes #3837 

Automatically merges configs from each layer and generates `/.nuxt/uno.config.mjs` file based on the Nuxt config's `extends` list. Then  the generated config is passed to the Vite/Webpack plugin.