### PR TITLE
docs: add install tips for transformers

### DIFF
--- a/docs/transformers/compile-class.md
+++ b/docs/transformers/compile-class.md
@@ -37,6 +37,14 @@ export default defineConfig({
 })
 ```
 
+::: tip
+This preset is included in the `unocss` package, you can also import it from there:
+
+```ts
+import { transformerCompileClass } from 'unocss'
+```
+:::
+
 ## Usage
 
 Add `:uno:` at the beginning of the class strings to mark them for compilation.

--- a/docs/transformers/directives.md
+++ b/docs/transformers/directives.md
@@ -35,6 +35,14 @@ export default defineConfig({
 })
 ```
 
+::: tip
+This preset is included in the `unocss` package, you can also import it from there:
+
+```ts
+import { transformerDirectives } from 'unocss'
+```
+:::
+
 ## Usage
 
 ### `@apply`

--- a/docs/transformers/variant-group.md
+++ b/docs/transformers/variant-group.md
@@ -34,6 +34,14 @@ export default defineConfig({
 })
 ```
 
+::: tip
+This preset is included in the `unocss` package, you can also import it from there:
+
+```ts
+import { transformerVariantGroup } from 'unocss'
+```
+:::
+
 ## Usage
 
 ```html


### PR DESCRIPTION
This PR adds install tips for the transformers that are now included in `unocss`