### PR TITLE
fix(vite): using astro integration in vitest causes hangs

### DIFF
--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -199,7 +199,7 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
         viteConfig = config
       },
       buildStart() {
-        tasks.push(setupContentExtractor(ctx, viteConfig.command === 'serve'))
+        tasks.push(setupContentExtractor(ctx, viteConfig.mode !== 'test' && viteConfig.command === 'serve'))
       },
     },
     {


### PR DESCRIPTION
close: #3822

The root problem is `chokidar`'s `watch` will prevent exiting. In `vitest`. we don't need to `watch` anything 
https://github.com/unocss/unocss/blob/f24c75371366f7b801b84f11e01043bdb3b3f84f/packages/shared-integration/src/content.ts#L43-L61