### PR TITLE
feat(nuxt): skip the root `uno.config` when merging

### DIFF
--- a/docs/integrations/nuxt.md
+++ b/docs/integrations/nuxt.md
@@ -58,6 +58,38 @@ The `uno.css` entry will be automatically injected by the module.
 
 We recommend to use the dedicated `uno.config.ts` file for configuration. See [Config File](/guide/config-file) for more details.
 
+You can enable the `nuxtLayers` option, so Nuxt will automatically merge `uno.config` files from each Nuxt layer:
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  // ...
+  unocss: {
+    nuxtLayers: true,
+  },
+})
+```
+
+then you can reexport the generated config in the root config file:
+
+```ts
+// uno.config.ts
+import config from './.nuxt/uno.config.mjs'
+
+export default config
+```
+
+or modify/extend it:
+
+```ts
+import { mergeConfigs } from '@unocss/core'
+import config from './.nuxt/uno.config.mjs'
+
+export default mergeConfigs(config, {
+  // your overrides
+})
+```
+
 ## License
 
 - MIT License &copy; 2021-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/examples/nuxt3-layers/uno.config.ts
+++ b/examples/nuxt3-layers/uno.config.ts
@@ -1,0 +1,3 @@
+import config from './.nuxt/uno.config.mjs'
+
+export default config

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -78,7 +78,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
       addTemplate({
         filename: 'uno.config.mjs',
         async getContents() {
-          const configPaths = (await Promise.all(nuxt.options._layers.map(layer =>
+          const configPaths = (await Promise.all(nuxt.options._layers.slice(1).map(layer =>
             findPath(options.configFile || ['uno.config', 'unocss.config'], { cwd: layer.config.srcDir }),
           )))
             .filter(Boolean)
@@ -97,7 +97,7 @@ export default mergeConfigs([${configPaths.map((_, index) => `cfg${index}`).join
 
     async function loadUnoConfig() {
       const { config: unoConfig } = await loadConfig<UserConfig>(process.cwd(), {
-        configFile: options.nuxtLayers ? resolve(nuxt.options.buildDir, 'uno.config.mjs') : options.configFile,
+        configFile: options.configFile,
       }, [], options)
 
       await nuxt.callHook('unocss:config', unoConfig)


### PR DESCRIPTION
Related https://github.com/unocss/unocss/issues/3837

https://github.com/unocss/unocss/pull/3838 added logic to merge **ALL** `uno.config`s from Nuxt layers and generate `./.nuxt/uno.config.mjs`. 

**Problem:**
Because Eslint, VSCode plugins and other tools rely on `uno.config` file, we need to tell them to look for the new location(`./.nuxt`). While this can be done for Eslint (settings->unocss->configPath), implementing a new option for VSCode, JetBrains etc. will kill DX.

This PR skips the root `uno.config` file when merging configs from Nuxt layers, so user should manually reexport merged config from `./.nuxt/uno.config.mjs` and other tools will work as usual:
```ts
// uno.config.ts
import config from './.nuxt/uno.config.mjs'

export default config
```