### PR TITLE
fix(preset-mini): make sure important variant handles number 0 value

### DIFF
--- a/packages/preset-mini/src/_variants/important.ts
+++ b/packages/preset-mini/src/_variants/important.ts
@@ -20,7 +20,7 @@ export function variantImportant(): VariantObject {
           matcher: base,
           body: (body) => {
             body.forEach((v) => {
-              if (v[1])
+              if (v[1] || v[1] === 0)
                 v[1] += ' !important'
             })
             return body

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -642,6 +642,7 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .shrink-0{flex-shrink:0;}
 .shrink-\$variable{flex-shrink:var(--variable);}
 .shrink-10{flex-shrink:10;}
+.\!flex-grow-0{flex-grow:0 !important;}
 .flex-grow,
 .grow{flex-grow:1;}
 .flex-grow-0,

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -344,6 +344,7 @@ export const presetMiniTargets: string[] = [
   'flex-shrink-0',
   'flex-grow',
   'flex-grow-0',
+  '!flex-grow-0',
   'flex-basis-0',
   'flex-basis-1/2',
   'flex-$variable',


### PR DESCRIPTION
This PR changes `if (v[1])` in variantImport() to `if (v[1] || v[1] === 0)` to make sure it works with rules ending in 0 such as `!flex-grow-0`.

Feel free to edit.

fix #3896