### PR TITLE
chore(preset-legact-compact,preset-rem-to-px,preset-tagify,preset-typography): add links to jsdoc

### DIFF
--- a/packages/preset-legacy-compat/src/index.ts
+++ b/packages/preset-legacy-compat/src/index.ts
@@ -13,6 +13,9 @@ export interface LegacyCompatOptions {
   commaStyleColorFunction?: boolean
 }
 
+/**
+ * @see https://unocss.dev/presets/legacy-compat
+ */
 export const presetLegacyCompat = definePreset((options: LegacyCompatOptions = {}) => {
   const {
     commaStyleColorFunction = false,

--- a/packages/preset-rem-to-px/src/index.ts
+++ b/packages/preset-rem-to-px/src/index.ts
@@ -10,6 +10,9 @@ export interface RemToPxOptions {
   baseFontSize?: number
 }
 
+/**
+ * @see https://unocss.dev/presets/rem-to-px
+ */
 export const presetRemToPx = definePreset((options: RemToPxOptions = {}) => {
   const {
     baseFontSize = 16,

--- a/packages/preset-tagify/src/index.ts
+++ b/packages/preset-tagify/src/index.ts
@@ -7,6 +7,9 @@ export * from './extractor'
 export * from './types'
 export * from './variant'
 
+/**
+ * @see https://unocss.dev/presets/tagify
+ */
 export const presetTagify = definePreset((options: TagifyOptions = {}) => {
   const {
     defaultExtractor = true,

--- a/packages/preset-typography/src/index.ts
+++ b/packages/preset-typography/src/index.ts
@@ -57,6 +57,7 @@ export interface TypographyOptions {
  * })
  * ```
  *
+ * @see https://unocss.dev/presets/typography
  * @returns typography preset
  * @public
  */


### PR DESCRIPTION
These presets lack `@see xxx` jsdoc comments in their dts files. This PR adds their corresponding links to align the behavior of other presets.