### PR TITLE
docs: Fix an example code with nuxt merge config sample

### DIFF
--- a/docs/integrations/nuxt.md
+++ b/docs/integrations/nuxt.md
@@ -82,7 +82,7 @@ export default config
 or modify/extend it:
 
 ```ts
-import { mergeConfigs } from 'unocss'
+import { mergeConfigs } from '@unocss/core'
 import config from './.nuxt/uno.config.mjs'
 
 export default mergeConfigs([config, {

--- a/docs/integrations/nuxt.md
+++ b/docs/integrations/nuxt.md
@@ -82,12 +82,12 @@ export default config
 or modify/extend it:
 
 ```ts
-import { mergeConfigs } from '@unocss/core'
+import { mergeConfigs } from 'unocss'
 import config from './.nuxt/uno.config.mjs'
 
-export default mergeConfigs(config, {
+export default mergeConfigs([config, {
   // your overrides
-})
+}])
 ```
 
 ## License


### PR DESCRIPTION
The sample is outdated as the import is now available directly from `unocss` and the signature of function `mergeConfigs` takes an array of configs instead of what the existing example states.