### PR TITLE
feat(vscode): support Yarn PnP environment

### DIFF
--- a/packages/vscode/src/contextLoader.ts
+++ b/packages/vscode/src/contextLoader.ts
@@ -1,5 +1,6 @@
 import { readdir } from 'fs/promises'
 import path from 'path'
+import { exists } from 'fs-extra'
 import type { UnocssPluginContext, UserConfig, UserConfigDefaults } from '@unocss/core'
 import { notNull } from '@unocss/core'
 import { sourceObjectFields, sourcePluginFactory } from 'unconfig/presets'
@@ -114,6 +115,18 @@ export class ContextLoader {
     const cached = this.contextsMap.get(dir)
     if (cached !== undefined)
       return cached
+
+    // Yarn PnP workflow, setup the PnP resolver
+    for (const file of ['.pnp.js', '.pnp.cjs']) {
+      if (await exists(path.join(dir, file))) {
+        try {
+          // `require` is used due to dynamic import.
+          // eslint-disable-next-line ts/no-var-requires, ts/no-require-imports
+          require(path.join(dir, file)).setup()
+        }
+        catch {}
+      }
+    }
 
     const load = async () => {
       log.appendLine('\n-----------')


### PR DESCRIPTION
## Summary

This PR modified VSCode extension code, making it support a development environment with Yarn PnP enabled.

As I am not familiar with UnoCSS itself (this is my first Pull Request!) and also VSCode extension development, I could only try my best to make it usable.

### Workflow

- Check if there is `.pnp.cjs` or `.pnp.js` file in the current directory
- If true, try to `require` that file and then call its `setup` function
- Then, those modules that cannot be imported before should be able to be imported by Yarn's loader

### How to Test

- Build this extension code.
- Use Yarn >= v2, the easiest method is to enable `corepack` (which is available in recent Node.js).
- Create a test project with Yarn, I use `corepack yarn@4 create vite --template react-ts`.
- Install and Enable UnoCSS into that project.
- Open this VSCode extension code in VSCode, then hit `F5` and open the directory created above.

In my case, it could successfully load the config with this change:

```log
⚪️ UnoCSS for VS Code v0.61.0

📂 roots search mode.

-----------
🛠 Resolving config for /home/maiko/workspaces/common/test-unocss-vscode-ext
🛠 New configuration loaded from
  - /home/maiko/workspaces/common/test-unocss-vscode-ext/uno.config.ts
ℹ️ 1 presets, 1084 rules, 1 shortcuts, 59 variants, 0 transformers loaded
🗂️ Enabled context: /home/maiko/workspaces/common/test-unocss-vscode-ext
```

Instead of complaining that `unocss` was missing:

```log
⚪️ UnoCSS for VS Code v0.61.0

📂 roots search mode.

-----------
🛠 Resolving config for /home/maiko/workspaces/common/test-unocss-vscode-ext
⚠️ Error on loading config. Config directory: /home/maiko/workspaces/common/test-unocss-vscode-ext
Error: Cannot find module 'unocss'
Require stack:
- /home/maiko/workspaces/common/test-unocss-vscode-ext/uno.config.ts
    at Module._resolveFilename (node:internal/modules/cjs/loader:1055:15)
    at Function.i._resolveFilename (node:electron/js2c/utility_init:2:13405)
    at Function.resolve (node:internal/modules/helpers:136:19)
    at _resolve5 (/home/maiko/.vscode-insiders/extensions/antfu.unocss-0.61.0/dist/index.js:38888:36)
    at jiti2 (/home/maiko/.vscode-insiders/extensions/antfu.unocss-0.61.0/dist/index.js:38943:30)
    at /home/maiko/workspaces/common/test-unocss-vscode-ext/uno.config.ts:1:177
    at evalModule (/home/maiko/.vscode-insiders/extensions/antfu.unocss-0.61.0/dist/index.js:38989:15)
    at jiti2 (/home/maiko/.vscode-insiders/extensions/antfu.unocss-0.61.0/dist/index.js:38953:20)
    at loadConfigFile (/home/maiko/.vscode-insiders/extensions/antfu.unocss-0.61.0/dist/index.js:92218:13)
    at Object.load (/home/maiko/.vscode-insiders/extensions/antfu.unocss-0.61.0/dist/index.js:92142:24)
    at loadConfig (/home/maiko/.vscode-insiders/extensions/antfu.unocss-0.61.0/dist/index.js:92281:18)
    at reloadConfig (/home/maiko/.vscode-insiders/extensions/antfu.unocss-0.61.0/dist/index.js:92333:20)
🗂️ Enabled context: [none]
```

### Related Issues

fix #758 
fix #3566 