### PR TITLE
fix(web-fonts): missing `local` node10 types

### DIFF
--- a/packages/preset-web-fonts/package.json
+++ b/packages/preset-web-fonts/package.json
@@ -36,6 +36,14 @@
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*",
+        "./*"
+      ]
+    }
+  },
   "files": [
     "*.css",
     "dist"


### PR DESCRIPTION
This PR adds `typesVersions` to resolve types in node10 (missing in the original PR #3962):

![imagen](https://github.com/unocss/unocss/assets/6311119/47998339-1bb3-47c2-ad91-c4cc32605633)
