### PR TITLE
docs: fix vitepress md typo. Vitepress use `info` instead of `note`.

### DIFF
--- a/docs/presets/web-fonts.md
+++ b/docs/presets/web-fonts.md
@@ -228,7 +228,7 @@ export default defineConfig({
 
 This will download the fonts assets to `public/assets/fonts` and serve them from `/assets/fonts` on the client. When doing this, please make sure the license of the fonts allows you to redistribute so, the tool is not responsible for any legal issues.
 
-:::note
+::: info
 
 This feature is Node.js specific and will not work in the browser.
 


### PR DESCRIPTION
See https://unocss.dev/presets/web-fonts#serve-fonts-locally

![image](https://github.com/unocss/unocss/assets/86149525/4bbfe3d4-b7ed-454a-a538-cefd5122449b)
