### PR TITLE
fix(shared-integration): defaultIdeMatchInclude String literals

### DIFF
--- a/packages/shared-integration/src/defaults.ts
+++ b/packages/shared-integration/src/defaults.ts
@@ -14,7 +14,8 @@ export const defaultFilesystemGlobs = [
  */
 export const defaultIdeMatchInclude: RegExp[] = [
   // String literals
-  /(['"`])[^\\1]*?\1/g,
+  // eslint-disable-next-line no-control-regex
+  /(['"`])[^\x01]*?\1/g,
   // HTML tags
   /<[^/?<>0-9$_!](?:"[^"]*"|'[^']*'|[^>])+>/g,
   // CSS directives


### PR DESCRIPTION
close: #3970

# before
<img width="755" alt="image" src="https://github.com/user-attachments/assets/9b112e1f-2096-4e36-9ff1-5c1bd0ea77a8">

# after
<img width="784" alt="image" src="https://github.com/user-attachments/assets/3e3abf35-6750-476d-b57e-82c93fe653b3">
