### PR TITLE
fix(shared-integration): prevent potential data race in `flushTask`

### DIFF
--- a/packages/shared-integration/src/context.ts
+++ b/packages/shared-integration/src/context.ts
@@ -108,7 +108,8 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
   async function flushTasks() {
     const _tasks = [...tasks]
     await Promise.all(_tasks)
-    tasks.splice(0, _tasks.length)
+    if (tasks[0] === _tasks[0])
+      tasks.splice(0, _tasks.length)
   }
 
   return {


### PR DESCRIPTION
Related to #3978, but it's hard to check whether this PR can fix it.

`flushTask` can be asynchronously called for multiple times at the same time, and previously, if this happens, the `tasks` array would be spliced twice - which may cause problems of losing styles.
