### PR TITLE
fix(svelte-scoped): make sure createRecoveryConfigLoader() runs before reloadConfig()

### DIFF
--- a/packages/svelte-scoped/src/_vite/index.ts
+++ b/packages/svelte-scoped/src/_vite/index.ts
@@ -42,9 +42,8 @@ const defaults: UserConfigDefaults = {
 
 function createSvelteScopedContext(configOrPath?: UserConfig | string): SvelteScopedContext {
   const uno = createGenerator()
-  const ready = reloadConfig()
-
   const loadConfig = createRecoveryConfigLoader()
+  const ready = reloadConfig()
 
   async function reloadConfig() {
     const { config, sources } = await loadConfig(process.cwd(), configOrPath)


### PR DESCRIPTION
This PR fixes an error caused by  `const ready = reloadConfig();` (that called `loadConfig()`) being run before `const loadConfig = createRecoveryConfigLoader();`

https://github.com/unocss/unocss/pull/3953 didn't really solve the main issue in Svelte Scoped because destructuring here:

`const { config, sources } = await loadConfig(process.cwd(), configOrPath)`

won't work when the returned value of loadConfig is undefined. 

I'm also not sure how it's supposed to work in here:

```ts
try {
      const config = await loadConfig(cwd, configOrPath, extraConfigSources, defaults)
      lastResolved = config
      return config
    }
    catch (e) {
      if (lastResolved) {
        console.error(e)
        return lastResolved
      }
      throw e
    }
```

If `lastResolved` is only set when `loadConfig()` didn't give an error it seems to me like

```ts
        console.error(e)
        return lastResolved
      }
```

will never happen.

---

I managed to edit Svelte Scoped so the server doesn't crash using
`packages/svelte-scoped/src/_vite/index.ts`
```ts
  async function reloadConfig() {
    let config, sources;
    let loadedConfig = await loadConfig(process.cwd(), configOrPath);
    if (loadedConfig) {
      config = loadedConfig.config;
      sources = loadedConfig.sources
      uno.setConfig(config, defaults);
      return { config, sources };
    }
    else {
      console.error("Could not reload UnoCSS config.")
      return;
    }
  }
  return {
    uno,
    ready
  };
```

but maybe there's a more reasonable solution?