### PR TITLE
feat(preset-mini): support `(float|clear)-(start|end)`

### DIFF
--- a/packages/preset-mini/src/_rules/position.ts
+++ b/packages/preset-mini/src/_rules/position.ts
@@ -150,6 +150,8 @@ export const floats: Rule[] = [
   // floats
   ['float-left', { float: 'left' }],
   ['float-right', { float: 'right' }],
+  ['float-start', { float: 'inline-start' }],
+  ['float-end', { float: 'inline-end' }],
   ['float-none', { float: 'none' }],
   ...makeGlobalStaticRules('float'),
 
@@ -157,6 +159,8 @@ export const floats: Rule[] = [
   ['clear-left', { clear: 'left' }],
   ['clear-right', { clear: 'right' }],
   ['clear-both', { clear: 'both' }],
+  ['clear-start', { clear: 'inline-start' }],
+  ['clear-end', { clear: 'inline-end' }],
   ['clear-none', { clear: 'none' }],
   ...makeGlobalStaticRules('clear'),
 ]


### PR DESCRIPTION
Add logical support for `float` and `clear`: `float-start`, `float-end`, `clear-start`, and `clear-end`. [Tailwind has added these](https://tailwindcss.com/docs/float).