### PR TITLE
chore: update `.vscodeignore`

### DIFF
--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -2,3 +2,7 @@
 .vscode/**
 .vscode-test/**
 scripts/**
+src/**
+test/**
+tsconfig.json
+tsup.config.ts


### PR DESCRIPTION
I think the published plugin does not need to contain ts code and related configuration files.