### PR TITLE
docs(integrations): add unocss to nuxt docs

### DIFF
--- a/docs/integrations/nuxt.md
+++ b/docs/integrations/nuxt.md
@@ -11,13 +11,13 @@ The Nuxt module for UnoCSS.
 
 ::: code-group
   ```bash [pnpm]
-  pnpm add -D @unocss/nuxt
+  pnpm add -D unocss @unocss/nuxt
   ```
   ```bash [yarn]
-  yarn add -D @unocss/nuxt
+  yarn add -D unocss @unocss/nuxt
   ```
   ```bash [npm]
-  npm install -D @unocss/nuxt
+  npm install -D unocss @unocss/nuxt
   ```
 :::
 


### PR DESCRIPTION
This PR adds `unocss` to nuxt integrations docs for less confusion.