### PR TITLE
fix(@unocss/inspector): fix Typescript lookup paths error

### DIFF
--- a/alias.ts
+++ b/alias.ts
@@ -12,7 +12,7 @@ export const alias: Record<string, string> = {
   '@unocss/core': r('./packages/core/src/'),
   '@unocss/extractor-pug': r('./packages/extractor-pug/src/'),
   '@unocss/extractor-svelte': r('./packages/extractor-svelte/src/'),
-  '@unocss/inspector': r('./packages/inspector/node/'),
+  '@unocss/inspector': r('./packages/inspector/src/'),
   '@unocss/nuxt': r('./packages/nuxt/src/'),
   '@unocss/preset-attributify': r('./packages/preset-attributify/src/'),
   '@unocss/preset-icons': r('./packages/preset-icons/src/'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
       "@unocss/extractor-arbitrary-variants": ["./packages/extractor-arbitrary-variants/src/index.ts"],
       "@unocss/extractor-pug": ["./packages/extractor-pug/src/index.ts"],
       "@unocss/extractor-svelte": ["./packages/extractor-svelte/src/index.ts"],
-      "@unocss/inspector": ["./packages/inspector/node/index.ts"],
+      "@unocss/inspector": ["./packages/inspector/src/index.ts"],
       "@unocss/postcss": ["./packages/postcss/src/index.ts"],
       "@unocss/postcss/esm": ["./packages/postcss/src/esm.ts"],
       "@unocss/preset-attributify": ["./packages/preset-attributify/src/index.ts"],


### PR DESCRIPTION
There seems to be an error in the configuration of the `@unocss/inspector` path in tsconfig.json. Which result in the error `Could not find a declaration file for module '@unocss/inspector'` occurs in the `index.ts` file located at `unocss/packages/vite/src/`.

<img width="910" alt="WeChatWorkScreenshot_3a869a5a-a72d-41f2-929f-693e7fde6cea" src="https://github.com/user-attachments/assets/8812ba94-17af-4f50-a82d-305791ca8d29">
