### PR TITLE
test(svelte-scoped): replace hard coded utility count value with utility count from the returned result

### DIFF
--- a/packages/svelte-scoped/src/_preprocess/transformApply/getUtils.test.ts
+++ b/packages/svelte-scoped/src/_preprocess/transformApply/getUtils.test.ts
@@ -29,7 +29,7 @@ describe('getUtils', async () => {
     expect(result).toMatchInlineSnapshot(`
       [
         [
-          86,
+          ${result[0][0]},
           ".\\-",
           "margin-bottom:0.25rem;margin-right:0.25rem;",
           undefined,
@@ -41,7 +41,7 @@ describe('getUtils', async () => {
           undefined,
         ],
         [
-          86,
+          ${result[0][0]},
           ".\\-:hover",
           "margin-right:0.5rem;",
           undefined,
@@ -64,7 +64,7 @@ describe('getUtils', async () => {
     expect(result).toMatchInlineSnapshot(`
       [
         [
-          86,
+          ${result[0][0]},
           ".\\-:hover",
           "margin-right:0.25rem;font-weight:500;",
           undefined,


### PR DESCRIPTION
This PR replaces the hard coded utility count value in a Svelte Scoped test with the actual returned utility count from `result`. The utility count isn't what's being tested here and this test fails in any PR that adds utilities. (for example https://github.com/unocss/unocss/pull/3997)

