### PR TITLE
docs: nuxt-layers example

### DIFF
--- a/examples/nuxt3-layers/nuxt.config.ts
+++ b/examples/nuxt3-layers/nuxt.config.ts
@@ -4,6 +4,8 @@ export default defineNuxtConfig({
     '@unocss/nuxt',
   ],
   unocss: {
+    attributify: true,
+    icons: true,
     nuxtLayers: true,
     shortcuts: [
       ['btn', 'px-4 py-1 rounded inline-block bg-teal-600 text-white cursor-pointer hover:bg-teal-700 disabled:cursor-default disabled:bg-gray-600 disabled:opacity-50'],


### PR DESCRIPTION
I've noticed that the Nuxt Example and the Nuxt Layers Example look different. This PR fixes that.

https://stackblitz.com/github/unocss/unocss/tree/main/examples/nuxt3
https://stackblitz.com/github/unocss/unocss/tree/main/examples/nuxt3-layers