### PR TITLE
docs(vscode): include `vscode-iconify` extension hint for icons preset

### DIFF
--- a/docs/integrations/vscode.md
+++ b/docs/integrations/vscode.md
@@ -16,3 +16,11 @@ description: UnoCSS for VS Code.
 To get the best IDE experience, we recommend you to [use a separate `uno.config.ts` file](/guide/config-file) for configuring your UnoCSS.
 
 The extension will try to find the UnoCSS configurations under your project. When there is no config found, the extension will be disabled.
+
+## Icons Preset
+
+If you're using the [Icons Preset](/presets/icons), you can also install [Iconify IntelliSense](https://marketplace.visualstudio.com/items?itemName=antfu.iconify):
+- inline display corresponding icons
+- auto-completion for icon-sets
+- hover
+- snippets

--- a/docs/integrations/vscode.md
+++ b/docs/integrations/vscode.md
@@ -19,8 +19,4 @@ The extension will try to find the UnoCSS configurations under your project. Whe
 
 ## Icons Preset
 
-If you're using the [Icons Preset](/presets/icons), you can also install [Iconify IntelliSense](https://marketplace.visualstudio.com/items?itemName=antfu.iconify):
-- inline display corresponding icons
-- auto-completion for icon-sets
-- hover
-- snippets
+If you're using the [Icons Preset](/presets/icons), you can also install [Iconify IntelliSense](https://marketplace.visualstudio.com/items?itemName=antfu.iconify) to get inlay preview, auto-completion, and hover information for your icons.


### PR DESCRIPTION
Testing some repo with icons the extension not working and found this comment from Anthony: https://github.com/unocss/unocss/issues/692#issuecomment-1064426263