### PR TITLE
docs: display rainbow switcher in Firefox

### DIFF
--- a/docs/.vitepress/theme/components/RainbowAnimationSwitcher.vue
+++ b/docs/.vitepress/theme/components/RainbowAnimationSwitcher.vue
@@ -118,8 +118,4 @@ const switchTitle = computed(() => {
   /*rtl:ignore*/
   transform: translateX(18px);
 }
-
-html.browser-firefox .group {
-  display: none !important;
-}
 </style>


### PR DESCRIPTION
Firefox also applying rainbow animation, this PR just removes the style to display the switcher.