### PR TITLE
fix(preset-icons): missing default unit `em`

### DIFF
--- a/packages/preset-icons/src/core.ts
+++ b/packages/preset-icons/src/core.ts
@@ -29,7 +29,7 @@ export function createPresetIcons(lookupIconLoader: (options: IconsOptions) => P
       autoInstall = false,
       collectionsNodeResolvePath,
       layer = 'icons',
-      unit,
+      unit = 'em',
       processor,
     } = options
 


### PR DESCRIPTION
I have a strange behavior if you don't set `unit` in config but tsdoc default is em
 https://github.com/unocss/unocss/blob/bdd82c3200c10c3ef3b922b47ebd392155ecb6c4/packages/preset-icons/src/types.ts#L90

style: 

```css
.i-belong-icon-checkmark{
  background:url("data:image/svg+xml;utf8,...") no-repeat;
  background-size:100% 100%;
  background-color:transparent;
  display:inline-block;
  width:24;
  height:25;
}
```

![CleanShot 2024-08-07 at 16 57 18@2x](https://github.com/user-attachments/assets/ec854fde-8f83-4a51-be34-9627159ecad0)
