### PR TITLE
docs: add descriptions of `breakpoints` and `extendTheme`

### DIFF
--- a/docs/config/theme.md
+++ b/docs/config/theme.md
@@ -16,9 +16,9 @@ UnoCSS also supports the theming system that you might be familiar with in Tailw
 theme: {
   // ...
   colors: {
-    'veryCool': '#0000ff', // class="text-very-cool"
-    'brand': {
-      'primary': 'hsl(var(--hue, 217) 78% 51%)', //class="bg-brand-primary"
+    veryCool: '#0000ff', // class="text-very-cool"
+    brand: {
+      primary: 'hsl(var(--hue, 217) 78% 51%)', //class="bg-brand-primary"
     },
   },
 }
@@ -88,6 +88,21 @@ theme: {
 }
 ```
 
+If you want to inherit the `original` theme breakpoints, you can use the `extendTheme`:
+
+```ts
+extendTheme: (theme) => {
+  return {
+    ...theme,
+    breakpoints: {
+      ...theme.breakpoints,
+      sm: '320px',
+      md: '640px',
+    },
+  }
+}
+```
+
 ::: info
 `verticalBreakpoints` is same as `breakpoints` but for vertical layout.
 :::
@@ -106,5 +121,37 @@ theme: {
     md: `${40 * 16}px`,
     lg: '960px',
   },
+}
+```
+
+## ExtendTheme
+
+`ExtendTheme` allows you to edit the **deeply merged theme** to get the complete theme object.
+
+Custom functions mutate the theme object.
+
+```ts
+extendTheme: (theme) => {
+  theme.colors.veryCool = '#0000ff' // class="text-very-cool"
+  theme.colors.brand = {
+    primary: 'hsl(var(--hue, 217) 78% 51%)', // class="bg-brand-primary"
+  }
+}
+```
+
+It's also possible to return a new theme object to completely replace the original one.
+
+```ts
+extendTheme: (theme) => {
+  return {
+    ...theme,
+    colors: {
+      ...theme.colors,
+      veryCool: '#0000ff', // class="text-very-cool"
+      brand: {
+        primary: 'hsl(var(--hue, 217) 78% 51%)', // class="bg-brand-primary"
+      },
+    },
+  }
 }
 ```

--- a/docs/presets/mini.md
+++ b/docs/presets/mini.md
@@ -116,16 +116,18 @@ will generate:
 ### Theme
 You can fully customize your theme property in your config, and UnoCSS will eventually deeply merge it to the default theme.
 
-<!--eslint-skip-->
+:::warning
+`breakpoints` propertie isn't deeply merged, but overridden, see [Breakpoints](/config/theme#breakpoints).
+:::
 
 ```ts
 presetMini({
   theme: {
     // ...
     colors: {
-      'veryCool': '#0000ff', // class="text-very-cool"
-      'brand': {
-        'primary': 'hsl(var(--hue, 217) 78% 51%)', //class="bg-brand-primary"
+      veryCool: '#0000ff', // class="text-very-cool"
+      brand: {
+        primary: 'hsl(var(--hue, 217) 78% 51%)', // class="bg-brand-primary"
       }
     },
   }

--- a/docs/presets/mini.md
+++ b/docs/presets/mini.md
@@ -117,7 +117,7 @@ will generate:
 You can fully customize your theme property in your config, and UnoCSS will eventually deeply merge it to the default theme.
 
 :::warning
-`breakpoints` propertie isn't deeply merged, but overridden, see [Breakpoints](/config/theme#breakpoints).
+`breakpoints` property isn't deeply merged, but overridden, see [Breakpoints](/config/theme#breakpoints).
 :::
 
 ```ts


### PR DESCRIPTION
Related to #3038 