### PR TITLE
fix(svelte-scoped): fix error check

### DIFF
--- a/packages/svelte-scoped/src/_vite/index.ts
+++ b/packages/svelte-scoped/src/_vite/index.ts
@@ -14,7 +14,7 @@ import { ConfigHMRPlugin } from './config-hmr'
 export function UnocssSvelteScopedVite(options: UnocssSvelteScopedViteOptions = {}): Plugin[] {
   const context = createSvelteScopedContext(options.configOrPath)
 
-  if (context.uno.config.transformers)
+  if (context.uno.config.transformers?.length)
     throw new Error('Due to the differences in normal UnoCSS global usage and Svelte Scoped usage, "config.transformers" will be ignored. You can still use transformers in CSS files with the "cssFileTransformers" option.')
 
   if (!options.classPrefix)


### PR DESCRIPTION
The addition in #4071 breaks svelte-scoped since there's a condition to check for the presence of transformers within the config.

Empty arrays are still truthy in JS; this fixes it.