### PR TITLE
fix(attributify): add `b` type for jsx

### DIFF
--- a/packages/preset-attributify/src/jsx.ts
+++ b/packages/preset-attributify/src/jsx.ts
@@ -83,6 +83,7 @@ export type SeparateEnabled =
   | 'backdrop'
   | 'bg'
   | 'blend'
+  | 'b'
   | 'border'
   | 'box'
   | 'container'


### PR DESCRIPTION
fix: 
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/cf0e50c8-e1c2-4e86-8e1f-ac7f905fd530">


fixed:
<img width="1113" alt="image" src="https://github.com/user-attachments/assets/47d0cdc5-bd80-4852-8a83-ddd4f42cb87d">


<img width="389" alt="image" src="https://github.com/user-attachments/assets/6226ad15-a5c4-4040-9aef-06a5829007e3">
