### PR TITLE
docs: update group icon plugin

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitepress'
 import type { DefaultTheme } from 'vitepress/types'
 import { transformerTwoslash } from '@shikijs/vitepress-twoslash'
-import { groupIconPlugin } from 'vitepress-plugin-group-icons'
+import { groupIconMdPlugin } from 'vitepress-plugin-group-icons'
 import { version } from '../../package.json'
 
 const ogUrl = 'https://unocss.dev/'
@@ -283,7 +283,7 @@ export default defineConfig({
       }),
     ],
     config(md) {
-      md.use(groupIconPlugin)
+      md.use(groupIconMdPlugin)
     },
   },
 

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,7 +3,6 @@ import { h, watch } from 'vue'
 import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import TwoslashFloatingVue from '@shikijs/vitepress-twoslash/client'
-import { GroupIconComponent } from 'vitepress-plugin-group-icons/client'
 import UnoCSSLayout from './UnoCSSLayout.vue'
 import RainbowAnimationSwitcher from './components/RainbowAnimationSwitcher.vue'
 
@@ -13,6 +12,7 @@ import './rainbow.css'
 import './vars.css'
 import './overrides.css'
 import 'uno.css'
+import 'virtual:group-icons.css'
 
 let homePageStyle: HTMLStyleElement | undefined
 
@@ -24,7 +24,6 @@ export default {
   enhanceApp({ app, router }) {
     app.component('RainbowAnimationSwitcher', RainbowAnimationSwitcher)
     app.use(TwoslashFloatingVue)
-    app.use(GroupIconComponent)
 
     if (typeof window === 'undefined')
       return

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import UnoCSS from 'unocss/vite'
 import Components from 'unplugin-vue-components/vite'
+import { groupIconVitePlugin } from 'vitepress-plugin-group-icons'
 
 export default defineConfig({
   optimizeDeps: {
@@ -25,5 +26,6 @@ export default defineConfig({
         /\.md$/,
       ],
     }),
+    groupIconVitePlugin(),
   ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,8 +379,8 @@ catalogs:
       specifier: ^1.3.3
       version: 1.3.3
     vitepress-plugin-group-icons:
-      specifier: ^1.0.0
-      version: 1.0.0
+      specifier: ^1.0.1
+      version: 1.0.1
     vitest:
       specifier: ^2.0.5
       version: 2.0.5
@@ -800,7 +800,7 @@ importers:
         version: 1.3.3(@algolia/client-search@4.19.1)(@types/node@22.5.0)(@types/react@18.3.4)(fuse.js@7.0.0)(postcss@8.4.41)(react@18.3.1)(search-insights@2.7.0)(terser@5.31.6)(typescript@5.5.4)
       vitepress-plugin-group-icons:
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 1.0.1
 
   examples/vue-cli4:
     dependencies:
@@ -3266,7 +3266,7 @@ packages:
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^9.9.0
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
   '@eslint-community/regexpp@4.11.0':
     resolution: {integrity: sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==}
@@ -6438,7 +6438,7 @@ packages:
     resolution: {integrity: sha512-3RQOsJEoAExM3KHAayvTpRJQOYxTETP89RS9x0QRBK4cvCut0Tyjmb1xVQWY8ibC49M0B+QeSGrVZhtbcxOl4Q==}
     peerDependencies:
       eslint: ^9.0.0
-      vitest: ^2.0.5
+      vitest: ^1.0.0 || ^2.0.0
 
   eslint@9.9.1:
     resolution: {integrity: sha512-dHvhrbfr4xFQ9/dq+jcVneZMyRYLjggWjk6RVsIiHsP8Rz6yZ8LvZ//iU4TrZF+SXWG+JkNF2OyiZRvzgRDqMg==}
@@ -10495,8 +10495,8 @@ packages:
       vite:
         optional: true
 
-  vitepress-plugin-group-icons@1.0.0:
-    resolution: {integrity: sha512-YJsKk56WJ7BM+hIMjqOG5055EpjaW5snkxT3BnxUqDBBXen0T1x/Ln7HZWRjC1eTxLVlajNr/6weapGZ5jJaSA==}
+  vitepress-plugin-group-icons@1.0.1:
+    resolution: {integrity: sha512-wt169hnYGtRz68GgGxh9qx8AIQATGDluWT0x79Y9HuA/Z+q22W07lo5mCGrafYl3Fnme4C0i2WY1zKOqQl8KdA==}
 
   vitepress@1.3.3:
     resolution: {integrity: sha512-6UzEw/wZ41S/CATby7ea7UlffvRER/uekxgN6hbEvSys9ukmLOKsz87Ehq9yOx1Rwiw+Sj97yjpivP8w1sUmng==}
@@ -21375,7 +21375,7 @@ snapshots:
     optionalDependencies:
       vite: 5.4.2(@types/node@22.5.0)(terser@5.31.6)
 
-  vitepress-plugin-group-icons@1.0.0:
+  vitepress-plugin-group-icons@1.0.1:
     dependencies:
       '@iconify-json/logos': 1.1.44
       '@iconify/utils': 2.1.32

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -138,7 +138,7 @@ catalog:
   vite-plugin-pages: ^0.32.3
   vite-plugin-windicss: ^1.9.3
   vitepress: ^1.3.3
-  vitepress-plugin-group-icons: ^1.0.0
+  vitepress-plugin-group-icons: ^1.0.1
   vitest: ^2.0.5
   vue: ^3.4.38
   vue-eslint-parser: ^9.4.3


### PR DESCRIPTION
There are breaking changes after [vitepress-plugin-group-icons@v1.0.0](https://github.com/yuyinws/vitepress-plugin-group-icons/releases/tag/v1.0.0).

It will generate the pure css icon now and no js runtime needed.

And when this PR([vitepress@4152](https://github.com/vuejs/vitepress/pull/4152)) is release on Vitepress, the markdown config is also no need: 

https://github.com/yuyinws/unocss/blob/7efb16f4e9a84ad2bc8885bf57e82eff96b7b213/docs/.vitepress/config.ts#L285-L288

I will open another pr then.
