### PR TITLE
style(play): fix light mode playground selection background 

### DIFF
--- a/packages/inspector/client/theme.ts
+++ b/packages/inspector/client/theme.ts
@@ -41,7 +41,7 @@ export const vitesseTheme = EditorView.theme({
   },
 
   '.cm-cursor, .cm-dropCursor': { borderLeftColor: cursor },
-  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': { backgroundColor: selection },
+  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': { backgroundColor: `${selection} !important` },
 
   '.cm-panels': { backgroundColor: darkBackground, color: foreground },
   '.cm-panels.cm-panels-top': { borderBottom: '2px solid black' },


### PR DESCRIPTION
fix light mode playgorund selection background

Before: 
<img width="584" alt="image" src="https://github.com/user-attachments/assets/3dee0701-3a3f-4494-9ab1-3c136ec5d59f">

preview: https://unocss.dev/play/

After:
<img width="675" alt="image" src="https://github.com/user-attachments/assets/5e7e5a0c-8371-49ab-ba02-4d84b5d425a8">

preview: https://deploy-preview-4107--unocss.netlify.app/play/

