### PR TITLE
fix(svelte-scoped): dynamically import presetUno

### DIFF
--- a/packages/svelte-scoped/src/_preprocess/index.ts
+++ b/packages/svelte-scoped/src/_preprocess/index.ts
@@ -1,7 +1,6 @@
 import process from 'node:process'
 import type { PreprocessorGroup } from 'svelte/types/compiler/preprocess'
 import { type UnoGenerator, type UserConfig, type UserConfigDefaults, createGenerator, warnOnce } from '@unocss/core'
-import presetUno from '@unocss/preset-uno'
 import { createRecoveryConfigLoader } from '@unocss/config'
 import { transformClasses } from './transformClasses'
 import { checkForApply, transformStyle } from './transformStyle'
@@ -84,10 +83,15 @@ async function getGenerator(config: UserConfig, unoContextFromVite?: SvelteScope
     return unoContextFromVite.uno
   }
 
-  const defaults: UserConfigDefaults = {
-    presets: [
-      presetUno(),
-    ],
+  let defaults: UserConfigDefaults | undefined
+  if (!config.presets) {
+    const presetUno = (await import('@unocss/preset-uno')).default
+    defaults = {
+      presets: [
+        presetUno(),
+      ],
+    }
   }
+
   return createGenerator(config, defaults)
 }

--- a/packages/svelte-scoped/src/_vite/index.ts
+++ b/packages/svelte-scoped/src/_vite/index.ts
@@ -3,7 +3,6 @@ import type { Plugin } from 'vite'
 import { createGenerator } from '@unocss/core'
 import type { UserConfig, UserConfigDefaults } from '@unocss/core'
 import { createRecoveryConfigLoader } from '@unocss/config'
-import presetUno from '@unocss/preset-uno'
 import type { SvelteScopedContext } from '../preprocess'
 import type { UnocssSvelteScopedViteOptions } from './types'
 import { PassPreprocessToSveltePlugin } from './passPreprocessToSveltePlugin'
@@ -34,12 +33,6 @@ export function UnocssSvelteScopedVite(options: UnocssSvelteScopedViteOptions = 
   return plugins
 }
 
-const defaults: UserConfigDefaults = {
-  presets: [
-    presetUno(),
-  ],
-}
-
 function createSvelteScopedContext(configOrPath?: UserConfig | string): SvelteScopedContext {
   const uno = createGenerator()
   const loadConfig = createRecoveryConfigLoader()
@@ -47,6 +40,17 @@ function createSvelteScopedContext(configOrPath?: UserConfig | string): SvelteSc
 
   async function reloadConfig() {
     const { config, sources } = await loadConfig(process.cwd(), configOrPath)
+
+    let defaults: UserConfigDefaults | undefined
+    if (!config.presets) {
+      const presetUno = (await import('@unocss/preset-uno')).default
+      defaults = {
+        presets: [
+          presetUno(),
+        ],
+      }
+    }
+
     uno.setConfig(config, defaults)
     return { config, sources }
   }


### PR DESCRIPTION
fixes https://github.com/unocss/unocss/issues/4116

Allows using `@unocss/svelte-scoped` without having to install `@unocss/preset-uno`