### PR TITLE
feat(extractor-pug): make extractor-pug work with `svelte`

### DIFF
--- a/packages/extractor-pug/src/index.ts
+++ b/packages/extractor-pug/src/index.ts
@@ -25,7 +25,7 @@ export default function extractorPug(options: Options = {}): Extractor {
         }
         catch {}
       }
-      else if (ctx.id.endsWith('.vue')) {
+      else if (ctx.id.endsWith('.vue') || ctx.id.endsWith('.svelte')) {
         const matches = Array.from(ctx.code.matchAll(regexVueTemplate))
         let tail = ''
         for (const match of matches) {


### PR DESCRIPTION
this is a quick and dirty fix, as [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess/blob/main/docs/preprocessing.md#auto-preprocessing-options) allows setting an arbitray `markupTagName` instead of "template".

todo: should really make option to adjust the `regexVueTemplate`.