### PR TITLE
fix(vscode): when loadContextInDirectory error not add contextsMap

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -68,6 +68,8 @@ export async function loadConfig<U extends UserConfig>(
   return result
 }
 
+export const errorCwdMap = new Set()
+
 /**
  * Create a factory function that returns a config loader that recovers from errors.
  *
@@ -90,6 +92,8 @@ export function createRecoveryConfigLoader<U extends UserConfig>() {
     }
     catch (e) {
       if (lastResolved) {
+        // 如果报错了，就不要再追加到 this.contextsMap 中
+        errorCwdMap.add(cwd)
         console.error(e)
         return lastResolved
       }

--- a/packages/vscode/src/contextLoader.ts
+++ b/packages/vscode/src/contextLoader.ts
@@ -6,6 +6,7 @@ import { notNull } from '@unocss/core'
 import { sourceObjectFields, sourcePluginFactory } from 'unconfig/presets'
 import presetUno from '@unocss/preset-uno'
 import type { ExtensionContext, StatusBarItem } from 'vscode'
+import { errorCwdMap } from '@unocss/config'
 import { resolveOptions as resolveNuxtOptions } from '../../nuxt/src/options'
 import { createNanoEvents } from '../../core/src/utils/events'
 import { createContext, isCssId } from './integration'
@@ -217,8 +218,10 @@ export class ContextLoader {
     }
 
     const context = await load()
-    if (!this.contextsMap.has(dir))
+    if (!this.contextsMap.has(dir) && !errorCwdMap.has(dir))
       this.contextsMap.set(dir, context)
+    else if (errorCwdMap.has(dir))
+      errorCwdMap.delete(dir)
     this.fileContextCache.clear()
     this.events.emit('reload')
 


### PR DESCRIPTION
close: #4133
If an error is reported, do not append it to this.contextsMap, otherwise it will be cached and subsequent updates will not take effect.
By the way, the @ method of `unconfig` using alias does not seem to be supported.

