### PR TITLE
feat(docs): enhance `code block` readability

### DIFF
--- a/docs/config/extractors.md
+++ b/docs/config/extractors.md
@@ -2,8 +2,7 @@
 
 Extractors are used to extract the usage of utilities from your source code.
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 
 export default defineConfig({
@@ -17,8 +16,7 @@ By default [extractorSplit](https://github.com/unocss/unocss/blob/main/packages/
 
 To override the default extractors, you can use `extractorDefault` option.
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 
 export default defineConfig({

--- a/docs/config/presets.md
+++ b/docs/config/presets.md
@@ -4,8 +4,7 @@ Presets are partial configurations that will be merged into the main configurati
 
 When authoring a preset, we usually export a constructor function that you could ask for some preset-specific options. For example:
 
-```ts
-// my-preset.ts
+```ts [my-preset.ts]
 import { Preset, definePreset } from 'unocss'
 
 export default definePreset((options?: MyPresetOptions) => {
@@ -24,8 +23,7 @@ export default definePreset((options?: MyPresetOptions) => {
 
 Then the user can use it like this:
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import myPreset from './my-preset'
 

--- a/docs/config/rules.md
+++ b/docs/config/rules.md
@@ -164,8 +164,7 @@ When you really need some advanced rules that aren't covered by the combination 
 
 It allows you to return a string from the dynamic rule's body function which will be **directly** passed to the generated CSS (this also means you need to take care of things like CSS escaping, variant applying, CSS constructing, and so on).
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig, toEscapedSelector as e } from 'unocss'
 
 export default defineConfig({

--- a/docs/config/transformers.md
+++ b/docs/config/transformers.md
@@ -2,8 +2,7 @@
 
 Provides a unified interface to transform source code in order to support conventions.
 
-```ts
-// my-transformer.ts
+```ts [my-transformer.ts]
 import { createFilter } from '@rollup/pluginutils'
 import { SourceCodeTransformer } from 'unocss'
 

--- a/docs/extractors/arbitrary-variants.md
+++ b/docs/extractors/arbitrary-variants.md
@@ -28,7 +28,7 @@ This extractor is included in [`@unocss/preset-mini`](/presets/mini) as the defa
   ```
 :::
 
-```ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import extractorArbitrary from '@unocss/extractor-arbitrary-variants'
 

--- a/docs/extractors/mdc.md
+++ b/docs/extractors/mdc.md
@@ -21,7 +21,7 @@ Support extracting classes from [MDC (Markdown Components)](https://content.nuxt
   ```
 :::
 
-```ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import extractorMdc from '@unocss/extractor-mdc'
 

--- a/docs/extractors/pug.md
+++ b/docs/extractors/pug.md
@@ -21,7 +21,7 @@ Support extracting classes from Pug template.
   ```
 :::
 
-```ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import extractorPug from '@unocss/extractor-pug'
 

--- a/docs/extractors/svelte.md
+++ b/docs/extractors/svelte.md
@@ -32,8 +32,7 @@ Will be extracted as `text-orange-400` and generates:
   ```
 :::
 
-```ts
-// uno.config.js
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import extractorSvelte from '@unocss/extractor-svelte'
 

--- a/docs/guide/config-file.md
+++ b/docs/guide/config-file.md
@@ -4,8 +4,7 @@ We **highly recommend to use a dedicated `uno.config.ts` file** to configure you
 
 A full featured config file looks like this:
 
-```ts twoslash
-// uno.config.ts
+```ts twoslash [uno.config.ts]
 import {
   defineConfig,
   presetAttributify,
@@ -48,8 +47,7 @@ Compared to the inline configuration inside your `vite.config.ts` or other tools
 
 By default, UnoCSS will automatically look for `uno.config.{js,ts,mjs,mts}` or `unocss.config.{js,ts,mjs,mts}` in the root directory of your project. You can also specify the config file manually, for example in Vite:
 
-```ts
-// vite.config.ts
+```ts [vite.config.ts]
 import { defineConfig } from 'vite'
 import UnoCSS from 'unocss/vite'
 

--- a/docs/guide/extracting.md
+++ b/docs/guide/extracting.md
@@ -26,8 +26,7 @@ By default, UnoCSS will extract the utilities usage from files in your build pip
 
 To configure them, you can update your `uno.config.ts`:
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 export default defineConfig({
   content: {
     pipeline: {
@@ -79,8 +78,7 @@ If you want the UnoCSS to skip a block of code without being extracted in any ex
 
 In cases that you are using integrations that does not have access to the build tools pipeline (for example, the [PostCSS](/integrations/postcss) plugin), or you are integrating with backend frameworks such that the code does not go through the pipeline, you can manually specify the files to be extracted.
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 export default defineConfig({
   content: {
     filesystem: [
@@ -99,8 +97,7 @@ Additionally, you can also extract utilities usages from inline text, that you m
 
 You may also pass an async function to return the content. But note that the function will only be called once at the build time.
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 export default defineConfig({
   content: {
     inline: [
@@ -130,8 +127,7 @@ Sometimes you might want to use dynamic concatenations like:
 
 Due the fact that UnoCSS works in build time using static extraction, at the compile time it can't possibility know all the combination of the utilities then. For that, you can configure the `safelist` option.
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 safelist: 'p-1 p-2 p-3 p-4'.split(' ')
 ```
 
@@ -146,8 +142,7 @@ The corresponding CSS will always be generated:
 
 Or more flexible:
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 safelist: [
   ...Array.from({ length: 4 }, (_, i) => `p-${i + 1}`),
 ]
@@ -184,8 +179,7 @@ And then use it in your template:
 
 Similar to `safelist`, you can also configure `blocklist` to exclude some utilities from being generated. This is useful to exclude some extraction false positives. Different from `safelist`, `blocklist` accepts both string for exact match and regular expression for pattern match.
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 blocklist: [
   'p-1',
   /^p-[2-4]$/,

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -9,8 +9,7 @@ UnoCSS is the instant atomic CSS engine, that is designed to be flexible and ext
 
 For example, you could define your custom CSS utilities, by providing rules in your local [config file](/guide/config-file).
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 
 export default defineConfig({
@@ -34,8 +33,7 @@ This will add a new CSS utility `m-1` to your project. Since UnoCSS is on-demand
 
 To make it more flexible, you can make your rule dynamic by changing the first argument on the rule (we call it matcher) to a `RegExp`, and the body to a function, for example:
 
-```diff
-// uno.config.ts
+```diff [uno.config.ts]
 export default defineConfig({
   rules: [
 -    ['m-1', { margin: '1px' }],
@@ -60,8 +58,7 @@ By doing this, now you can have arbitrary margin utilities, like `m-1`, `m-100` 
 
 Once you made a few rules, you can extract them into a preset, and share it with others. For example, you can create a preset for your company's design system, and share it with your team.
 
-```ts
-// my-preset.ts
+```ts [my-preset.ts]
 import { Preset } from 'unocss'
 
 export const myPreset: Preset = {
@@ -76,8 +73,7 @@ export const myPreset: Preset = {
 }
 ```
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import { myPreset } from './my-preset'
 

--- a/docs/guide/presets.md
+++ b/docs/guide/presets.md
@@ -12,8 +12,7 @@ Presets are the heart of UnoCSS. They let you make your own custom framework in 
 
 To set presets to your project:
 
-```ts twoslash
-// uno.config.ts
+```ts twoslash [uno.config.ts]
 import { defineConfig, presetAttributify, presetUno } from 'unocss'
 
 export default defineConfig({
@@ -29,8 +28,7 @@ When the `presets` option is specified, the default preset will be ignored.
 
 To disable the default preset, you can set `presets` to an empty array:
 
-```ts twoslash
-// uno.config.ts
+```ts twoslash [uno.config.ts]
 import { defineConfig } from 'unocss'
 
 export default defineConfig({

--- a/docs/integrations/astro.md
+++ b/docs/integrations/astro.md
@@ -21,8 +21,7 @@ The UnoCSS integration for [Astro](https://astro.build/): `@unocss/astro`. Check
   ```
 :::
 
-```ts
-// astro.config.ts
+```ts [astro.config.ts]
 import { defineConfig } from 'astro/config'
 import UnoCSS from 'unocss/astro'
 
@@ -35,8 +34,7 @@ export default defineConfig({
 
 Create a `uno.config.ts` file:
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 
 export default defineConfig({
@@ -62,8 +60,7 @@ By default, [browser style reset](/guide/style-reset) will not be injected. To e
 
 And update your `astro.config.ts`:
 
-```ts
-// astro.config.ts
+```ts [astro.config.ts]
 import { defineConfig } from 'astro/config'
 import UnoCSS from 'unocss/astro'
 
@@ -92,8 +89,7 @@ This plugin does not come with any default presets.
   ```
 :::
 
-```ts
-// astro.config.mjs
+```ts [astro.config.mjs]
 import UnoCSS from '@unocss/astro'
 
 export default {

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -59,7 +59,7 @@ Example package configuration:
 Make sure to add escaped quotes to your npm script glob patterns.
 :::
 
-```json
+```json [package.json]
 {
   "scripts": {
     "dev": "unocss \"site/{snippets,templates}/**/*.php\" --watch",
@@ -93,7 +93,7 @@ The final `uno.css` will be generated to the current directory by default.
 
 Create a `uno.config.js` or `uno.config.ts` configuration file the root-level of your project to customize UnoCSS.
 
-```ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 
 export default defineConfig({

--- a/docs/integrations/eslint.md
+++ b/docs/integrations/eslint.md
@@ -23,8 +23,7 @@ ESLint config for UnoCSS: `@unocss/eslint-config`.
 
 In [Flat Config Style](https://eslint.org/docs/latest/use/configure/configuration-files-new):
 
-```js
-// eslint.config.js
+```js [eslint.config.js]
 import unocss from '@unocss/eslint-config/flat'
 
 export default [
@@ -35,7 +34,7 @@ export default [
 
 In legacy `.eslintrc` style:
 
-```json
+```json [.eslintrc]
 {
   "extends": [
     "@unocss"
@@ -54,7 +53,7 @@ In legacy `.eslintrc` style:
 
 These rules are not enabled by default. To enable it, add the following to your `.eslintrc`:
 
-```json
+```json [.eslintrc]
 {
   "extends": [
     "@unocss"
@@ -72,8 +71,7 @@ Throw warning or error when using utilities listed in `blocklist` get matched.
 
 You can customize messages for blocked rules to make them more informative and context-specific by using the `message` property of the meta object:
 
-```ts
-// uno.config.ts
+```ts [unocss.config.ts]
 export default defineConfig({
   blocklist: [
     ['bg-red-500', { message: 'Use bg-red-600 instead' }],

--- a/docs/integrations/next.md
+++ b/docs/integrations/next.md
@@ -29,8 +29,7 @@ Getting Started with UnoCSS and Next.js.
 
 Create `uno.config.ts` at the root of your project.
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import {
   defineConfig,
   presetAttributify,

--- a/docs/integrations/nuxt.md
+++ b/docs/integrations/nuxt.md
@@ -23,8 +23,7 @@ The Nuxt module for UnoCSS.
 
 Add `@unocss/nuxt` to your Nuxt config file:
 
-```ts
-// nuxt.config.ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   modules: [
     '@unocss/nuxt',
@@ -34,8 +33,7 @@ export default defineNuxtConfig({
 
 Create a `uno.config.ts` file:
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 
 export default defineConfig({
@@ -60,8 +58,7 @@ We recommend to use the dedicated `uno.config.ts` file for configuration. See [C
 
 You can enable the `nuxtLayers` option, so Nuxt will automatically merge `uno.config` files from each Nuxt layer:
 
-```ts
-// nuxt.config.ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   // ...
   unocss: {
@@ -72,8 +69,7 @@ export default defineNuxtConfig({
 
 then you can reexport the generated config in the root config file:
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import config from './.nuxt/uno.config.mjs'
 
 export default config

--- a/docs/integrations/postcss.md
+++ b/docs/integrations/postcss.md
@@ -27,8 +27,7 @@ This package is in an experimental state right now. It doesn't follow semver, an
   ```
 :::
 
-```ts
-// postcss.config.mjs
+```ts [postcss.config.mjs]
 import UnoCSS from '@unocss/postcss'
 
 export default {
@@ -38,8 +37,7 @@ export default {
 }
 ```
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig, presetUno } from 'unocss'
 
 export default defineConfig({
@@ -54,8 +52,7 @@ export default defineConfig({
 })
 ```
 
-```css
-/* style.css */
+```css [style.css]
 @unocss;
 ```
 
@@ -67,8 +64,7 @@ export default defineConfig({
 
 You can also inject each layer individually:
 
-```css
-/* style.css */
+```css [style.css]
 @unocss preflights;
 @unocss default;
 

--- a/docs/integrations/runtime.md
+++ b/docs/integrations/runtime.md
@@ -12,7 +12,7 @@ UnoCSS runtime provide a CDN build that runs the UnoCSS right in the browser. It
 
 Add the following line to your `index.html`:
 
-```html
+```html [index.html]
 <script src="https://cdn.jsdelivr.net/npm/@unocss/runtime"></script>
 ```
 

--- a/docs/integrations/svelte-scoped.md
+++ b/docs/integrations/svelte-scoped.md
@@ -191,8 +191,7 @@ In Svelte or SvelteKit apps, inject generated styles directly into your Svelte c
 
 Add `@unocss/svelte-scoped/vite` to your Vite config:
 
-```ts
-// vite.config.ts
+```ts [vite.config.ts]
 import { defineConfig } from 'vite'
 import { sveltekit } from '@sveltejs/kit/vite'
 import UnoCSS from '@unocss/svelte-scoped/vite'
@@ -218,7 +217,7 @@ While almost all styles are placed into individual components, there are still a
 
 Add the `%unocss-svelte-scoped.global%` placeholder into your `<head>` tag. In Svelte this is `index.html`. In SvelteKit this will be in `app.html` before `%sveltekit.head%`:
 
-```html
+```html [index.html]
 <head>
   <!-- ... -->
   <title>SvelteKit using UnoCSS Svelte Scoped</title>
@@ -229,7 +228,7 @@ Add the `%unocss-svelte-scoped.global%` placeholder into your `<head>` tag. In S
 
 If using SvelteKit, you also must add the following to the `transformPageChunk` hook in your `src/hooks.server.js` file:
 
-```js
+```js [src/hooks.server.js]
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
   const response = await resolve(event, {
@@ -271,8 +270,7 @@ Use utility styles to build a component library that is not dependent on includi
 
 Add `@unocss/svelte-scoped/preprocess` to your Svelte config:
 
-```ts
-// svelte.config.js
+```ts [svelte.config.js]
 import adapter from '@sveltejs/adapter-auto'
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 import UnoCSS from '@unocss/svelte-scoped/preprocess'
@@ -342,8 +340,7 @@ Your safelist styles will be wrapped with `:global()` to avoid being automatical
 
 Place your UnoCSS settings in an `uno.config.ts` file:
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 
 export default defineConfig({
@@ -371,8 +368,7 @@ For other presets, if they don't rely on traditional `class="..."` usage you wil
 
 Transformers are supported for your CSS files (css|postcss|sass|scss|less|stylus|styl). To use them, add the transformer into the `cssFileTransformers` option in your `vite.config.ts`:
 
-```ts
-// vite.config.ts
+```ts [vite.config.ts]
 import transformerDirectives from '@unocss/transformer-directives'
 
 export default defineConfig({

--- a/docs/integrations/vite.md
+++ b/docs/integrations/vite.md
@@ -33,8 +33,7 @@ The Vite plugin ships with the `unocss` package.
 
 Install the plugin:
 
-```ts
-// vite.config.ts
+```ts [vite.config.ts]
 import UnoCSS from 'unocss/vite'
 import { defineConfig } from 'vite'
 
@@ -47,8 +46,7 @@ export default defineConfig({
 
 Create a `uno.config.ts` file:
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 
 export default defineConfig({
@@ -58,8 +56,7 @@ export default defineConfig({
 
 Add `virtual:uno.css` to your main entry:
 
-```ts
-// main.ts
+```ts [main.ts]
 import 'virtual:uno.css'
 ```
 
@@ -122,8 +119,7 @@ When using VanillaJS or TypeScript, you need to add `js` and `ts` files extensio
 
 If you're using `@vitejs/plugin-react`:
 
-```ts
-// vite.config.js
+```ts [vite.config.ts]
 import UnoCSS from 'unocss/vite'
 import React from '@vitejs/plugin-react'
 
@@ -139,8 +135,7 @@ If you're using `@unocss/preset-attributify` you should remove `tsc` from the `b
 
 If you are using `@vitejs/plugin-react` with `@unocss/preset-attributify`, you must add the plugin before `@vitejs/plugin-react`.
 
-```ts
-// vite.config.js
+```ts [vite.config.ts]
 import UnoCSS from 'unocss/vite'
 import React from '@vitejs/plugin-react'
 
@@ -160,8 +155,7 @@ You have a `React` example project on [examples/vite-react](https://github.com/u
 
 If you're using `@preact/preset-vite`:
 
-```ts
-// vite.config.js
+```ts [vite.config.ts]
 import Preact from '@preact/preset-vite'
 import UnoCSS from 'unocss/vite'
 
@@ -175,8 +169,7 @@ export default {
 
 or if you're using `@prefresh/vite`:
 
-```ts
-// vite.config.js
+```ts [vite.config.ts]
 import Prefresh from '@prefresh/vite'
 import UnoCSS from 'unocss/vite'
 
@@ -202,8 +195,7 @@ To support `class:foo` and `class:foo={bar}` add the plugin and configure `extra
 
 You can use simple rules with `class:`, for example `class:bg-red-500={foo}` or using `shortcuts` to include multiples rules, see `src/App.svelte` on linked example project below.
 
-```ts
-// vite.config.js
+```ts [vite.config.ts]
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import UnoCSS from 'unocss/vite'
 import extractorSvelte from '@unocss/extractor-svelte'
@@ -229,8 +221,7 @@ To support `class:foo` and `class:foo={bar}` add the plugin and configure `extra
 
 You can use simple rules with `class:`, for example `class:bg-red-500={foo}` or using `shortcuts` to include multiples rules, see `src/routes/+layout.svelte` on linked example project below.
 
-```ts
-// vite.config.js
+```ts [vite.config.ts]
 import { sveltekit } from '@sveltejs/kit/vite'
 import UnoCSS from 'unocss/vite'
 import extractorSvelte from '@unocss/extractor-svelte'
@@ -261,8 +252,7 @@ To work with web components you need to enable `shadow-dom` mode on the plugin.
 
 Don't forget to remove the import for `uno.css` since the `shadow-dom` mode will not expose it and the application will not work.
 
-```ts
-// vite.config.js
+```ts [vite.config.ts]
 import UnoCSS from 'unocss/vite'
 
 export default {
@@ -312,8 +302,7 @@ The `part-[<part-name>]:<rule|shortcut>` will work only with this plugin using t
 
 The plugin uses `nth-of-type` to avoid collisions with multiple parts in the same web component and for the same parts on distinct web components, you don't need to worry about it, the plugin will take care for you.
 
-```ts
-// vite.config.js
+```ts [vite.config.ts]
 import UnoCSS from 'unocss/vite'
 
 export default {
@@ -362,8 +351,7 @@ template.innerHTML = `
 
 You need to add the `vite-plugin-solid` plugin after UnoCSS's plugin.
 
-```ts
-// vite.config.js
+```ts [vite.config.ts]
 import solidPlugin from 'vite-plugin-solid'
 import UnoCSS from 'unocss/vite'
 
@@ -383,8 +371,7 @@ export default {
 
 You need to add the `vite-plugin-elm` plugin before UnoCSS's plugin.
 
-```ts
-// vite.config.js
+```ts [vite.config.ts]
 import { defineConfig } from 'vite'
 import Elm from 'vite-plugin-elm'
 import UnoCSS from 'unocss/vite'

--- a/docs/integrations/webpack.md
+++ b/docs/integrations/webpack.md
@@ -96,8 +96,7 @@ module.exports = {
 
 Create a `uno.config.ts` file:
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 
 export default defineConfig({
@@ -113,8 +112,7 @@ If you are using webpack@4.x, the `optimization.realContentHash` configuration i
 
 Add `uno.css` to your main entry:
 
-```ts
-// main.ts
+```ts [main.ts]
 import 'uno.css'
 ```
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,6 @@
     "ofetch": "catalog:",
     "unocss": "workspace:*",
     "vitepress": "catalog:",
-    "vitepress-plugin-group-icons": "^1.2.3"
+    "vitepress-plugin-group-icons": "catalog:"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,6 @@
     "ofetch": "catalog:",
     "unocss": "workspace:*",
     "vitepress": "catalog:",
-    "vitepress-plugin-group-icons": "catalog:"
+    "vitepress-plugin-group-icons": "^1.2.3"
   }
 }

--- a/docs/presets/attributify.md
+++ b/docs/presets/attributify.md
@@ -24,8 +24,7 @@ This enables the [attributify mode](#attributify-mode) for other presets.
   ```
 :::
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import presetAttributify from '@unocss/preset-attributify'
 
 export default defineConfig({
@@ -152,8 +151,7 @@ Create `shims.d.ts` with the following content:
 
 Since Volar 0.36, [it's now strict to unknown attributes](https://github.com/johnsoncodehk/volar/issues/1077#issuecomment-1145361472). To opt-out, you can add the following file to your project:
 
-```ts
-// html.d.ts
+```ts [html.d.ts]
 declare module '@vue/runtime-dom' {
   interface HTMLAttributes {
     [key: string]: any

--- a/docs/presets/icons.md
+++ b/docs/presets/icons.md
@@ -67,8 +67,7 @@ Check [all available icons](https://icones.js.org/).
 
 We use [Iconify](https://iconify.design) as our data source of icons. You need to install the corresponding icon-set in `devDependencies` by following the `@iconify-json/*` pattern. For example, `@iconify-json/mdi` for [Material Design Icons](https://materialdesignicons.com/), `@iconify-json/tabler` for [Tabler](https://tabler-icons.io/). You can refer to [Icônes](https://icones.js.org/) or [Iconify](https://icon-sets.iconify.design/) for all the collections available.
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import presetIcons from '@unocss/preset-icons'
 
@@ -208,8 +207,7 @@ You can also provide your own custom collections using also [CustomIconLoader](h
 
 Additionally, you can also use [FileSystemIconLoader](https://github.com/iconify/iconify/blob/master/packages/utils/src/loader/node-loaders.ts#L9) to load your custom icons from your file system. You will need to install `@iconify/utils` package as `dev dependency`.
 
-```ts
-// uno.config.ts
+```ts [unocss.config.ts]
 import fs from 'node:fs/promises'
 import { defineConfig, presetIcons } from 'unocss'
 
@@ -254,8 +252,7 @@ External packages must include `icons.json` file with the `icons` data in `Iconi
 :::
 
 For example, you can use `an-awesome-collection` or `@my-awesome-collections/some-collection` to load your custom or third party icons:
-```ts
-// uno.config.ts
+```ts [unocss.config.ts]
 import { defineConfig, presetIcons } from 'unocss'
 import { createExternalPackageIconLoader } from '@iconify/utils/lib/loader/external-pkg'
 
@@ -269,8 +266,7 @@ export default defineConfig({
 ```
 
 You can also combine it with other custom icon loaders, for example:
-```ts
-// uno.config.ts
+```ts [unocss.config.ts]
 import { defineConfig, presetIcons } from 'unocss'
 import { FileSystemIconLoader } from 'unplugin-icons/loaders'
 import { createExternalPackageIconLoader } from '@iconify/utils/lib/loader/external-pkg'

--- a/docs/presets/legacy-compat.md
+++ b/docs/presets/legacy-compat.md
@@ -28,8 +28,7 @@ By default none of the options are enabled, you need to opt-in each of them expl
   ```
 :::
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import presetLegacyCompat from '@unocss/preset-legacy-compat'
 

--- a/docs/presets/mini.md
+++ b/docs/presets/mini.md
@@ -24,8 +24,7 @@ The basic preset for UnoCSS, with only the most essential utilities.
   ```
 :::
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import presetMini from '@unocss/preset-mini'
 

--- a/docs/presets/rem-to-px.md
+++ b/docs/presets/rem-to-px.md
@@ -24,8 +24,7 @@ Converts rem to px for all utilities.
   ```
 :::
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import presetRemToPx from '@unocss/preset-rem-to-px'
 

--- a/docs/presets/tagify.md
+++ b/docs/presets/tagify.md
@@ -24,8 +24,7 @@ This enables the [tagify mode](#tagify-mode) for other presets.
   ```
 :::
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import presetTagify from '@unocss/preset-tagify'
 

--- a/docs/presets/typography.md
+++ b/docs/presets/typography.md
@@ -34,8 +34,7 @@ import { presetTypography } from 'unocss'
 
 ## Usage
 
-```js
-// uno.config.ts
+```js [uno.config.js]
 import {
   defineConfig,
   presetAttributify,
@@ -196,8 +195,7 @@ interface TypographyCompatibilityOptions {
 
 ## Example
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig, presetAttributify, presetUno } from 'unocss'
 import { presetTypography } from '@unocss/preset-typography'
 

--- a/docs/presets/uno.md
+++ b/docs/presets/uno.md
@@ -28,8 +28,7 @@ This preset inherits [`@unocss/preset-wind`](/presets/wind) and [`@unocss/preset
   ```
 :::
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import presetUno from '@unocss/preset-uno'
 

--- a/docs/presets/web-fonts.md
+++ b/docs/presets/web-fonts.md
@@ -26,8 +26,7 @@ See [all supported providers](#providers).
   ```
 :::
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import presetWebFonts from '@unocss/preset-web-fonts'
 import presetUno from '@unocss/preset-uno'
@@ -65,8 +64,7 @@ PR welcome to add more providers. 🙌
 
 Use your own function to fetch font source.
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import presetWebFonts from '@unocss/preset-web-fonts'
 import presetUno from '@unocss/preset-uno'

--- a/docs/presets/wind.md
+++ b/docs/presets/wind.md
@@ -28,8 +28,7 @@ This preset inherits [`@unocss/preset-mini`](/presets/mini).
   ```
 :::
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import presetWind from '@unocss/preset-wind'
 
@@ -136,8 +135,7 @@ However, setting `important` to `true` can introduce some issues when incorporat
 
 To get around this, you can set important to an ID selector like `#app` instead:
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import presetWind from '@unocss/preset-wind'
 

--- a/docs/transformers/attributify-jsx.md
+++ b/docs/transformers/attributify-jsx.md
@@ -59,8 +59,7 @@ export function Component() {
   ```
 :::
 
-```ts{12}
-// uno.config.ts
+```ts{11} [uno.config.ts]
 import { defineConfig, presetAttributify } from 'unocss'
 import transformerAttributifyJsx from '@unocss/transformer-attributify-jsx'
 

--- a/docs/transformers/compile-class.md
+++ b/docs/transformers/compile-class.md
@@ -24,8 +24,7 @@ Compile group of classes into one class. Inspired by the [compilation mode](http
   ```
 :::
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import transformerCompileClass from '@unocss/transformer-compile-class'
 

--- a/docs/transformers/directives.md
+++ b/docs/transformers/directives.md
@@ -22,8 +22,7 @@ UnoCSS transformer for `@apply`, `@screen` and `theme()` directives: `@unocss/tr
   ```
 :::
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import transformerDirectives from '@unocss/transformer-directives'
 

--- a/docs/transformers/variant-group.md
+++ b/docs/transformers/variant-group.md
@@ -21,8 +21,7 @@ Enables the [variant group feature](https://windicss.org/features/variant-groups
   ```
 :::
 
-```ts
-// uno.config.ts
+```ts [uno.config.ts]
 import { defineConfig } from 'unocss'
 import transformerVariantGroup from '@unocss/transformer-variant-group'
 

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -26,6 +26,10 @@ export default defineConfig({
         /\.md$/,
       ],
     }),
-    groupIconVitePlugin(),
+    groupIconVitePlugin({
+      customIcon: {
+        postcss: 'vscode-icons:file-type-postcss',
+      },
+    }),
   ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ catalogs:
     vitepress:
       specifier: ^1.3.3
       version: 1.3.3
+    vitepress-plugin-group-icons:
+      specifier: ^1.2.3
+      version: 1.2.3
     vitest:
       specifier: ^2.0.5
       version: 2.0.5
@@ -796,7 +799,7 @@ importers:
         specifier: 'catalog:'
         version: 1.3.3(@algolia/client-search@4.19.1)(@types/node@22.5.0)(@types/react@18.3.4)(fuse.js@7.0.0)(postcss@8.4.41)(react@18.3.1)(search-insights@2.7.0)(terser@5.31.6)(typescript@5.5.4)
       vitepress-plugin-group-icons:
-        specifier: ^1.2.3
+        specifier: 'catalog:'
         version: 1.2.3
 
   examples/vue-cli4:
@@ -810,10 +813,10 @@ importers:
         version: link:../../packages/webpack
       '@vue/cli-plugin-babel':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(esbuild@0.23.1)(vue@2.7.16)
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(vue@2.7.16)
       '@vue/cli-service':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
+        version: 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -838,10 +841,10 @@ importers:
         version: link:../../packages/webpack
       '@vue/cli-plugin-babel':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(esbuild@0.23.1)(vue@2.7.16)
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(vue@2.7.16)
       '@vue/cli-service':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
+        version: 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
       unocss:
         specifier: link:../../packages/unocss
         version: link:../../packages/unocss
@@ -1589,13 +1592,13 @@ importers:
     devDependencies:
       '@types/webpack':
         specifier: 'catalog:'
-        version: 5.28.5(esbuild@0.23.1)
+        version: 5.28.5
       '@types/webpack-sources':
         specifier: 'catalog:'
         version: 3.2.3
       webpack:
         specifier: 'catalog:'
-        version: 5.94.0(esbuild@0.23.1)
+        version: 5.94.0
 
   playground:
     devDependencies:
@@ -13708,13 +13711,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.94.0(esbuild@0.23.1))':
+  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.94.0)':
     dependencies:
       chalk: 3.0.0
       error-stack-parser: 2.1.4
       string-width: 4.2.3
       strip-ansi: 6.0.1
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
 
   '@soda/get-current-script@1.0.2': {}
 
@@ -14011,11 +14014,11 @@ snapshots:
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
 
-  '@types/webpack@5.28.5(esbuild@0.23.1)':
+  '@types/webpack@5.28.5':
     dependencies:
       '@types/node': 22.5.0
       tapable: 2.2.1
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -14388,15 +14391,15 @@ snapshots:
 
   '@vue/cli-overlay@5.0.8': {}
 
-  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(esbuild@0.23.1)(vue@2.7.16)':
+  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(vue@2.7.16)':
     dependencies:
       '@babel/core': 7.25.2
       '@vue/babel-preset-app': 5.0.8(@babel/core@7.25.2)(core-js@3.38.1)(vue@2.7.16)
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
-      babel-loader: 8.3.0(@babel/core@7.25.2)(webpack@5.94.0(esbuild@0.23.1))
-      thread-loader: 3.0.4(webpack@5.94.0(esbuild@0.23.1))
-      webpack: 5.94.0(esbuild@0.23.1)
+      babel-loader: 8.3.0(@babel/core@7.25.2)(webpack@5.94.0)
+      thread-loader: 3.0.4(webpack@5.94.0)
+      webpack: 5.94.0
     transitivePeerDependencies:
       - '@swc/core'
       - core-js
@@ -14407,29 +14410,29 @@ snapshots:
       - vue
       - webpack-cli
 
-  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(encoding@0.1.13)':
+  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(encoding@0.1.13)':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
-  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))':
+  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
 
-  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)':
+  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)':
     dependencies:
       '@babel/helper-compilation-targets': 7.25.2
-      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.94.0(esbuild@0.23.1))
+      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.94.0)
       '@soda/get-current-script': 1.0.2
       '@types/minimist': 1.2.5
       '@vue/cli-overlay': 5.0.8
-      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(encoding@0.1.13)
-      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))
+      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(encoding@0.1.13)
+      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)(pug@3.0.3)(react@18.3.1)
-      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.4.38)(css-loader@6.11.0(webpack@5.94.0(esbuild@0.23.1)))(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.94.0(esbuild@0.23.1))
+      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.4.38)(css-loader@6.11.0(webpack@5.94.0))(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.94.0)
       '@vue/web-component-wrapper': 1.3.0
       acorn: 8.12.1
       acorn-walk: 8.3.3
@@ -14440,9 +14443,9 @@ snapshots:
       cli-highlight: 2.1.11
       clipboardy: 2.3.0
       cliui: 7.0.4
-      copy-webpack-plugin: 9.1.0(webpack@5.94.0(esbuild@0.23.1))
-      css-loader: 6.11.0(webpack@5.94.0(esbuild@0.23.1))
-      css-minimizer-webpack-plugin: 3.4.1(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1))
+      copy-webpack-plugin: 9.1.0(webpack@5.94.0)
+      css-loader: 6.11.0(webpack@5.94.0)
+      css-minimizer-webpack-plugin: 3.4.1(webpack@5.94.0)
       cssnano: 5.1.15(postcss@8.4.41)
       debug: 4.3.6
       default-gateway: 6.0.3
@@ -14451,27 +14454,27 @@ snapshots:
       fs-extra: 9.1.0
       globby: 11.1.0
       hash-sum: 2.0.0
-      html-webpack-plugin: 5.6.0(webpack@5.94.0(esbuild@0.23.1))
+      html-webpack-plugin: 5.6.0(webpack@5.94.0)
       is-file-esm: 1.0.0
       launch-editor-middleware: 2.8.1
       lodash.defaultsdeep: 4.6.1
       lodash.mapvalues: 4.6.0
-      mini-css-extract-plugin: 2.9.0(webpack@5.94.0(esbuild@0.23.1))
+      mini-css-extract-plugin: 2.9.0(webpack@5.94.0)
       minimist: 1.2.8
       module-alias: 2.2.3
       portfinder: 1.0.32
       postcss: 8.4.41
-      postcss-loader: 6.2.1(postcss@8.4.41)(webpack@5.94.0(esbuild@0.23.1))
-      progress-webpack-plugin: 1.0.16(webpack@5.94.0(esbuild@0.23.1))
+      postcss-loader: 6.2.1(postcss@8.4.41)(webpack@5.94.0)
+      progress-webpack-plugin: 1.0.16(webpack@5.94.0)
       ssri: 8.0.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1))
-      thread-loader: 3.0.4(webpack@5.94.0(esbuild@0.23.1))
-      vue-loader: 17.4.2(@vue/compiler-sfc@3.4.38)(vue@2.7.16)(webpack@5.94.0(esbuild@0.23.1))
+      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
+      thread-loader: 3.0.4(webpack@5.94.0)
+      vue-loader: 17.4.2(@vue/compiler-sfc@3.4.38)(vue@2.7.16)(webpack@5.94.0)
       vue-style-loader: 4.1.3
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
       webpack-bundle-analyzer: 4.10.2
       webpack-chain: 6.5.1
-      webpack-dev-server: 4.15.2(debug@4.3.6)(webpack@5.94.0(esbuild@0.23.1))
+      webpack-dev-server: 4.15.2(debug@4.3.6)(webpack@5.94.0)
       webpack-merge: 5.10.0
       webpack-virtual-modules: 0.4.6
       whatwg-fetch: 3.6.20
@@ -15215,14 +15218,14 @@ snapshots:
 
   b4a@1.6.4: {}
 
-  babel-loader@8.3.0(@babel/core@7.25.2)(webpack@5.94.0(esbuild@0.23.1)):
+  babel-loader@8.3.0(@babel/core@7.25.2)(webpack@5.94.0):
     dependencies:
       '@babel/core': 7.25.2
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -15762,7 +15765,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@9.1.0(webpack@5.94.0(esbuild@0.23.1)):
+  copy-webpack-plugin@9.1.0(webpack@5.94.0):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -15770,7 +15773,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
 
   core-js-compat@3.38.0:
     dependencies:
@@ -15831,7 +15834,7 @@ snapshots:
     dependencies:
       postcss: 8.4.41
 
-  css-loader@6.11.0(webpack@5.94.0(esbuild@0.23.1)):
+  css-loader@6.11.0(webpack@5.94.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.41)
       postcss: 8.4.41
@@ -15842,9 +15845,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
 
-  css-minimizer-webpack-plugin@3.4.1(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1)):
+  css-minimizer-webpack-plugin@3.4.1(webpack@5.94.0):
     dependencies:
       cssnano: 5.1.15(postcss@8.4.41)
       jest-worker: 27.5.1
@@ -15852,9 +15855,7 @@ snapshots:
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
       source-map: 0.6.1
-      webpack: 5.94.0(esbuild@0.23.1)
-    optionalDependencies:
-      esbuild: 0.23.1
+      webpack: 5.94.0
 
   css-select@4.3.0:
     dependencies:
@@ -17332,7 +17333,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0(esbuild@0.23.1)):
+  html-webpack-plugin@5.6.0(webpack@5.94.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -17340,7 +17341,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
 
   htmlparser2@6.1.0:
     dependencies:
@@ -18508,11 +18509,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.0(webpack@5.94.0(esbuild@0.23.1)):
+  mini-css-extract-plugin@2.9.0(webpack@5.94.0):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
 
   minimalistic-assert@1.0.1: {}
 
@@ -19391,13 +19392,13 @@ snapshots:
       tsx: 4.16.2
       yaml: 2.5.0
 
-  postcss-loader@6.2.1(postcss@8.4.41)(webpack@5.94.0(esbuild@0.23.1)):
+  postcss-loader@6.2.1(postcss@8.4.41)(webpack@5.94.0):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
       postcss: 8.4.41
       semver: 7.6.3
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
 
   postcss-merge-longhand@5.1.7(postcss@8.4.41):
     dependencies:
@@ -19703,12 +19704,12 @@ snapshots:
 
   process@0.11.10: {}
 
-  progress-webpack-plugin@1.0.16(webpack@5.94.0(esbuild@0.23.1)):
+  progress-webpack-plugin@1.0.16(webpack@5.94.0):
     dependencies:
       chalk: 2.4.2
       figures: 2.0.0
       log-update: 2.3.0
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
 
   promise-retry@2.0.1:
     dependencies:
@@ -20753,16 +20754,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  terser-webpack-plugin@5.3.10(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1)):
+  terser-webpack-plugin@5.3.10(webpack@5.94.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.31.6
-      webpack: 5.94.0(esbuild@0.23.1)
-    optionalDependencies:
-      esbuild: 0.23.1
+      webpack: 5.94.0
 
   terser@5.31.6:
     dependencies:
@@ -20783,14 +20782,14 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  thread-loader@3.0.4(webpack@5.94.0(esbuild@0.23.1)):
+  thread-loader@3.0.4(webpack@5.94.0):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.0
       loader-utils: 2.0.4
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
 
   through@2.3.8: {}
 
@@ -21576,15 +21575,15 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.4.38)(css-loader@6.11.0(webpack@5.94.0(esbuild@0.23.1)))(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.94.0(esbuild@0.23.1)):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.4.38)(css-loader@6.11.0(webpack@5.94.0))(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.94.0):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)(pug@3.0.3)(react@18.3.1)
-      css-loader: 6.11.0(webpack@5.94.0(esbuild@0.23.1))
+      css-loader: 6.11.0(webpack@5.94.0)
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4
       vue-style-loader: 4.1.3
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.4.38
       prettier: 2.8.8
@@ -21644,12 +21643,12 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@17.4.2(@vue/compiler-sfc@3.4.38)(vue@2.7.16)(webpack@5.94.0(esbuild@0.23.1)):
+  vue-loader@17.4.2(@vue/compiler-sfc@3.4.38)(vue@2.7.16)(webpack@5.94.0):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.1
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.4.38
       vue: 2.7.16
@@ -21757,16 +21756,16 @@ snapshots:
       deepmerge: 1.5.2
       javascript-stringify: 2.1.0
 
-  webpack-dev-middleware@5.3.4(webpack@5.94.0(esbuild@0.23.1)):
+  webpack-dev-middleware@5.3.4(webpack@5.94.0):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
 
-  webpack-dev-server@4.15.2(debug@4.3.6)(webpack@5.94.0(esbuild@0.23.1)):
+  webpack-dev-server@4.15.2(debug@4.3.6)(webpack@5.94.0):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -21796,10 +21795,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.94.0(esbuild@0.23.1))
+      webpack-dev-middleware: 5.3.4(webpack@5.94.0)
       ws: 8.18.0
     optionalDependencies:
-      webpack: 5.94.0(esbuild@0.23.1)
+      webpack: 5.94.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -21818,7 +21817,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.94.0(esbuild@0.23.1):
+  webpack@5.94.0:
     dependencies:
       '@types/estree': 1.0.5
       '@webassemblyjs/ast': 1.12.1
@@ -21840,7 +21839,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1))
+      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,9 +378,6 @@ catalogs:
     vitepress:
       specifier: ^1.3.3
       version: 1.3.3
-    vitepress-plugin-group-icons:
-      specifier: ^1.0.3
-      version: 1.0.3
     vitest:
       specifier: ^2.0.5
       version: 2.0.5
@@ -799,8 +796,8 @@ importers:
         specifier: 'catalog:'
         version: 1.3.3(@algolia/client-search@4.19.1)(@types/node@22.5.0)(@types/react@18.3.4)(fuse.js@7.0.0)(postcss@8.4.41)(react@18.3.1)(search-insights@2.7.0)(terser@5.31.6)(typescript@5.5.4)
       vitepress-plugin-group-icons:
-        specifier: 'catalog:'
-        version: 1.0.3
+        specifier: ^1.2.3
+        version: 1.2.3
 
   examples/vue-cli4:
     dependencies:
@@ -813,10 +810,10 @@ importers:
         version: link:../../packages/webpack
       '@vue/cli-plugin-babel':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(vue@2.7.16)
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(esbuild@0.23.1)(vue@2.7.16)
       '@vue/cli-service':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
+        version: 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -841,10 +838,10 @@ importers:
         version: link:../../packages/webpack
       '@vue/cli-plugin-babel':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(vue@2.7.16)
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(esbuild@0.23.1)(vue@2.7.16)
       '@vue/cli-service':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
+        version: 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
       unocss:
         specifier: link:../../packages/unocss
         version: link:../../packages/unocss
@@ -1592,13 +1589,13 @@ importers:
     devDependencies:
       '@types/webpack':
         specifier: 'catalog:'
-        version: 5.28.5
+        version: 5.28.5(esbuild@0.23.1)
       '@types/webpack-sources':
         specifier: 'catalog:'
         version: 3.2.3
       webpack:
         specifier: 'catalog:'
-        version: 5.94.0
+        version: 5.94.0(esbuild@0.23.1)
 
   playground:
     devDependencies:
@@ -1756,6 +1753,9 @@ packages:
   '@antfu/install-pkg@0.4.0':
     resolution: {integrity: sha512-vI73C0pFA9L+5v+djh0WSLXb8qYQGH5fX8nczaFe1OTI/8Fh03JS1Mov1V7urb6P3A2cBlBqZNjJIKv54+zVRw==}
 
+  '@antfu/install-pkg@0.4.1':
+    resolution: {integrity: sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==}
+
   '@antfu/ni@0.22.4':
     resolution: {integrity: sha512-uCzh43cmUwQQcgv2BPyo0JWOMgXhcaE+F2I6Ucmfc7f9ir52lfA4OtZXdfL5D8cMa5GAwuCSNqOshIol8YN82g==}
     hasBin: true
@@ -1788,44 +1788,44 @@ packages:
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/core-auth@1.7.2':
-    resolution: {integrity: sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==}
+  '@azure/core-auth@1.8.0':
+    resolution: {integrity: sha512-YvFMowkXzLbXNM11yZtVLhUCmuG0ex7JKOH366ipjmHBhL3vpDcPAeWF+jf0X+jVXwFqo3UhsWUq4kH0ZPdu/g==}
     engines: {node: '>=18.0.0'}
 
   '@azure/core-client@1.9.2':
     resolution: {integrity: sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/core-rest-pipeline@1.16.1':
-    resolution: {integrity: sha512-ExPSbgjwCoht6kB7B4MeZoBAxcQSIl29r/bPeazZJx50ej4JJCByimLOrZoIsurISNyJQQHf30b3JfqC3Hb88A==}
+  '@azure/core-rest-pipeline@1.17.0':
+    resolution: {integrity: sha512-62Vv8nC+uPId3j86XJ0WI+sBf0jlqTqPUFCBNrGtlaUeQUIXWV/D8GE5A1d+Qx8H7OQojn2WguC8kChD6v0shA==}
     engines: {node: '>=18.0.0'}
 
   '@azure/core-tracing@1.1.2':
     resolution: {integrity: sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/core-util@1.9.0':
-    resolution: {integrity: sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==}
+  '@azure/core-util@1.10.0':
+    resolution: {integrity: sha512-dqLWQsh9Nro1YQU+405POVtXnwrIVqPyfUzc4zXCbThTg7+vNNaiMkwbX9AMXKyoFYFClxmB3s25ZFr3+jZkww==}
     engines: {node: '>=18.0.0'}
 
   '@azure/identity@4.3.0':
     resolution: {integrity: sha512-LHZ58/RsIpIWa4hrrE2YuJ/vzG1Jv9f774RfTTAVDZDriubvJ0/S5u4pnw4akJDlS0TiJb6VMphmVUFsWmgodQ==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/logger@1.1.2':
-    resolution: {integrity: sha512-l170uE7bsKpIU6B/giRc9i4NI0Mj+tANMMMxf7Zi/5cKzEqPayP7+X1WPrG7e+91JgY8N+7K7nF2WOi7iVhXvg==}
+  '@azure/logger@1.1.4':
+    resolution: {integrity: sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/msal-browser@3.17.0':
-    resolution: {integrity: sha512-csccKXmW2z7EkZ0I3yAoW/offQt+JECdTIV/KrnRoZyM7wCSsQWODpwod8ZhYy7iOyamcHApR9uCh0oD1M+0/A==}
+  '@azure/msal-browser@3.23.0':
+    resolution: {integrity: sha512-+QgdMvaeEpdtgRTD7AHHq9aw8uga7mXVHV1KshO1RQ2uI5B55xJ4aEpGlg/ga3H+0arEVcRfT4ZVmX7QLXiCVw==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-common@14.12.0':
-    resolution: {integrity: sha512-IDDXmzfdwmDkv4SSmMEyAniJf6fDu3FJ7ncOjlxkDuT85uSnLEhZi3fGZpoR7T4XZpOMx9teM9GXBgrfJgyeBw==}
+  '@azure/msal-common@14.14.2':
+    resolution: {integrity: sha512-XV0P5kSNwDwCA/SjIxTe9mEAsKB0NqGNSuaVrkCCE2lAyBr/D6YtD80Vkdp4tjWnPFwjzkwldjr1xU/facOJog==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-node@2.9.2':
-    resolution: {integrity: sha512-8tvi6Cos3m+0KmRbPjgkySXi+UQU/QiuVRFnrxIwt5xZlEEFa69O04RTaNESGgImyBBlYbo2mfE8/U8Bbdk1WQ==}
+  '@azure/msal-node@2.13.1':
+    resolution: {integrity: sha512-sijfzPNorKt6+9g1/miHwhj6Iapff4mPQx1azmmZExgzUROqWTM1o3ACyxDja0g47VpowFy/sxTM/WsuCyXTiw==}
     engines: {node: '>=16'}
 
   '@babel/code-frame@7.24.7':
@@ -3360,6 +3360,9 @@ packages:
   '@iconify-json/vscode-icons@1.1.37':
     resolution: {integrity: sha512-02+dR2/LdIZTqGfyQerla5snhdN4edwYgpDuFZpI2lK9w8OVm26WYbg8RR8TxXQrlCRs726NQYxl5W+7V1YM/Q==}
 
+  '@iconify-json/vscode-icons@1.2.1':
+    resolution: {integrity: sha512-pEZCknk+6xlx7JC8e5Sz0cpkS3yezKKSouii0OTkUnTM3Kljc7V01AbYJ3iarw4b41jV0CpDpzj3BzRdvweGaA==}
+
   '@iconify/json@2.2.241':
     resolution: {integrity: sha512-zpeIjmIrTjl0ra6BYTYDfoK/hXn++xT5Hllc87K5SQwnqKs9RJeToSBzjF1gAsrxia+ilkhtGCcqbFF0ppDXiw==}
 
@@ -3368,6 +3371,9 @@ packages:
 
   '@iconify/utils@2.1.32':
     resolution: {integrity: sha512-LeifFZPPKu28O3AEDpYJNdEbvS4/ojAPyIW+pF/vUpJTYnbTiXUHkCh0bwgFRzKvdpb8H4Fbfd/742++MF4fPQ==}
+
+  '@iconify/utils@2.1.33':
+    resolution: {integrity: sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==}
 
   '@img/sharp-darwin-arm64@0.33.3':
     resolution: {integrity: sha512-FaNiGX1MrOuJ3hxuNzWgsT/mg5OHG/Izh59WW2mk1UwYHUwtfbhk5QNKYZgxf0pLOhx9ctGiGa2OykD71vOnSw==}
@@ -4169,8 +4175,8 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.4.2
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.0.0':
-    resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0':
+    resolution: {integrity: sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^3.0.0
@@ -5973,6 +5979,15 @@ packages:
 
   debug@4.3.6:
     resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -8394,6 +8409,9 @@ packages:
   package-manager-detector@0.1.2:
     resolution: {integrity: sha512-iePyefLTOm2gEzbaZKSW+eBMjg+UYsQvUKxmvGXAQ987K16efBg10MxIjZs08iyX+DY2/owKY9DIdu193kX33w==}
 
+  package-manager-detector@0.2.0:
+    resolution: {integrity: sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==}
+
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
 
@@ -9939,6 +9957,9 @@ packages:
   tinyexec@0.2.0:
     resolution: {integrity: sha512-au8dwv4xKSDR+Fw52csDo3wcDztPdne2oM1o/7LFro4h6bdFmvyUAeAfX40pwDtzHgRFqz1XWaUqgKS2G83/ig==}
 
+  tinyexec@0.3.0:
+    resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
+
   tinyglobby@0.2.5:
     resolution: {integrity: sha512-Dlqgt6h0QkoHttG53/WGADNh9QhcjCAIZMTERAVhdpmIBEejSuLI9ZmGKWzB7tweBjlk30+s/ofi4SLmBeTYhw==}
     engines: {node: '>=12.0.0'}
@@ -10027,6 +10048,9 @@ packages:
 
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   tsup@8.2.4:
     resolution: {integrity: sha512-akpCPePnBnC/CXgRrcy72ZSntgIEUa1jN0oJbbvpALWKNOz1B7aM+UVDWGRGIO/T/PZugAESWDJUAb5FD48o8Q==}
@@ -10495,8 +10519,8 @@ packages:
       vite:
         optional: true
 
-  vitepress-plugin-group-icons@1.0.3:
-    resolution: {integrity: sha512-IGQ7Jw52vHeBKTT1sgjhl/pGT1TwtL0MyeCb6m1xHthyoFQLqnkzVyEyUGkZfw0LBtro5OwmRvcYbDUSjMVOGw==}
+  vitepress-plugin-group-icons@1.2.3:
+    resolution: {integrity: sha512-Z2FGK/zubHFAE3luai2PYSyl247wIgAyj88EBNIe6DumJLz8Z+eFhLFwDafY/lfMnjwDDbrEl0aM5HWwg0Io/w==}
 
   vitepress@1.3.3:
     resolution: {integrity: sha512-6UzEw/wZ41S/CATby7ea7UlffvRER/uekxgN6hbEvSys9ukmLOKsz87Ehq9yOx1Rwiw+Sj97yjpivP8w1sUmng==}
@@ -11121,6 +11145,11 @@ snapshots:
       package-manager-detector: 0.1.2
       tinyexec: 0.2.0
 
+  '@antfu/install-pkg@0.4.1':
+    dependencies:
+      package-manager-detector: 0.2.0
+      tinyexec: 0.3.0
+
   '@antfu/ni@0.22.4': {}
 
   '@antfu/utils@0.7.10': {}
@@ -11170,95 +11199,95 @@ snapshots:
 
   '@azure/abort-controller@1.1.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.7.0
     optional: true
 
   '@azure/abort-controller@2.1.2':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.7.0
     optional: true
 
-  '@azure/core-auth@1.7.2':
+  '@azure/core-auth@1.8.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.9.0
-      tslib: 2.6.2
+      '@azure/core-util': 1.10.0
+      tslib: 2.7.0
     optional: true
 
   '@azure/core-client@1.9.2':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.7.2
-      '@azure/core-rest-pipeline': 1.16.1
+      '@azure/core-auth': 1.8.0
+      '@azure/core-rest-pipeline': 1.17.0
       '@azure/core-tracing': 1.1.2
-      '@azure/core-util': 1.9.0
-      '@azure/logger': 1.1.2
-      tslib: 2.6.2
+      '@azure/core-util': 1.10.0
+      '@azure/logger': 1.1.4
+      tslib: 2.7.0
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@azure/core-rest-pipeline@1.16.1':
+  '@azure/core-rest-pipeline@1.17.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.7.2
+      '@azure/core-auth': 1.8.0
       '@azure/core-tracing': 1.1.2
-      '@azure/core-util': 1.9.0
-      '@azure/logger': 1.1.2
+      '@azure/core-util': 1.10.0
+      '@azure/logger': 1.1.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
-      tslib: 2.6.2
+      tslib: 2.7.0
     transitivePeerDependencies:
       - supports-color
     optional: true
 
   '@azure/core-tracing@1.1.2':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.7.0
     optional: true
 
-  '@azure/core-util@1.9.0':
+  '@azure/core-util@1.10.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      tslib: 2.6.2
+      tslib: 2.7.0
     optional: true
 
   '@azure/identity@4.3.0':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.7.2
+      '@azure/core-auth': 1.8.0
       '@azure/core-client': 1.9.2
-      '@azure/core-rest-pipeline': 1.16.1
+      '@azure/core-rest-pipeline': 1.17.0
       '@azure/core-tracing': 1.1.2
-      '@azure/core-util': 1.9.0
-      '@azure/logger': 1.1.2
-      '@azure/msal-browser': 3.17.0
-      '@azure/msal-node': 2.9.2
+      '@azure/core-util': 1.10.0
+      '@azure/logger': 1.1.4
+      '@azure/msal-browser': 3.23.0
+      '@azure/msal-node': 2.13.1
       events: 3.3.0
       jws: 4.0.0
       open: 8.4.2
       stoppable: 1.1.0
-      tslib: 2.6.2
+      tslib: 2.7.0
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@azure/logger@1.1.2':
+  '@azure/logger@1.1.4':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.7.0
     optional: true
 
-  '@azure/msal-browser@3.17.0':
+  '@azure/msal-browser@3.23.0':
     dependencies:
-      '@azure/msal-common': 14.12.0
+      '@azure/msal-common': 14.14.2
     optional: true
 
-  '@azure/msal-common@14.12.0':
+  '@azure/msal-common@14.14.2':
     optional: true
 
-  '@azure/msal-node@2.9.2':
+  '@azure/msal-node@2.13.1':
     dependencies:
-      '@azure/msal-common': 14.12.0
+      '@azure/msal-common': 14.14.2
       jsonwebtoken: 9.0.2
       uuid: 8.3.2
     optional: true
@@ -12738,6 +12767,10 @@ snapshots:
     dependencies:
       '@iconify/types': 2.0.0
 
+  '@iconify-json/vscode-icons@1.2.1':
+    dependencies:
+      '@iconify/types': 2.0.0
+
   '@iconify/json@2.2.241':
     dependencies:
       '@iconify/types': 2.0.0
@@ -12751,6 +12784,18 @@ snapshots:
       '@antfu/utils': 0.7.10
       '@iconify/types': 2.0.0
       debug: 4.3.6
+      kolorist: 1.8.0
+      local-pkg: 0.5.0
+      mlly: 1.7.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@iconify/utils@2.1.33':
+    dependencies:
+      '@antfu/install-pkg': 0.4.1
+      '@antfu/utils': 0.7.10
+      '@iconify/types': 2.0.0
+      debug: 4.3.7
       kolorist: 1.8.0
       local-pkg: 0.5.0
       mlly: 1.7.1
@@ -13663,13 +13708,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.94.0)':
+  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.94.0(esbuild@0.23.1))':
     dependencies:
       chalk: 3.0.0
       error-stack-parser: 2.1.4
       string-width: 4.2.3
       strip-ansi: 6.0.1
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
 
   '@soda/get-current-script@1.0.2': {}
 
@@ -13736,10 +13781,10 @@ snapshots:
       tiny-glob: 0.2.9
       vite: 5.4.2(@types/node@22.5.0)(terser@5.31.6)
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.2.19)(vite@5.4.2(@types/node@22.5.0)(terser@5.31.6)))(svelte@4.2.19)(vite@5.4.2(@types/node@22.5.0)(terser@5.31.6))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.2.19)(vite@5.4.2(@types/node@22.5.0)(terser@5.31.6)))(svelte@4.2.19)(vite@5.4.2(@types/node@22.5.0)(terser@5.31.6))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.2.19)(vite@5.4.2(@types/node@22.5.0)(terser@5.31.6))
-      debug: 4.3.6
+      debug: 4.3.7
       svelte: 4.2.19
       vite: 5.4.2(@types/node@22.5.0)(terser@5.31.6)
     transitivePeerDependencies:
@@ -13747,8 +13792,8 @@ snapshots:
 
   '@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.2.19)(vite@5.4.2(@types/node@22.5.0)(terser@5.31.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.2.19)(vite@5.4.2(@types/node@22.5.0)(terser@5.31.6)))(svelte@4.2.19)(vite@5.4.2(@types/node@22.5.0)(terser@5.31.6))
-      debug: 4.3.6
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.2.19)(vite@5.4.2(@types/node@22.5.0)(terser@5.31.6)))(svelte@4.2.19)(vite@5.4.2(@types/node@22.5.0)(terser@5.31.6))
+      debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.11
@@ -13966,11 +14011,11 @@ snapshots:
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
 
-  '@types/webpack@5.28.5':
+  '@types/webpack@5.28.5(esbuild@0.23.1)':
     dependencies:
       '@types/node': 22.5.0
       tapable: 2.2.1
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -14343,15 +14388,15 @@ snapshots:
 
   '@vue/cli-overlay@5.0.8': {}
 
-  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(vue@2.7.16)':
+  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(core-js@3.38.1)(encoding@0.1.13)(esbuild@0.23.1)(vue@2.7.16)':
     dependencies:
       '@babel/core': 7.25.2
       '@vue/babel-preset-app': 5.0.8(@babel/core@7.25.2)(core-js@3.38.1)(vue@2.7.16)
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
-      babel-loader: 8.3.0(@babel/core@7.25.2)(webpack@5.94.0)
-      thread-loader: 3.0.4(webpack@5.94.0)
-      webpack: 5.94.0
+      babel-loader: 8.3.0(@babel/core@7.25.2)(webpack@5.94.0(esbuild@0.23.1))
+      thread-loader: 3.0.4(webpack@5.94.0(esbuild@0.23.1))
+      webpack: 5.94.0(esbuild@0.23.1)
     transitivePeerDependencies:
       - '@swc/core'
       - core-js
@@ -14362,29 +14407,29 @@ snapshots:
       - vue
       - webpack-cli
 
-  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(encoding@0.1.13)':
+  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(encoding@0.1.13)':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
-  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))':
+  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)
 
-  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)':
+  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3)':
     dependencies:
       '@babel/helper-compilation-targets': 7.25.2
-      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.94.0)
+      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.94.0(esbuild@0.23.1))
       '@soda/get-current-script': 1.0.2
       '@types/minimist': 1.2.5
       '@vue/cli-overlay': 5.0.8
-      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(encoding@0.1.13)
-      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))
+      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))(encoding@0.1.13)
+      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.38)(encoding@0.1.13)(esbuild@0.23.1)(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.2.3))
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)(pug@3.0.3)(react@18.3.1)
-      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.4.38)(css-loader@6.11.0(webpack@5.94.0))(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.94.0)
+      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.4.38)(css-loader@6.11.0(webpack@5.94.0(esbuild@0.23.1)))(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.94.0(esbuild@0.23.1))
       '@vue/web-component-wrapper': 1.3.0
       acorn: 8.12.1
       acorn-walk: 8.3.3
@@ -14395,9 +14440,9 @@ snapshots:
       cli-highlight: 2.1.11
       clipboardy: 2.3.0
       cliui: 7.0.4
-      copy-webpack-plugin: 9.1.0(webpack@5.94.0)
-      css-loader: 6.11.0(webpack@5.94.0)
-      css-minimizer-webpack-plugin: 3.4.1(webpack@5.94.0)
+      copy-webpack-plugin: 9.1.0(webpack@5.94.0(esbuild@0.23.1))
+      css-loader: 6.11.0(webpack@5.94.0(esbuild@0.23.1))
+      css-minimizer-webpack-plugin: 3.4.1(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1))
       cssnano: 5.1.15(postcss@8.4.41)
       debug: 4.3.6
       default-gateway: 6.0.3
@@ -14406,27 +14451,27 @@ snapshots:
       fs-extra: 9.1.0
       globby: 11.1.0
       hash-sum: 2.0.0
-      html-webpack-plugin: 5.6.0(webpack@5.94.0)
+      html-webpack-plugin: 5.6.0(webpack@5.94.0(esbuild@0.23.1))
       is-file-esm: 1.0.0
       launch-editor-middleware: 2.8.1
       lodash.defaultsdeep: 4.6.1
       lodash.mapvalues: 4.6.0
-      mini-css-extract-plugin: 2.9.0(webpack@5.94.0)
+      mini-css-extract-plugin: 2.9.0(webpack@5.94.0(esbuild@0.23.1))
       minimist: 1.2.8
       module-alias: 2.2.3
       portfinder: 1.0.32
       postcss: 8.4.41
-      postcss-loader: 6.2.1(postcss@8.4.41)(webpack@5.94.0)
-      progress-webpack-plugin: 1.0.16(webpack@5.94.0)
+      postcss-loader: 6.2.1(postcss@8.4.41)(webpack@5.94.0(esbuild@0.23.1))
+      progress-webpack-plugin: 1.0.16(webpack@5.94.0(esbuild@0.23.1))
       ssri: 8.0.1
-      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
-      thread-loader: 3.0.4(webpack@5.94.0)
-      vue-loader: 17.4.2(@vue/compiler-sfc@3.4.38)(vue@2.7.16)(webpack@5.94.0)
+      terser-webpack-plugin: 5.3.10(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1))
+      thread-loader: 3.0.4(webpack@5.94.0(esbuild@0.23.1))
+      vue-loader: 17.4.2(@vue/compiler-sfc@3.4.38)(vue@2.7.16)(webpack@5.94.0(esbuild@0.23.1))
       vue-style-loader: 4.1.3
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
       webpack-bundle-analyzer: 4.10.2
       webpack-chain: 6.5.1
-      webpack-dev-server: 4.15.2(debug@4.3.6)(webpack@5.94.0)
+      webpack-dev-server: 4.15.2(debug@4.3.6)(webpack@5.94.0(esbuild@0.23.1))
       webpack-merge: 5.10.0
       webpack-virtual-modules: 0.4.6
       whatwg-fetch: 3.6.20
@@ -14895,7 +14940,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.6
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -15170,14 +15215,14 @@ snapshots:
 
   b4a@1.6.4: {}
 
-  babel-loader@8.3.0(@babel/core@7.25.2)(webpack@5.94.0):
+  babel-loader@8.3.0(@babel/core@7.25.2)(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       '@babel/core': 7.25.2
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -15717,7 +15762,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@9.1.0(webpack@5.94.0):
+  copy-webpack-plugin@9.1.0(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -15725,7 +15770,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
 
   core-js-compat@3.38.0:
     dependencies:
@@ -15786,7 +15831,7 @@ snapshots:
     dependencies:
       postcss: 8.4.41
 
-  css-loader@6.11.0(webpack@5.94.0):
+  css-loader@6.11.0(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.41)
       postcss: 8.4.41
@@ -15797,9 +15842,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
 
-  css-minimizer-webpack-plugin@3.4.1(webpack@5.94.0):
+  css-minimizer-webpack-plugin@3.4.1(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       cssnano: 5.1.15(postcss@8.4.41)
       jest-worker: 27.5.1
@@ -15807,7 +15852,9 @@ snapshots:
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
       source-map: 0.6.1
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
+    optionalDependencies:
+      esbuild: 0.23.1
 
   css-select@4.3.0:
     dependencies:
@@ -15968,6 +16015,10 @@ snapshots:
   debug@4.3.6:
     dependencies:
       ms: 2.1.2
+
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
 
   decimal.js@10.4.3: {}
 
@@ -17281,7 +17332,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0):
+  html-webpack-plugin@5.6.0(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -17289,7 +17340,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -17351,7 +17402,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.6
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -18457,11 +18508,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.0(webpack@5.94.0):
+  mini-css-extract-plugin@2.9.0(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
 
   minimalistic-assert@1.0.1: {}
 
@@ -19076,6 +19127,8 @@ snapshots:
 
   package-manager-detector@0.1.2: {}
 
+  package-manager-detector@0.2.0: {}
+
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -19338,13 +19391,13 @@ snapshots:
       tsx: 4.16.2
       yaml: 2.5.0
 
-  postcss-loader@6.2.1(postcss@8.4.41)(webpack@5.94.0):
+  postcss-loader@6.2.1(postcss@8.4.41)(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
       postcss: 8.4.41
       semver: 7.6.3
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
 
   postcss-merge-longhand@5.1.7(postcss@8.4.41):
     dependencies:
@@ -19650,12 +19703,12 @@ snapshots:
 
   process@0.11.10: {}
 
-  progress-webpack-plugin@1.0.16(webpack@5.94.0):
+  progress-webpack-plugin@1.0.16(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       chalk: 2.4.2
       figures: 2.0.0
       log-update: 2.3.0
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
 
   promise-retry@2.0.1:
     dependencies:
@@ -19986,7 +20039,7 @@ snapshots:
 
   require-in-the-middle@7.3.0:
     dependencies:
-      debug: 4.3.6
+      debug: 4.3.7
       module-details-from-path: 1.0.3
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -20353,7 +20406,7 @@ snapshots:
   socks-proxy-agent@8.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.6
+      debug: 4.3.7
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -20700,14 +20753,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  terser-webpack-plugin@5.3.10(webpack@5.94.0):
+  terser-webpack-plugin@5.3.10(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.31.6
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
+    optionalDependencies:
+      esbuild: 0.23.1
 
   terser@5.31.6:
     dependencies:
@@ -20728,14 +20783,14 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  thread-loader@3.0.4(webpack@5.94.0):
+  thread-loader@3.0.4(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.0
       loader-utils: 2.0.4
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
 
   through@2.3.8: {}
 
@@ -20751,6 +20806,8 @@ snapshots:
   tinybench@2.8.0: {}
 
   tinyexec@0.2.0: {}
+
+  tinyexec@0.3.0: {}
 
   tinyglobby@0.2.5:
     dependencies:
@@ -20817,6 +20874,9 @@ snapshots:
       typescript: 5.5.4
 
   tslib@2.6.2: {}
+
+  tslib@2.7.0:
+    optional: true
 
   tsup@8.2.4(jiti@1.21.6)(postcss@8.4.41)(tsx@4.16.2)(typescript@5.5.4)(yaml@2.5.0):
     dependencies:
@@ -21375,10 +21435,11 @@ snapshots:
     optionalDependencies:
       vite: 5.4.2(@types/node@22.5.0)(terser@5.31.6)
 
-  vitepress-plugin-group-icons@1.0.3:
+  vitepress-plugin-group-icons@1.2.3:
     dependencies:
       '@iconify-json/logos': 1.1.44
-      '@iconify/utils': 2.1.32
+      '@iconify-json/vscode-icons': 1.2.1
+      '@iconify/utils': 2.1.33
     transitivePeerDependencies:
       - supports-color
 
@@ -21515,15 +21576,15 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.4.38)(css-loader@6.11.0(webpack@5.94.0))(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.94.0):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.4.38)(css-loader@6.11.0(webpack@5.94.0(esbuild@0.23.1)))(lodash@4.17.21)(prettier@2.8.8)(pug@3.0.3)(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)(pug@3.0.3)(react@18.3.1)
-      css-loader: 6.11.0(webpack@5.94.0)
+      css-loader: 6.11.0(webpack@5.94.0(esbuild@0.23.1))
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4
       vue-style-loader: 4.1.3
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
     optionalDependencies:
       '@vue/compiler-sfc': 3.4.38
       prettier: 2.8.8
@@ -21583,12 +21644,12 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@17.4.2(@vue/compiler-sfc@3.4.38)(vue@2.7.16)(webpack@5.94.0):
+  vue-loader@17.4.2(@vue/compiler-sfc@3.4.38)(vue@2.7.16)(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.1
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
     optionalDependencies:
       '@vue/compiler-sfc': 3.4.38
       vue: 2.7.16
@@ -21696,16 +21757,16 @@ snapshots:
       deepmerge: 1.5.2
       javascript-stringify: 2.1.0
 
-  webpack-dev-middleware@5.3.4(webpack@5.94.0):
+  webpack-dev-middleware@5.3.4(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
 
-  webpack-dev-server@4.15.2(debug@4.3.6)(webpack@5.94.0):
+  webpack-dev-server@4.15.2(debug@4.3.6)(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -21735,10 +21796,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.94.0)
+      webpack-dev-middleware: 5.3.4(webpack@5.94.0(esbuild@0.23.1))
       ws: 8.18.0
     optionalDependencies:
-      webpack: 5.94.0
+      webpack: 5.94.0(esbuild@0.23.1)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -21757,7 +21818,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.94.0:
+  webpack@5.94.0(esbuild@0.23.1):
     dependencies:
       '@types/estree': 1.0.5
       '@webassemblyjs/ast': 1.12.1
@@ -21779,7 +21840,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
+      terser-webpack-plugin: 5.3.10(esbuild@0.23.1)(webpack@5.94.0(esbuild@0.23.1))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -138,7 +138,7 @@ catalog:
   vite-plugin-pages: ^0.32.3
   vite-plugin-windicss: ^1.9.3
   vitepress: ^1.3.3
-  vitepress-plugin-group-icons: ^1.0.3
+  vitepress-plugin-group-icons: ^1.2.3
   vitest: ^2.0.5
   vue: ^3.4.38
   vue-eslint-parser: ^9.4.3


### PR DESCRIPTION
## Description

There are new feature after [vitepress-plugin-group-icons@1.2.0](https://github.com/yuyinws/vitepress-plugin-group-icons/releases/tag/v1.2.0). It can add a title bar for `code block`, and display the icon and name on the title bar meanwhile.

## Some screenshots:

<img width="730" alt="image" src="https://github.com/user-attachments/assets/6963f0e2-6312-4d7b-af41-d1d395ab03eb">

<img width="757" alt="image" src="https://github.com/user-attachments/assets/1a0263b4-f58e-4881-b67a-94519a14ba93">

<img width="740" alt="image" src="https://github.com/user-attachments/assets/fc83d0f7-374a-4575-b9b1-31ca839f7b50">

<img width="805" alt="image" src="https://github.com/user-attachments/assets/47079ccd-23f2-4d26-a066-a830d0c7d442">

