### PR TITLE
feat(core): add symbols.layer

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -10,6 +10,7 @@ export const symbols: ControlSymbols = {
   variants: '$$symbol-variants' as unknown as ControlSymbols['variants'],
   parent: '$$symbol-parent' as unknown as ControlSymbols['parent'],
   selector: '$$symbol-selector' as unknown as ControlSymbols['selector'],
+  layer: '$$symbol-layer' as unknown as ControlSymbols['layer'],
 }
 
 export class UnoGenerator<Theme extends object = object> {
@@ -614,6 +615,12 @@ export class UnoGenerator<Theme extends object = object> {
             else if (entry[0] === symbols.selector) {
               variants = [
                 { selector: entry[1] },
+                ...variants,
+              ]
+            }
+            else if (entry[0] === symbols.layer) {
+              variants = [
+                { layer: entry[1] },
                 ...variants,
               ]
             }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -77,6 +77,7 @@ declare const SymbolShortcutsNoMerge: unique symbol
 declare const SymbolVariants: unique symbol
 declare const SymbolParent: unique symbol
 declare const SymbolSelector: unique symbol
+declare const SymbolLayer: unique symbol
 
 export interface ControlSymbols {
   /**
@@ -95,6 +96,10 @@ export interface ControlSymbols {
    * Selector modifier
    */
   selector: typeof SymbolSelector
+  /**
+   * Layer modifier
+   */
+  layer: typeof SymbolLayer
 }
 
 export interface ControlSymbolsValue {
@@ -102,6 +107,7 @@ export interface ControlSymbolsValue {
   [SymbolVariants]: VariantHandler[]
   [SymbolParent]: string
   [SymbolSelector]: (selector: string) => string
+  [SymbolLayer]: string
 }
 
 export type ObjectToEntry<T> = { [K in keyof T]: [K, T[K]] }[keyof T]

--- a/packages/core/test/__snapshots__/extended-info.test.ts.snap
+++ b/packages/core/test/__snapshots__/extended-info.test.ts.snap
@@ -29,6 +29,7 @@ Map {
             ],
           ],
           "symbols": {
+            "layer": "$$symbol-layer",
             "parent": "$$symbol-parent",
             "selector": "$$symbol-selector",
             "shortcutsNoMerge": "$$symbol-shortcut-no-merge",
@@ -75,6 +76,7 @@ Map {
             ],
           ],
           "symbols": {
+            "layer": "$$symbol-layer",
             "parent": "$$symbol-parent",
             "selector": "$$symbol-selector",
             "shortcutsNoMerge": "$$symbol-shortcut-no-merge",
@@ -119,6 +121,7 @@ Map {
             ],
           ],
           "symbols": {
+            "layer": "$$symbol-layer",
             "parent": "$$symbol-parent",
             "selector": "$$symbol-selector",
             "shortcutsNoMerge": "$$symbol-shortcut-no-merge",

--- a/packages/core/test/rule-symbols.test.ts
+++ b/packages/core/test/rule-symbols.test.ts
@@ -156,3 +156,39 @@ it('selector', async () => {
       .color-red:hover{color:lighten(red, 10%);}"
     `)
 })
+
+it('layer', async () => {
+  const uno1 = createGenerator({
+    rules: [
+      [/^color-(.*)$/, function * ([, color], ctx) {
+        yield {
+          color,
+          [ctx.symbols.layer]: color,
+        }
+      }],
+    ],
+  })
+  expect((await uno1.generate('color-red')).css)
+    .toMatchInlineSnapshot(`
+      "/* layer: red */
+      .color-red{color:red;}"
+    `)
+})
+
+it('layer string', async () => {
+  const uno1 = createGenerator({
+    rules: [
+      [/^color-(.*)$/, function * ([, color], ctx) {
+        yield {
+          color,
+          [ctx.symbols.layer]: 'custom-layer',
+        }
+      }],
+    ],
+  })
+  expect((await uno1.generate('color-red')).css)
+    .toMatchInlineSnapshot(`
+      "/* layer: custom-layer */
+      .color-red{color:red;}"
+    `)
+})


### PR DESCRIPTION
This PR adds `symbols.layer` which can be used to specify a layer either with an string/function or a regex match. `symbols.layer` does not make it possible to change the order of the layer, for that use `layers:` as before.

```ts
rules: [
      [/^color-(.*)$/, function * ([, color], ctx) {
        yield {
          color,
          [ctx.symbols.layer]: color,
        }
      }],
    ],
```
`color-red`:

```css
"/* layer: red */
.color-red{color:red;}"
```

fixes #4131
