### PR TITLE
docs(config): layers using variants

### DIFF
--- a/docs/config/layers.md
+++ b/docs/config/layers.md
@@ -98,3 +98,27 @@ outputToCssLayers: {
   }
 }
 ```
+
+## Layers using variants
+
+Layers can be created using variants.
+
+`uno-layer-<name>:` can be used to create a UnoCSS layer.
+
+```html
+<p class="uno-layer-my-layer:text-xl">text</p>
+
+/* layer: my-layer */
+.uno-layer-my-layer\:text-xl{font-size:1.25rem;line-height:1.75rem;}
+```
+
+`layer-<name>:` can be used to create a CSS @layer.
+
+```html
+<p class="layer-my-layer:text-xl">text</p>
+
+/* layer: default */
+@layer my-layer{
+.layer-my-layer\:text-xl{font-size:1.25rem;line-height:1.75rem;}
+}
+```


### PR DESCRIPTION
This PR adds some info about creating layers using variants in the `config layers` docs instead of in the preset docs. There seems to be a lot of people who don't realize that `uno-layer:` exists so adding this in the `config layers` docs could help.