### PR TITLE
docs(rules): explain symbols.layer in symbols docs

### DIFF
--- a/docs/config/rules.md
+++ b/docs/config/rules.md
@@ -119,6 +119,7 @@ Will generate:
 
 - `symbols.parent`: The parent wrapper of the generated CSS rule (eg. `@supports`, `@media`, etc.)
 - `symbols.selector`: A function to modify the selector of the generated CSS rule (see the example below)
+- `symbols.layer`: A string/function/regex match that sets the UnoCSS layer of the generated CSS rule
 - `symbols.variants`: An array of variant handler that are applied to the current CSS object
 - `symbols.shortcutsNoMerge`: A boolean to disable the merging of the current rule in shortcuts
 


### PR DESCRIPTION
This PR adds `symbols.layer` in the rules docs to actually explain what it does, I forgot this in the other PR.