### PR TITLE
docs: add tutorial links update contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The instant on-demand Atomic CSS engine.
 <p align="center">
 <a href="https://unocss.dev/">📚 Documentation</a> |
 <a href="https://unocss.dev/interactive/">🧑‍💻 Interactive Docs</a> |
-<a href="https://unocss.dev/play/">🤹‍♂️ Playground</a>
+<a href="https://unocss.dev/play/">🤹‍♂️ Playground</a> |
+<a href="https://tutorial.unocss.dev/">🎓 Tutorial</a>
 </p>
 <br>
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -150,6 +150,7 @@ const Nav: DefaultTheme.NavItem[] = [
   },
   { text: 'Interactive Docs', link: '/interactive/', target: '_blank' },
   { text: 'Playground', link: '/play/', target: '_blank' },
+  { text: 'Tutorial', link: 'https://tutorial.unocss.dev/', target: '_blank' },
   {
     text: `v${version}`,
     items: [

--- a/docs/.vitepress/contributors.ts
+++ b/docs/.vitepress/contributors.ts
@@ -128,6 +128,14 @@ const plainTeamMembers: CoreTeam[] = [
     title: 'Passionate about open source & FE Developer',
     desc: '@webview-use author, vscode plugin master, open source magician, antfu’s number one fan',
   },
+  {
+    avatar: 'https://github.com/henrikvilhelmberglund.png',
+    name: 'Henrik Berglund',
+    github: 'henrikvilhelmberglund',
+    twitter: 'henrikvberglund',
+    title: 'Frontend Developer',
+    desc: 'Loves Svelte, Vite and open source, author of the UnoCSS tutorial',
+  },
 ]
 
 const teamMembers = plainTeamMembers.map(tm => createLinks(tm))

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,10 @@ hero:
       text: Playground
       link: https://unocss.dev/play/
       target: _blank
+    - theme: alt
+      text: Tutorial
+      link: https://tutorial.unocss.dev/
+      target: _blank
 
 features:
   - icon: <span class="i-carbon:ibm-toolchain"></span>


### PR DESCRIPTION
This PR:

- Adds links to the tutorial in the README, a CTA link and in the nav in the index. Not too sure if it should be everywhere, feel free to edit. Link to the repo itself in case anyone wants to contribute is https://github.com/henrikvilhelmberglund/unocss-tutorial

- Adds myself to the team member list. 😊