### PR TITLE
fix(postcss): postcss dependency should always be added

### DIFF
--- a/packages/postcss/src/esm.ts
+++ b/packages/postcss/src/esm.ts
@@ -136,19 +136,19 @@ export function createPlugin(options: UnoPostcssPluginOptions) {
     for (let i = 0; i < entries.length; i += BATCH_SIZE) {
       const batch = entries.slice(i, i + BATCH_SIZE)
       promises.push(...batch.map(async (file) => {
-        const { mtimeMs } = await stat(file)
-
-        if (fileMap.has(file) && mtimeMs <= fileMap.get(file))
-          return
-
-        fileMap.set(file, mtimeMs)
-
         result.messages.push({
           type: 'dependency',
           plugin: directiveMap.unocss,
           file: normalize(file),
           parent: from,
         })
+
+        const { mtimeMs } = await stat(file)
+
+        if (fileMap.has(file) && mtimeMs <= fileMap.get(file))
+          return
+
+        fileMap.set(file, mtimeMs)
 
         const content = await readFile(file, 'utf8')
         const { matched } = await uno.generate(content, {


### PR DESCRIPTION
Fix UnoCSS HMR not working when use `@unocss/postcss` because postcss dependency is not added correctly.

Related PR: https://github.com/unocss/unocss/pull/4048/files#diff-4693bd37b5c3bdb6333760a51bd95d59c108fe0893e24e1237babd281d8b01e4R138-R146

fix: https://github.com/web-infra-dev/rsbuild/issues/3528