### PR TITLE
fix(extractor-arbitrary-variants): skip extracting encoded html entities

### DIFF
--- a/packages/core/test/extractor.test.ts
+++ b/packages/core/test/extractor.test.ts
@@ -20,4 +20,5 @@ it('extractorSplitArbitrary', async () => {
   }
 
   expect(await extract('<div class="[content:\'bar:baz\'] [foo:bar:baz]">')).not.contains('[foo:bar:baz]')
+  expect(await extract('<div class="after:content-[&#39;&#39;]">')).not.toContain('after:content-[&#39;&#39;]')
 })

--- a/packages/extractor-arbitrary-variants/src/index.ts
+++ b/packages/extractor-arbitrary-variants/src/index.ts
@@ -28,7 +28,7 @@ export function splitCodeWithArbitraryVariants(code: string): string[] {
   // Convert the information in [] in advance to prevent incorrect separation
   const skipMap = new Map<string, string>()
   const skipFlag = '@unocss-skip-arbitrary-brackets'
-  code = transformSkipCode(code, skipMap, /-\[[^\]]*\]/g, skipFlag)
+  code = transformSkipCode(code, skipMap, /-\[(?!&.+?;)[^\]]*\]/g, skipFlag)
 
   if (!code)
     return result


### PR DESCRIPTION
Fixes #4105

Changes in #3875 caused some previously uncaptured arbitrary variants to be processed by Uno. In case of #4105 during SSR, Vue encode HTML entities like that:

```tsx
return (_ctx: any,_push: any,_parent: any,_attrs: any) => {
  _push(`<div${_ssrRenderAttrs(_attrs)}><h1 class="after:content-[&#39;&#39;] w-[12px]">Bug Reproduction</h1></div>`)
}
```

Uno thinks `after:content-[&#39;&#39;]` is a different candidate than `after:content-['']` and generates another utility class. But it generates invalid code. Uno should have been aware of it's processing a string that has encoded html entity or at least shouldn't have been generating an invalid code. There may be other false positive (but valid) candidates UnoCSS generating in production code. But I don't have an example in my hand yet.

I think it is safe to skip these candidates as they already processed during pre-transform scan.

