### PR TITLE
ci: use `--only-templates`

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -33,4 +33,4 @@ jobs:
         run: pnpm build
 
       - name: Release
-        run: pnpm dlx pkg-pr-new publish --compact --pnpm './packages/*'
+        run: pnpm dlx pkg-pr-new publish --compact --pnpm './packages/*' --only-templates


### PR DESCRIPTION
Only show templates to avoid long comments.

Reference: https://github.com/stackblitz-labs/pkg.pr.new/pull/172