### PR TITLE
feat(svelte-scoped): add sveltescoped useThemeFunction option

### DIFF
--- a/packages/svelte-scoped/src/_preprocess/index.ts
+++ b/packages/svelte-scoped/src/_preprocess/index.ts
@@ -47,6 +47,7 @@ export function UnocssSveltePreprocess(options: UnocssSveltePreprocessOptions = 
 
       const { hasApply, applyVariables } = checkForApply(content, options.applyVariables)
       const hasThemeFn = !!content.match(themeRE)
+      const useThemeFn = options.useThemeFunction ?? true
 
       const changeNeeded = addPreflights || addSafelist || hasApply || hasThemeFn
       if (!changeNeeded)
@@ -69,6 +70,7 @@ export function UnocssSveltePreprocess(options: UnocssSveltePreprocessOptions = 
           prepend: preflightsSafelistCss,
           applyVariables,
           hasThemeFn,
+          useThemeFn,
         })
       }
 

--- a/packages/svelte-scoped/src/_preprocess/transformStyle.test.ts
+++ b/packages/svelte-scoped/src/_preprocess/transformStyle.test.ts
@@ -1,0 +1,96 @@
+import { createGenerator } from '@unocss/core'
+import presetUno from '@unocss/preset-uno'
+import { describe, expect, it } from 'vitest'
+import { transformStyle } from './transformStyle'
+
+describe('transformStyle transforms theme with useThemeFn true', () => {
+  const uno = createGenerator({
+    presets: [
+      presetUno({
+        theme: {
+          colors: {
+            blue: {
+              500: '#3b82f6',
+            },
+          },
+        },
+      }),
+    ],
+  })
+
+  async function transform(content: string) {
+    const transformed = await transformStyle({ content, uno, filename: 'test.css', prepend: '', applyVariables: [], hasThemeFn: true, useThemeFn: true })
+    return transformed?.code
+  }
+
+  it('handles theme()', async () => {
+    const style = `.custom-class {
+  @apply bg-[theme('colors.blue.500')];
+}`
+    expect(await transform(style)).toMatchInlineSnapshot(`
+      ".custom-class {
+        @apply bg-[#3b82f6];
+      }"
+    `)
+  })
+})
+
+describe('????transformStyle transforms theme with useThemeFn true', () => {
+  const uno = createGenerator({
+    presets: [
+      presetUno({
+        theme: {
+          colors: {
+            blue: {
+              500: '#3b82f6',
+            },
+          },
+        },
+      }),
+    ],
+  })
+
+  async function transform(content: string) {
+    const transformed = await transformStyle({ content, uno, filename: 'test.css', prepend: '', applyVariables: ['at-apply'], hasThemeFn: true, useThemeFn: true })
+    return transformed?.code
+  }
+
+  it('handles theme()', async () => {
+    const style = `.custom-class {
+  @apply bg-[theme('colors.blue.500')];
+}`
+    expect(await transform(style)).toMatchInlineSnapshot(`
+      ".custom-class {
+        background-color: #3b82f6;
+      }"
+    `)
+  })
+})
+
+describe('transformStyle does not transform theme with useThemeFn false', () => {
+  const uno = createGenerator({
+    presets: [
+      presetUno({
+        theme: {
+          colors: {
+            blue: {
+              500: '#3b82f6',
+            },
+          },
+        },
+      }),
+    ],
+  })
+
+  async function transform(content: string) {
+    const transformed = await transformStyle({ content, uno, filename: 'test.css', prepend: '', applyVariables: [], hasThemeFn: true, useThemeFn: false })
+    return transformed?.code
+  }
+
+  it('returns undefined since the string did not change', async () => {
+    const style = `.custom-class {
+  @apply bg-[theme('colors.blue.500')];
+}`
+    expect(await transform(style)).toBe(undefined)
+  })
+})

--- a/packages/svelte-scoped/src/_preprocess/transformStyle.ts
+++ b/packages/svelte-scoped/src/_preprocess/transformStyle.ts
@@ -24,6 +24,7 @@ export async function transformStyle({
   filename,
   applyVariables,
   hasThemeFn,
+  useThemeFn,
 }: {
   content: string
   uno: UnoGenerator
@@ -31,6 +32,7 @@ export async function transformStyle({
   prepend: string
   applyVariables: string[]
   hasThemeFn: boolean
+  useThemeFn: boolean
 }): Promise<Processed | void> {
   const s = new MagicString(content)
 
@@ -38,7 +40,7 @@ export async function transformStyle({
     await transformApply({ s, uno, applyVariables })
 
   if (hasThemeFn)
-    transformTheme(s, uno.config.theme)
+    transformTheme(s, uno.config.theme, useThemeFn)
 
   if (!s.hasChanged())
     return

--- a/packages/svelte-scoped/src/_preprocess/transformTheme.test.ts
+++ b/packages/svelte-scoped/src/_preprocess/transformTheme.test.ts
@@ -20,7 +20,7 @@ div {
   background: theme('colors.blue.500');
   margin-right: theme("spacing.sm"); 
 }`.trim()
-    expect(transformTheme(new MagicString(code), theme).toString()).toMatchInlineSnapshot(`
+    expect(transformTheme(new MagicString(code), theme, true).toString()).toMatchInlineSnapshot(`
         "div { 
           background: #3b82f6;
           margin-right: 0.875rem; 
@@ -28,9 +28,23 @@ div {
     `)
   })
 
+  it('does not replace when useThemeFn is false', () => {
+    const code = `
+div { 
+  background: theme('colors.blue.500');
+  margin-right: theme("spacing.sm"); 
+}`.trim()
+    expect(transformTheme(new MagicString(code), theme, false).toString()).toMatchInlineSnapshot(`
+        "div { 
+          background: theme('colors.blue.500');
+          margin-right: theme("spacing.sm"); 
+        }"
+    `)
+  })
+
   it('does nothing if contains no arguments', () => {
     const noArgument = 'div { background: theme() }'
-    expect(transformTheme(new MagicString(noArgument), theme).toString()).toBe(noArgument)
+    expect(transformTheme(new MagicString(noArgument), theme, true).toString()).toBe(noArgument)
   })
 })
 

--- a/packages/svelte-scoped/src/_preprocess/transformTheme.ts
+++ b/packages/svelte-scoped/src/_preprocess/transformTheme.ts
@@ -11,6 +11,7 @@ export function transformTheme(s: MagicString, theme: Theme, useThemeFn: boolean
       return getThemeValue(argumentsWithoutQuotes, theme)
     })
   }
+
   if (!useThemeFn)
     return s
   return s

--- a/packages/svelte-scoped/src/_preprocess/transformTheme.ts
+++ b/packages/svelte-scoped/src/_preprocess/transformTheme.ts
@@ -4,11 +4,16 @@ interface Theme { [key: string]: any }
 
 export const themeRE = /theme\((.+?)\)/g
 
-export function transformTheme(s: MagicString, theme: Theme): MagicString {
-  return s.replace(themeRE, (_, match) => {
-    const argumentsWithoutQuotes = match.slice(1, -1)
-    return getThemeValue(argumentsWithoutQuotes, theme)
-  })
+export function transformTheme(s: MagicString, theme: Theme, useThemeFn: boolean): MagicString {
+  if (useThemeFn) {
+    return s.replace(themeRE, (_, match) => {
+      const argumentsWithoutQuotes = match.slice(1, -1)
+      return getThemeValue(argumentsWithoutQuotes, theme)
+    })
+  }
+  if (!useThemeFn)
+    return s
+  return s
 }
 
 export function getThemeValue(rawArguments: string, theme: Theme): string {

--- a/packages/svelte-scoped/src/_preprocess/types.d.ts
+++ b/packages/svelte-scoped/src/_preprocess/types.d.ts
@@ -6,6 +6,12 @@ export interface UnocssSveltePreprocessOptions extends TransformClassesOptions, 
    * UnoCSS config or path to config file. If not provided, will load unocss.config.ts/js. It's recommended to use the separate config file if you are having trouble with the UnoCSS extension in VSCode.
    */
   configOrPath?: UserConfig | string
+  /**
+   * Whether to enable the UnoCSS theme() function.
+   *
+   * @default true
+   */
+  useThemeFunction?: boolean
 }
 
 export interface TransformClassesOptions {


### PR DESCRIPTION
(draft)

This PR adds a  `useThemeFunction` option to allow for disabling the Svelte Scoped preprocessor `theme()` functionality. You may want to disable it when using the Tailwind `theme()` and don't want to use the UnoCSS one.

Fixes #4166 

There are a few things I want to fix and some things I don't really understand (the test with ???) so marking this as draft for now.