### PR TITLE
fix(transformer-attributify-jsx): exclude `node_modules` by default

### DIFF
--- a/packages/transformer-attributify-jsx/src/index.ts
+++ b/packages/transformer-attributify-jsx/src/index.ts
@@ -64,7 +64,7 @@ export default function transformerAttributifyJsx(options: TransformerAttributif
 
   const idFilter = createFilter(
     options.include || [/\.[jt]sx$/, /\.mdx$/],
-    options.exclude || [],
+    options.exclude || [/node_modules/],
   )
 
   return {


### PR DESCRIPTION
close #4195

For this transformer, `node_modules files` should be excluded by default, otherwise there may be additional side effects.

If there is any special case I haven't considered, please feel free to close the PR.