### PR TITLE
feat(eslint-plugin): support utilities ordering in Vue attributify attributes

### DIFF
--- a/packages/eslint-plugin/src/constants.ts
+++ b/packages/eslint-plugin/src/constants.ts
@@ -1,2 +1,5 @@
 export const CLASS_FIELDS = ['class', 'classname']
 export const AST_NODES_WITH_QUOTES = ['Literal', 'VLiteral']
+
+// supports the default attributify prefix 'un-', and includes other potential UnoCSS-related prefixes for broader compatibility
+export const ATTRIBUTIFY_PREFIXES = ['un-', 'uno-', 'unocss-', 'un:', 'uno:', 'unocss:']

--- a/packages/eslint-plugin/src/rules/order.ts
+++ b/packages/eslint-plugin/src/rules/order.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/types'
 import type { ESLintUtils } from '@typescript-eslint/utils'
 import type { RuleListener } from '@typescript-eslint/utils/ts-eslint'
-import { AST_NODES_WITH_QUOTES, CLASS_FIELDS } from '../constants'
+import { AST_NODES_WITH_QUOTES, ATTRIBUTIFY_PREFIXES, CLASS_FIELDS } from '../constants'
 import { createRule, syncAction } from './_'
 
 export default createRule({
@@ -59,7 +59,7 @@ export default createRule({
 
     const templateBodyVisitor: RuleListener = {
       VAttribute(node: any) {
-        if (node.key.name === 'class') {
+        if (node.key.name === 'class' || ATTRIBUTIFY_PREFIXES.some((prefix: string) => node.key.name.startsWith(prefix))) {
           if (node.value.type === 'VLiteral')
             checkLiteral(node.value)
         }


### PR DESCRIPTION
- Add ATTRIBUTIFY_PREFIXES constant to include common UnoCSS-related prefixes
- Update VAttribute implementation

fix #4007 

https://stackblitz.com/edit/unocss-unocss-ptjzrg?file=src%2FApp.vue,patch%2F%40unocss%2Feslint-plugin%400.63.4%2Fdist%2Findex.mjs,package.json

https://github.com/user-attachments/assets/757114cb-e94a-42e5-96de-49cc41afb2d3



