### PR TITLE
docs: Update arbitrary-variants extractor example

### DIFF
--- a/docs/extractors/arbitrary-variants.md
+++ b/docs/extractors/arbitrary-variants.md
@@ -34,7 +34,7 @@ import { defineConfig } from 'unocss'
 
 export default defineConfig({
   extractors: [
-    extractorArbitrary(),
+    extractorArbitrary,
   ],
 })
 ```


### PR DESCRIPTION
The arbitrary variants extractor is not callable, it just needs to be imported