### PR TITLE
refactor(extactor-attributify)!: make arbitrary variants extractor callable

### DIFF
--- a/packages/core/test/extractor.test.ts
+++ b/packages/core/test/extractor.test.ts
@@ -16,7 +16,7 @@ it('extractorSplit', async () => {
 
 it('extractorSplitArbitrary', async () => {
   async function extract(code: string) {
-    return [...await extractorArbitraryVariants.extract!({ code, original: code } as any) || []]
+    return [...await extractorArbitraryVariants().extract!({ code, original: code } as any) || []]
   }
 
   expect(await extract('<div class="[content:\'bar:baz\'] [foo:bar:baz]">')).not.contains('[foo:bar:baz]')

--- a/packages/extractor-arbitrary-variants/src/index.ts
+++ b/packages/extractor-arbitrary-variants/src/index.ts
@@ -45,12 +45,12 @@ export function splitCodeWithArbitraryVariants(code: string): string[] {
   return result
 }
 
-export const extractorArbitraryVariants: Extractor = {
-  name: '@unocss/extractor-arbitrary-variants',
-  order: 0,
-  extract({ code }) {
-    return splitCodeWithArbitraryVariants(removeSourceMap(code))
-  },
+export function extractorArbitraryVariants(): Extractor {
+  return {
+    name: '@unocss/extractor-arbitrary-variants',
+    order: 0,
+    extract({ code }) {
+      return splitCodeWithArbitraryVariants(removeSourceMap(code))
+    },
+  }
 }
-
-export default extractorArbitraryVariants

--- a/packages/preset-mini/src/index.ts
+++ b/packages/preset-mini/src/index.ts
@@ -95,7 +95,7 @@ export const presetMini = definePreset((options: PresetMiniOptions = {}) => {
       : [],
     extractorDefault: options.arbitraryVariants === false
       ? undefined
-      : extractorArbitraryVariants,
+      : extractorArbitraryVariants(),
     autocomplete: {
       shorthands,
     },


### PR DESCRIPTION
See #4235 for further details.

This PR aligns the arbitrary variant extractor with the others and makes it callable.

Note the docs already show it as callable, so they do not need to be updated.