### PR TITLE
feat(core)!: deprecate `new UnoGenerator`, make `createGenerator()` async

### DIFF
--- a/docs/tools/core.md
+++ b/docs/tools/core.md
@@ -26,7 +26,7 @@ The core engine of UnoCSS without any presets: `@unocss/core`. It can be used as
 ```ts
 import { createGenerator } from '@unocss/core'
 
-const generator = createGenerator(
+const generator = await createGenerator(
   { /* user options */ },
   { /* default options */ }
 )

--- a/examples/vite-lit/package.json
+++ b/examples/vite-lit/package.json
@@ -26,7 +26,7 @@
     "typescript": "^5.6.3",
     "unocss": "link:../../packages/unocss",
     "vite": "^5.4.10",
-    "vite-plugin-inspect": "^0.8.7"
+    "vite-plugin-inspect": "^0.8.8"
   },
   "stackblitz": {
     "installDependencies": false,

--- a/interactive/components/ColorsTable.vue
+++ b/interactive/components/ColorsTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { searcher } from '~/composables/state'
 
-const colors = await searcher.getThemeColors()
+const colors = await searcher.value.getThemeColors()
 </script>
 
 <template>

--- a/interactive/components/ResultItem.vue
+++ b/interactive/components/ResultItem.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { ResultItem } from '~/types'
+import type { ResultItem, RuleItem } from '~/types'
 
 const { item, compact = undefined, index } = defineProps<{
-  item: ResultItem
+  item: ResultItem | RuleItem
   index?: number
   compact?: boolean | undefined
 }>()
@@ -63,13 +63,13 @@ const classes = computed(() => ([
         S
       </div>
       <div
-        v-else-if="item.context?.variants.length"
+        v-else-if="item.context?.variants?.length"
         badge-square-pink :class="badgeStyle" title="Variants"
       >
         V
       </div>
       <div
-        v-else-if="item.context?.rules.every(i => typeof i[0] === 'string')"
+        v-else-if="item.context?.rules?.every(i => typeof i[0] === 'string')"
         badge-square-gray :class="badgeStyle" title="Static Rule"
       >
         T

--- a/interactive/components/Search.vue
+++ b/interactive/components/Search.vue
@@ -53,7 +53,7 @@ async function executeSearch() {
   if (input.value)
     isSearching.value = true
   try {
-    searchResult.value = mapSearch(await searcher.search(input.value))
+    searchResult.value = mapSearch(await searcher.value?.search(input.value) || [])
   }
   catch (e) {
     console.error(e)
@@ -126,7 +126,7 @@ async function openItem(item: ResultItem) {
   if (isMobile.value && !isModalOpen.value)
     isModalOpen.value = true
   else
-    input.value = await searcher.getItemId(item)
+    input.value = await searcher.value.getItemId(item)
 }
 
 function selectItem(item: ResultItem) {

--- a/interactive/components/Summary.vue
+++ b/interactive/components/Summary.vue
@@ -3,7 +3,7 @@ import { searcher } from '~/composables/state'
 
 const isDefault = computed(() => (userConfigRaw.value || defaultConfigRaw) === defaultConfigRaw)
 
-const info = await searcher.getInfo()
+const info = searcher.value.getInfo()
 </script>
 
 <template>

--- a/interactive/components/TheNav.vue
+++ b/interactive/components/TheNav.vue
@@ -2,7 +2,7 @@
 import { currentTab, isCompact, toggleCompact } from '~/composables/state'
 
 const tab = currentTab
-const info = await searcher.getInfo()
+const info = searcher.value.getInfo()
 </script>
 
 <template>

--- a/interactive/components/details/Doc.vue
+++ b/interactive/components/details/Doc.vue
@@ -13,7 +13,7 @@ const caniuseItem = computed<DocItem>(() => ({
   url: `https://caniuse.com/?search=${encodeURIComponent(item.title)}`,
 }))
 
-const relatives = computed(() => searcher.getUtilsOfFeature(item.title))
+const relatives = computed(() => searcher.value?.getUtilsOfFeature(item.title) || [])
 </script>
 
 <template>

--- a/interactive/components/details/Rule.vue
+++ b/interactive/components/details/Rule.vue
@@ -10,7 +10,7 @@ const { item } = defineProps<{
 }>()
 
 const docs = computed(() => getDocs(item))
-const alias = computed(() => searcher.getAliasOf(item))
+const alias = computed(() => searcher.value?.getAliasOf(item) || [])
 const variantSteps = computed(() => {
   const steps: {
     variant?: Variant
@@ -48,7 +48,7 @@ const guides = computed(() => {
   return items
 })
 
-const sameRules = computed(() => searcher.getSameRules(item))
+const sameRules = computed(() => searcher.value.getSameRules(item))
 
 function getRegex101Link(regex: RegExp, text: string) {
   return `https://regex101.com/?regex=${encodeURIComponent(regex.source)}&flag=${encodeURIComponent(regex.flags)}&testString=${encodeURIComponent(text)}`
@@ -97,7 +97,7 @@ function getGitHubCodeSearchLink(key: RegExp | string, repo = 'unocss/unocss') {
               >
                 <PresetLabel
                   op50 hover:op100
-                  :preset="searcher.getPresetOfVariant(s.variant)"
+                  :preset="searcher?.getPresetOfVariant(s.variant)"
                   fallback="(inline)"
                 />
                 <span op30>></span>
@@ -201,7 +201,7 @@ function getGitHubCodeSearchLink(key: RegExp | string, repo = 'unocss/unocss') {
         <div border="~ main">
           <template v-for="g, idx of guides" :key="g.title">
             <div v-if="idx" divider />
-            <RouterLink :to="{ query: { s: searcher.getItemId(g) } }">
+            <RouterLink :to="{ query: { s: searcher?.getItemId(g) || '' } }">
               <ResultItem :item="g" />
             </RouterLink>
           </template>

--- a/interactive/composables/state.ts
+++ b/interactive/composables/state.ts
@@ -14,8 +14,8 @@ export { defaultConfigRaw }
 export const isCompact = useLocalStorage('uno-interact-compact', false)
 export const toggleCompact = useToggle(isCompact)
 
-const uno = await createGenerator({}, defaultConfig)
-export const searcher = createSearch({ uno, docs, guides })
+const _uno = createGenerator({}, defaultConfig)
+export const searcher = createSearch({ uno: _uno, docs, guides })
 
 const initParams = new URLSearchParams(location.search)
 
@@ -47,8 +47,8 @@ async function load() {
   }
 }
 
-watch(userConfig, () => {
-  uno.setConfig(userConfig.value || {}, defaultConfig)
+watch(userConfig, async () => {
+  (await _uno).setConfig(userConfig.value || {}, defaultConfig)
 })
 
 load()

--- a/interactive/composables/state.ts
+++ b/interactive/composables/state.ts
@@ -1,4 +1,5 @@
 import type { UserConfig } from '@unocss/core'
+import type { Ref } from 'vue'
 import { createGenerator } from '@unocss/core'
 import { createSearch, evaluateUserConfig } from '@unocss/shared-docs'
 import { breakpointsTailwind } from '@vueuse/core'
@@ -14,8 +15,14 @@ export { defaultConfigRaw }
 export const isCompact = useLocalStorage('uno-interact-compact', false)
 export const toggleCompact = useToggle(isCompact)
 
+export const searcher: Ref<ReturnType<typeof createSearch>> = shallowRef()
+
 const _uno = createGenerator({}, defaultConfig)
-export const searcher = createSearch({ uno: _uno, docs, guides })
+
+_uno.then((uno) => {
+  const search = createSearch({ uno, docs, guides })
+  searcher.value = search
+})
 
 const initParams = new URLSearchParams(location.search)
 

--- a/interactive/composables/state.ts
+++ b/interactive/composables/state.ts
@@ -14,7 +14,7 @@ export { defaultConfigRaw }
 export const isCompact = useLocalStorage('uno-interact-compact', false)
 export const toggleCompact = useToggle(isCompact)
 
-const uno = createGenerator({}, defaultConfig)
+const uno = await createGenerator({}, defaultConfig)
 export const searcher = createSearch({ uno, docs, guides })
 
 const initParams = new URLSearchParams(location.search)

--- a/packages/autocomplete/src/types.ts
+++ b/packages/autocomplete/src/types.ts
@@ -34,6 +34,6 @@ export interface UnocssAutocomplete {
   suggestInFile: (content: string, cursor: number) => Promise<SuggestResult | undefined>
   templates: (string | AutoCompleteFunction)[]
   cache: LRUCache<string, string[]>
-  reset: () => void
+  reset: () => Promise<void>
   enumerate: () => Promise<Set<string>>
 }

--- a/packages/autocomplete/test/autocomplete-fuzzy.test.ts
+++ b/packages/autocomplete/test/autocomplete-fuzzy.test.ts
@@ -3,8 +3,8 @@ import { createGenerator } from '@unocss/core'
 import presetMini from '@unocss/preset-mini'
 import { describe, expect, it } from 'vitest'
 
-describe('autocomplete-fuzzy', () => {
-  const uno = createGenerator({
+describe('autocomplete-fuzzy', async () => {
+  const uno = await createGenerator({
     presets: [
       presetMini(),
     ],

--- a/packages/autocomplete/test/autocomplete.test.ts
+++ b/packages/autocomplete/test/autocomplete.test.ts
@@ -4,8 +4,8 @@ import presetAttributify from '@unocss/preset-attributify'
 import presetUno from '@unocss/preset-uno'
 import { describe, expect, it } from 'vitest'
 
-describe('autocomplete', () => {
-  const uno = createGenerator({
+describe('autocomplete', async () => {
+  const uno = await createGenerator({
     presets: [
       presetAttributify(),
       presetUno(),
@@ -113,7 +113,7 @@ describe('autocomplete', () => {
   })
 
   it('should not suggest blocked rules', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -208,8 +208,8 @@ describe('autocomplete', () => {
   })
 })
 
-describe('autocomplete with attributify prefix', () => {
-  const uno = createGenerator({
+describe('autocomplete with attributify prefix', async () => {
+  const uno = await createGenerator({
     presets: [
       presetAttributify({
         prefix: 'u-',
@@ -306,7 +306,7 @@ describe('autocomplete with attributify prefix', () => {
   })
 
   it('should not suggest blocked rules', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -351,8 +351,8 @@ describe('autocomplete with attributify prefix', () => {
   })
 })
 
-describe('use uno cache', () => {
-  const uno = createGenerator({
+describe('use uno cache', async () => {
+  const uno = await createGenerator({
     presets: [
       presetUno(),
     ],

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -1,6 +1,4 @@
 import type { BlocklistMeta, BlocklistValue, ControlSymbols, ControlSymbolsEntry, CSSEntries, CSSEntriesInput, CSSObject, CSSValueInput, DynamicRule, ExtendedTokenInfo, ExtractorContext, GenerateOptions, GenerateResult, ParsedUtil, PreflightContext, PreparedRule, RawUtil, ResolvedConfig, RuleContext, RuleMeta, SafeListContext, Shortcut, ShortcutValue, StringifiedUtil, UserConfig, UserConfigDefaults, UtilObject, Variant, VariantContext, VariantHandler, VariantHandlerContext, VariantMatchedResult } from '../types'
-import { Theme } from '@unocss/preset-mini'
-import unoConfig from '../../../inspector/uno.config'
 import { version } from '../../package.json'
 import { resolveConfig } from '../config'
 import { LAYER_DEFAULT, LAYER_PREFLIGHTS } from '../constants'

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -1,4 +1,6 @@
 import type { BlocklistMeta, BlocklistValue, ControlSymbols, ControlSymbolsEntry, CSSEntries, CSSEntriesInput, CSSObject, CSSValueInput, DynamicRule, ExtendedTokenInfo, ExtractorContext, GenerateOptions, GenerateResult, ParsedUtil, PreflightContext, PreparedRule, RawUtil, ResolvedConfig, RuleContext, RuleMeta, SafeListContext, Shortcut, ShortcutValue, StringifiedUtil, UserConfig, UserConfigDefaults, UtilObject, Variant, VariantContext, VariantHandler, VariantHandlerContext, VariantMatchedResult } from '../types'
+import { Theme } from '@unocss/preset-mini'
+import unoConfig from '../../../inspector/uno.config'
 import { version } from '../../package.json'
 import { resolveConfig } from '../config'
 import { LAYER_DEFAULT, LAYER_PREFLIGHTS } from '../constants'
@@ -13,22 +15,29 @@ export const symbols: ControlSymbols = {
   layer: '$$symbol-layer' as unknown as ControlSymbols['layer'],
 }
 
-export class UnoGenerator<Theme extends object = object> {
+class UnoGeneratorInternal<Theme extends object = object> {
   public version = version
   private _cache = new Map<string, StringifiedUtil<Theme>[] | null>()
-  public config: ResolvedConfig<Theme>
+  public config: ResolvedConfig<Theme> = undefined!
   public blocked = new Set<string>()
   public parentOrders = new Map<string, number>()
   public events = createNanoEvents<{
     config: (config: ResolvedConfig<Theme>) => void
   }>()
 
-  constructor(
+  protected constructor(
     public userConfig: UserConfig<Theme> = {},
     public defaults: UserConfigDefaults<Theme> = {},
-  ) {
-    this.config = resolveConfig(userConfig, defaults)
-    this.events.emit('config', this.config)
+  ) {}
+
+  static async create<Theme extends object = object>(
+    userConfig: UserConfig<Theme> = {},
+    defaults: UserConfigDefaults<Theme> = {},
+  ): Promise<UnoGeneratorInternal<Theme>> {
+    const uno = new UnoGeneratorInternal(userConfig, defaults)
+    uno.config = resolveConfig(uno.userConfig, uno.defaults)
+    uno.events.emit('config', uno.config)
+    return uno
   }
 
   setConfig(
@@ -837,8 +846,24 @@ export class UnoGenerator<Theme extends object = object> {
   }
 }
 
-export function createGenerator<Theme extends object = object>(config?: UserConfig<Theme>, defaults?: UserConfigDefaults<Theme>) {
-  return new UnoGenerator<Theme>(config, defaults)
+export class UnoGenerator<Theme extends object = object> extends UnoGeneratorInternal<Theme> {
+  /**
+   * @deprecated `new UnoGenerator` is deprecated, please use `createGenerator()` instead
+   */
+  constructor(
+    userConfig: UserConfig<Theme> = {},
+    defaults: UserConfigDefaults<Theme> = {},
+  ) {
+    super(userConfig, defaults)
+    console.warn('`new UnoGenerator()` is deprecated, please use `createGenerator()` instead')
+  }
+}
+
+export async function createGenerator<Theme extends object = object>(
+  config?: UserConfig<Theme>,
+  defaults?: UserConfigDefaults<Theme>,
+): Promise<UnoGenerator<Theme>> {
+  return await UnoGeneratorInternal.create(config, defaults)
 }
 
 export const regexScopePlaceholder = /\s\$\$\s+/g

--- a/packages/core/test/blocklist.test.ts
+++ b/packages/core/test/blocklist.test.ts
@@ -4,12 +4,12 @@ import { describe, expect, it } from 'vitest'
 
 describe('blocklist', () => {
   it('basic', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
     })
-    const dos = createGenerator({
+    const dos = await createGenerator({
       warn: false,
       blocklist: [
         'block',

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -14,7 +14,7 @@ describe('config', () => {
     })
   }
   it('theme', async () => {
-    const uno = createUno({
+    const uno = await createUno({
       theme: {
         colors: {
           red: {
@@ -32,7 +32,7 @@ describe('config', () => {
   })
 
   it('extendTheme with return extend', async () => {
-    const uno = createUno({
+    const uno = await createUno({
       extendTheme(mergedTheme) {
         return {
           ...mergedTheme,
@@ -48,7 +48,7 @@ describe('config', () => {
   })
 
   it('extendTheme with return', async () => {
-    const unocss = createGenerator<Theme>({
+    const unocss = await createGenerator<Theme>({
       extendTheme: () => {
         return {
           colors: {
@@ -70,7 +70,7 @@ describe('config', () => {
   })
 
   it('extendTheme with mutation', async () => {
-    const unocss = createGenerator<Theme>({
+    const unocss = await createGenerator<Theme>({
       extendTheme: (theme) => {
         // @ts-expect-error test
         theme.colors.red[100] = 'green'
@@ -114,7 +114,7 @@ describe('config', () => {
       ],
     }
 
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetB,
       ],
@@ -138,7 +138,7 @@ describe('config', () => {
     const presetB: Preset = { name: 'presetB' }
     const presetC: Preset = { name: 'presetC', presets: [presetA] }
 
-    const unoA = createGenerator({
+    const unoA = await createGenerator({
       presets: [
         presetA,
         presetB,
@@ -148,7 +148,7 @@ describe('config', () => {
 
     expect(unoA.config.presets.map(i => i.name)).toEqual(['presetA', 'presetB'])
 
-    const unoB = createGenerator({
+    const unoB = await createGenerator({
       presets: [
         presetA,
         presetB,
@@ -306,8 +306,8 @@ describe('mergeConfigs', () => {
       `)
   })
 
-  it('content', () => {
-    const uno = createGenerator({
+  it('content', async () => {
+    const uno = await createGenerator({
       presets: [{
         name: 'test',
         content: {
@@ -326,8 +326,8 @@ describe('mergeConfigs', () => {
     })
   })
 
-  it('merge transformers', () => {
-    const uno = createGenerator({
+  it('merge transformers', async () => {
+    const uno = await createGenerator({
       presets: [
         {
           name: 'preset-foo',

--- a/packages/core/test/extended-info.test.ts
+++ b/packages/core/test/extended-info.test.ts
@@ -2,7 +2,7 @@ import { createGenerator } from '@unocss/core'
 import { expect, it } from 'vitest'
 
 it('extended-info', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     rules: [
       ['a', { name: 'bar1' }, { layer: 'a' }],
       ['b', { name: 'bar2' }, { layer: 'b' }],

--- a/packages/core/test/layer.test.ts
+++ b/packages/core/test/layer.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('layers', () => {
   it('static', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         ['a', { name: 'bar1' }, { layer: 'a' }],
         ['b', { name: 'bar2' }, { layer: 'b' }],
@@ -23,7 +23,7 @@ describe('layers', () => {
   })
 
   it('@import layer', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
         presetWebFonts({

--- a/packages/core/test/order.test.ts
+++ b/packages/core/test/order.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('order', () => {
   it('static', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         ['foo', { name: 'bar1' }],
         ['foo', { name: 'bar2' }],
@@ -17,7 +17,7 @@ describe('order', () => {
   })
 
   it('dynamic', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         [/^foo$/, () => ({ name: 'bar1' })],
         [/^foo$/, () => ({ name: 'bar2' })],
@@ -29,7 +29,7 @@ describe('order', () => {
   })
 
   it('variant ordering', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         [/^foo-.$/, ([m]) => ({ name: m })],
       ],
@@ -61,7 +61,7 @@ describe('order', () => {
   })
 
   it('variant ordering reversed', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         [/^foo-.$/, ([m]) => ({ name: m })],
       ],
@@ -93,7 +93,7 @@ describe('order', () => {
   })
 
   it('multiple variant sorting', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -110,7 +110,7 @@ describe('order', () => {
   })
 
   it('pseudo-elements sorting', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -125,7 +125,7 @@ describe('order', () => {
   })
 
   it('variant sorting', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         [/^foo-.$/, ([m]) => ({ foo: m })],
       ],
@@ -159,7 +159,7 @@ describe('order', () => {
   })
 
   it('fully controlled rules merged and sorted by body', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         ['uno', { '--var': 'uno' }],
         [/^foo-(.+)$/, ([, match]) => {

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -3,7 +3,7 @@ import presetUno from '@unocss/preset-uno'
 import { expect, it } from 'vitest'
 
 it('split string with custom separator', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetUno(),
     ],
@@ -15,7 +15,7 @@ it('split string with custom separator', async () => {
 })
 
 it('unable to generate token variant with explicit separator without dash', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetUno(),
     ],

--- a/packages/core/test/postprocess.test.ts
+++ b/packages/core/test/postprocess.test.ts
@@ -8,7 +8,7 @@ it('postprocess', async () => {
     'scale-100',
   ]
 
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetUno(),
       {

--- a/packages/core/test/preflights.test.ts
+++ b/packages/core/test/preflights.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('preflights', () => {
   it('basic', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       preflights: [
         {
           getCSS() {
@@ -30,7 +30,7 @@ describe('preflights', () => {
 
   it('no preflights with preset', async () => {
     const cssArray = [presetMini, presetUno, presetWind].map(async (preset) => {
-      const uno = createGenerator({
+      const uno = await createGenerator({
         presets: [preset({ preflight: false })],
       })
       const { css } = await uno.generate('')
@@ -46,7 +46,7 @@ describe('preflights', () => {
   })
 
   it('preflight root can be customized with string', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -59,7 +59,7 @@ describe('preflights', () => {
   })
 
   it('preflight root can be customized with array', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -72,7 +72,7 @@ describe('preflights', () => {
   })
 
   it('preflight root can be disabled using empty array', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -85,7 +85,7 @@ describe('preflights', () => {
   })
 
   it('preflight with variablePrefix', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini({
           variablePrefix: 'test-',
@@ -97,7 +97,7 @@ describe('preflights', () => {
   })
 
   it('preflight with empty variablePrefix', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini({
           variablePrefix: '',

--- a/packages/core/test/preprocess.test.ts
+++ b/packages/core/test/preprocess.test.ts
@@ -24,7 +24,7 @@ describe('preprocess', () => {
       'i-carbon-moon',
     ]
 
-    const uno = createGenerator({
+    const uno = await createGenerator({
       preprocess: m => m.startsWith('uno:') ? m.substr(4) : '',
       presets: [
         presetUno(),
@@ -59,7 +59,7 @@ describe('preprocess', () => {
     ]
 
     const prefixRE = /uno[:-]/
-    const uno = createGenerator({
+    const uno = await createGenerator({
       preprocess: m => prefixRE.test(m) ? m.replace(prefixRE, '') : '',
       presets: [
         presetUno(),

--- a/packages/core/test/rule-async.test.ts
+++ b/packages/core/test/rule-async.test.ts
@@ -3,7 +3,7 @@ import { expect, it } from 'vitest'
 
 it('rule-first', async () => {
   const order: number[] = []
-  const uno = createGenerator({
+  const uno = await createGenerator({
     rules: [
       [/^rule$/, () => new Promise(resolve => setTimeout(() => {
         order.push(1)
@@ -25,7 +25,7 @@ it('rule-first', async () => {
 
 it('preflight at the end', async () => {
   const order: number[] = []
-  const uno = createGenerator({
+  const uno = await createGenerator({
     rules: [
       [/^rule$/, () => new Promise(resolve => setTimeout(() => {
         order.push(1)

--- a/packages/core/test/rule-generator.test.ts
+++ b/packages/core/test/rule-generator.test.ts
@@ -2,7 +2,7 @@ import { createGenerator } from '@unocss/core'
 import { expect, it } from 'vitest'
 
 it('rule-generator', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     rules: [
       [/^rule$/, function* () {
         yield {
@@ -23,7 +23,7 @@ it('rule-generator', async () => {
 })
 
 it('rule-generator async', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     rules: [
       [/^rule$/, async function* () {
         yield {
@@ -49,7 +49,7 @@ it('rule-generator async', async () => {
 })
 
 it('rule-generator bail out', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     rules: [
       [/^rule-(.*)$/, function () {
         return {

--- a/packages/core/test/rule-prefix.test.ts
+++ b/packages/core/test/rule-prefix.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('prefix', () => {
   it('preset prefix', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno({ prefix: 'h-' }),
       ],
@@ -47,7 +47,7 @@ describe('prefix', () => {
   })
 
   it('uses first truthy prefix', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno({
           prefix: ['', 'h-'],
@@ -59,7 +59,7 @@ describe('prefix', () => {
   })
 
   it('generate tagged attributify', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno({
           prefix: 'h-',
@@ -72,7 +72,7 @@ describe('prefix', () => {
   })
 
   it('multiple preset prefix', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno({ prefix: ['h-', 'x-'] }),
       ],

--- a/packages/core/test/rule-raw.test.ts
+++ b/packages/core/test/rule-raw.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('rule-raw', () => {
   it('basic', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [],
       rules: [
         ['before', { content: 'before' }],

--- a/packages/core/test/rule-symbols.test.ts
+++ b/packages/core/test/rule-symbols.test.ts
@@ -3,7 +3,7 @@ import { createGenerator } from '@unocss/core'
 import { expect, it } from 'vitest'
 
 it('shortcuts-no-merge', async () => {
-  const uno1 = createGenerator({
+  const uno1 = await createGenerator({
     rules: [
       [/^color-(.*)$/, function * ([, color]) {
         yield {
@@ -29,7 +29,7 @@ it('shortcuts-no-merge', async () => {
       .shortcut{color:red;font-weight:bold;background-color:red;}"
     `)
 
-  const uno2 = createGenerator({
+  const uno2 = await createGenerator({
     rules: [
       [/^color-(.*)$/, function * ([, color], ctx) {
         yield {
@@ -59,7 +59,7 @@ it('shortcuts-no-merge', async () => {
 })
 
 it('variants', async () => {
-  const uno1 = createGenerator({
+  const uno1 = await createGenerator({
     rules: [
       [/^color-(.*)$/, function * ([, color], ctx) {
         yield {
@@ -104,7 +104,7 @@ it('variants', async () => {
 })
 
 it('parent', async () => {
-  const uno1 = createGenerator({
+  const uno1 = await createGenerator({
     rules: [
       [/^color-(.*)$/, function * ([, color], ctx) {
         yield {
@@ -136,7 +136,7 @@ it('parent', async () => {
 })
 
 it('selector', async () => {
-  const uno1 = createGenerator({
+  const uno1 = await createGenerator({
     rules: [
       [/^color-(.*)$/, function * ([, color], ctx) {
         yield {
@@ -158,7 +158,7 @@ it('selector', async () => {
 })
 
 it('layer', async () => {
-  const uno1 = createGenerator({
+  const uno1 = await createGenerator({
     rules: [
       [/^color-(.*)$/, function * ([, color], ctx) {
         yield {
@@ -176,7 +176,7 @@ it('layer', async () => {
 })
 
 it('layer string', async () => {
-  const uno1 = createGenerator({
+  const uno1 = await createGenerator({
     rules: [
       [/^color-(.*)$/, function * ([, color], ctx) {
         yield {

--- a/packages/core/test/safelist.test.ts
+++ b/packages/core/test/safelist.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('safelist', () => {
   it('basic', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],

--- a/packages/core/test/scope.test.ts
+++ b/packages/core/test/scope.test.ts
@@ -17,7 +17,7 @@ export const fixture = new Set([
   'scope-[.variant]:c-red',
 ])
 
-const uno = createGenerator({
+const uno = await createGenerator({
   presets: [
     presetUno(),
   ],

--- a/packages/core/test/selector-no-merge.test.ts
+++ b/packages/core/test/selector-no-merge.test.ts
@@ -2,8 +2,8 @@ import { createGenerator } from '@unocss/core'
 import { variantMatcher } from '@unocss/preset-mini/utils'
 import { describe, expect, it } from 'vitest'
 
-describe('selector', () => {
-  const uno = createGenerator({
+describe('selector', async () => {
+  const uno = await createGenerator({
     rules: [
       [/^to-merge$/, () => [{ merged: 1 }]],
       [/^merge-candidate$/, () => ({ merged: 1 })],
@@ -17,8 +17,8 @@ describe('selector', () => {
   })
 })
 
-describe('variant', () => {
-  const uno = createGenerator({
+describe('variant', async () => {
+  const uno = await createGenerator({
     shortcuts: [
       [/^m1-(.+)$/, ([, s]) => `moz:${s} webkit:${s}`],
       [/^m2-(.+)$/, ([, s]) => `moz:${s} merge-candidate`],

--- a/packages/core/test/shortcuts.test.ts
+++ b/packages/core/test/shortcuts.test.ts
@@ -4,8 +4,8 @@ import parserCSS from 'prettier/parser-postcss'
 import prettier from 'prettier/standalone'
 import { describe, expect, it } from 'vitest'
 
-describe('shortcuts', () => {
-  const uno = createGenerator({
+describe('shortcuts', async () => {
+  const uno = await createGenerator({
     shortcuts: [
       {
         sh1: 'px-2 py-3 sh3',

--- a/packages/core/test/use-css-layer.test.ts
+++ b/packages/core/test/use-css-layer.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('use-css-layer', () => {
   it('static', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         ['a', { name: 'bar1' }, { layer: 'a' }],
         ['b', { name: 'bar2' }, { layer: 'b' }],
@@ -23,7 +23,7 @@ describe('use-css-layer', () => {
   })
 
   it('change layer name', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [presetUno()],
       shortcuts: {
         'custom-shortcut': 'text-lg text-orange hover:text-teal',

--- a/packages/core/test/utils/define.test.ts
+++ b/packages/core/test/utils/define.test.ts
@@ -46,7 +46,7 @@ describe('definePreset', () => {
       }
     })
 
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetFn1(),
         presetFn2, // presetFn2 is a factory that will be evaluated by uno

--- a/packages/extractor-mdc/test/extractor-mdc.test.ts
+++ b/packages/extractor-mdc/test/extractor-mdc.test.ts
@@ -3,7 +3,7 @@ import { expect, it } from 'vitest'
 import extractorMdc from '../src/index'
 
 it('extractorMdc', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     extractors: [
       extractorMdc(),
     ],

--- a/packages/extractor-svelte/test/extractor-svelte.test.ts
+++ b/packages/extractor-svelte/test/extractor-svelte.test.ts
@@ -3,7 +3,7 @@ import extractorSvelte from '@unocss/extractor-svelte'
 import { expect, it } from 'vitest'
 
 it('extractorSvelte uses regular split with non .svelte files', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     extractors: [
       extractorSvelte(),
     ],
@@ -25,7 +25,7 @@ it('extractorSvelte uses regular split with non .svelte files', async () => {
 })
 
 it('extractorSvelte uses svelte-specific split with .svelte files', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     extractors: [
       extractorSvelte(),
     ],

--- a/packages/postcss/src/esm.ts
+++ b/packages/postcss/src/esm.ts
@@ -88,12 +88,12 @@ export function createPlugin(options: UnoPostcssPluginOptions) {
     try {
       const cfg = await config
       if (!uno) {
-        uno = createGenerator(cfg.config)
+        uno = await createGenerator(cfg.config)
       }
       else if (cfg.sources.length) {
         const config_mtime = (await stat(cfg.sources[0])).mtimeMs
         if (config_mtime > last_config_mtime) {
-          uno = createGenerator((await loadConfig()).config)
+          uno = await createGenerator((await loadConfig()).config)
           last_config_mtime = config_mtime
         }
       }

--- a/packages/preset-mini/src/_variants/pseudo.test.ts
+++ b/packages/preset-mini/src/_variants/pseudo.test.ts
@@ -4,7 +4,7 @@ import { variantPseudoClassesAndElements } from './pseudo'
 
 // https://github.com/unocss/unocss/issues/2713
 it('pseudo variant order', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     variants: [
       variantPseudoClassesAndElements(),
     ],
@@ -51,7 +51,7 @@ it('pseudo variant order', async () => {
 
 // https://github.com/unocss/unocss/issues/2733
 it('focus-visible:', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     variants: [
       variantPseudoClassesAndElements(),
     ],

--- a/packages/preset-mini/test/color.test.ts
+++ b/packages/preset-mini/test/color.test.ts
@@ -39,7 +39,7 @@ describe('preset-mini color utils', () => {
     // invalid
   })
 
-  it('parses color token', () => {
+  it('parses color token', async () => {
     const context: RuleContext = {
       theme: {
         colors: {
@@ -51,7 +51,7 @@ describe('preset-mini color utils', () => {
       symbols,
       rawSelector: '',
       currentSelector: '',
-      generator: createGenerator(),
+      generator: await createGenerator(),
       variantHandlers: [],
       variantMatch: ['', '', [], new Set()],
       constructCSS: () => '',

--- a/packages/rule-utils/test/variant-handler.test.ts
+++ b/packages/rule-utils/test/variant-handler.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('variants', () => {
   it('variant context is propagated', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         ['foo', { name: 'bar' }],
       ],
@@ -42,7 +42,7 @@ describe('variants', () => {
   })
 
   it('selector section is merged in order', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         ['foo', { name: 'bar' }],
       ],
@@ -65,7 +65,7 @@ describe('variants', () => {
   })
 
   it('variant can stack', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         ['foo', { name: 'bar' }],
       ],
@@ -116,7 +116,7 @@ describe('variants', () => {
   })
 
   it('noMerge on variant', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         ['foo', { name: 'bar' }],
       ],
@@ -150,7 +150,7 @@ describe('variants', () => {
   })
 
   it('noMerge variant with shortcut', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         ['foo', { name: 'bar' }],
       ],
@@ -184,7 +184,7 @@ describe('variants', () => {
   })
 
   it('selector match can be ordered', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       rules: [
         ['foo', { name: 'bar' }],
       ],

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -143,7 +143,7 @@ declare global {
   }
 }
 
-export default function init(inlineConfig: RuntimeOptions = {}) {
+export default async function init(inlineConfig: RuntimeOptions = {}): Promise<void> {
   if (typeof window == 'undefined') {
     console.warn('@unocss/runtime been used in non-browser environment, skipped.')
     return
@@ -163,7 +163,7 @@ export default function init(inlineConfig: RuntimeOptions = {}) {
   }
 
   runtimeOptions.configResolved?.(userConfig, userConfigDefaults)
-  const uno = createGenerator(userConfig, userConfigDefaults)
+  const uno = await createGenerator(userConfig, userConfigDefaults)
   const inject = (styleElement: HTMLStyleElement) => runtimeOptions.inject ? runtimeOptions.inject(styleElement) : html().prepend(styleElement)
   const rootElement = () => runtimeOptions.rootElement ? runtimeOptions.rootElement() : defaultDocument.body
   const styleElements = new Map<string, HTMLStyleElement>()

--- a/packages/runtime/test-dom/runtime-dom.test.ts
+++ b/packages/runtime/test-dom/runtime-dom.test.ts
@@ -25,7 +25,7 @@ describe('runtime dom manipulation', async () => {
   }
 
   it('runtime generates multiple styles', async () => {
-    const runtime = initRuntime()
+    const runtime = await initRuntime()
 
     await runtime?.extract('container mt0')
     const result = await runtime?.update()
@@ -42,7 +42,7 @@ describe('runtime dom manipulation', async () => {
   })
 
   it('runtime can retrieve styles ordered by layer', async () => {
-    const runtime = initRuntime({
+    const runtime = await initRuntime({
       layers: {
         pre: -10,
         default: 10,
@@ -59,7 +59,7 @@ describe('runtime dom manipulation', async () => {
   })
 
   it('runtime styles is placed in order', async () => {
-    const runtime = initRuntime()
+    const runtime = await initRuntime()
 
     await runtime?.extract('ring-red')
     const result = await runtime?.update()

--- a/packages/runtime/test-dom/runtime-dom.test.ts
+++ b/packages/runtime/test-dom/runtime-dom.test.ts
@@ -3,13 +3,13 @@
 import presetUno from '@unocss/preset-uno'
 import initUnocssRuntime from '@unocss/runtime'
 
-describe('runtime dom manipulation', () => {
+describe('runtime dom manipulation', async () => {
   afterEach(() => {
     window.document.documentElement.innerHTML = ''
   })
 
-  function initRuntime(options?: any) {
-    initUnocssRuntime({
+  async function initRuntime(options?: any) {
+    await initUnocssRuntime({
       defaults: {
         presets: [
           presetUno(),

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -38,7 +38,7 @@ const targets = [
 
 describe('runtime auto prefixer', () => {
   it('without autoprefixer', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -49,7 +49,7 @@ describe('runtime auto prefixer', () => {
   })
 
   it('using autoprefixer', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -63,7 +63,7 @@ describe('runtime auto prefixer', () => {
   })
 
   it('runtime tagify', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
         presetTagify(),

--- a/packages/shared-docs/src/search.ts
+++ b/packages/shared-docs/src/search.ts
@@ -9,16 +9,16 @@ import { computed, shallowReactive, toRaw } from 'vue'
 import { extractColors, formatCSS, sampleArray } from './utils'
 
 export interface SearchState {
-  uno: UnoGenerator | Promise<UnoGenerator>
+  uno: UnoGenerator
   docs: Ref<DocItem[]>
   guides: GuideItem[]
   limit?: number
 }
 
 export function createSearch(
-  { uno: _uno, docs, guides, limit = 25 }: SearchState,
+  { uno, docs, guides, limit = 25 }: SearchState,
 ) {
-  const ac = createAutocomplete(_uno)
+  const ac = createAutocomplete(uno)
   const matchedMap = shallowReactive(new Map<string, RuleItem>())
   const featuresMap = shallowReactive(new Map<string, Set<RuleItem>>())
 
@@ -61,9 +61,7 @@ export function createSearch(
 
   const az09 = Array.from('abcdefghijklmnopqrstuvwxyz01234567890')
 
-  Promise.resolve(_uno).then((uno) => {
-    uno.events.on('config', reset)
-  })
+  uno.events.on('config', reset)
 
   let _fusePrepare: Promise<void> | undefined
   async function search(input: string) {
@@ -161,7 +159,6 @@ export function createSearch(
     if (matchedMap.has(input))
       return matchedMap.get(input)
 
-    const uno = await _uno
     const token = await uno.parseToken(input)
     if (!token?.length)
       return

--- a/packages/shared-docs/src/search.ts
+++ b/packages/shared-docs/src/search.ts
@@ -9,16 +9,16 @@ import { computed, shallowReactive, toRaw } from 'vue'
 import { extractColors, formatCSS, sampleArray } from './utils'
 
 export interface SearchState {
-  uno: UnoGenerator
+  uno: UnoGenerator | Promise<UnoGenerator>
   docs: Ref<DocItem[]>
   guides: GuideItem[]
   limit?: number
 }
 
 export function createSearch(
-  { uno, docs, guides, limit = 25 }: SearchState,
+  { uno: _uno, docs, guides, limit = 25 }: SearchState,
 ) {
-  const ac = createAutocomplete(uno)
+  const ac = createAutocomplete(_uno)
   const matchedMap = shallowReactive(new Map<string, RuleItem>())
   const featuresMap = shallowReactive(new Map<string, Set<RuleItem>>())
 
@@ -61,7 +61,9 @@ export function createSearch(
 
   const az09 = Array.from('abcdefghijklmnopqrstuvwxyz01234567890')
 
-  uno.events.on('config', reset)
+  Promise.resolve(_uno).then((uno) => {
+    uno.events.on('config', reset)
+  })
 
   let _fusePrepare: Promise<void> | undefined
   async function search(input: string) {
@@ -159,6 +161,7 @@ export function createSearch(
     if (matchedMap.has(input))
       return matchedMap.get(input)
 
+    const uno = await _uno
     const token = await uno.parseToken(input)
     if (!token?.length)
       return

--- a/packages/shared-integration/test/sort-rules.test.ts
+++ b/packages/shared-integration/test/sort-rules.test.ts
@@ -3,8 +3,8 @@ import presetUno from '@unocss/preset-uno'
 import { describe, expect, it } from 'vitest'
 import { sortRules } from '../src/sort-rules'
 
-describe('sort rules', () => {
-  const uno = createGenerator({
+describe('sort rules', async () => {
+  const uno = await createGenerator({
     presets: [
       presetUno(),
     ],

--- a/packages/svelte-scoped/src/_preprocess/transformApply/getUtils.test.ts
+++ b/packages/svelte-scoped/src/_preprocess/transformApply/getUtils.test.ts
@@ -17,7 +17,7 @@ describe('getUtils', async () => {
     vi.restoreAllMocks()
   })
 
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetUno(),
     ],

--- a/packages/svelte-scoped/src/_preprocess/transformApply/index.test.ts
+++ b/packages/svelte-scoped/src/_preprocess/transformApply/index.test.ts
@@ -6,8 +6,8 @@ import parserCSS from 'prettier/parser-postcss'
 import { describe, expect, it } from 'vitest'
 import { transformApply } from '.'
 
-describe('transformApply', () => {
-  const uno = createGenerator({
+describe('transformApply', async () => {
+  const uno = await createGenerator({
     presets: [
       presetUno(),
     ],

--- a/packages/svelte-scoped/src/_preprocess/transformClasses/index.test.ts
+++ b/packages/svelte-scoped/src/_preprocess/transformClasses/index.test.ts
@@ -8,9 +8,9 @@ import { describe, expect, it } from 'vitest'
 import prettierSvelte from 'prettier-plugin-svelte'
 import { transformClasses } from '.'
 
-describe('transform', () => {
+describe('transform', async () => {
   const safelistClassToSkip = 'mr-7'
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetUno(),
       presetIcons({

--- a/packages/svelte-scoped/src/_vite/index.ts
+++ b/packages/svelte-scoped/src/_vite/index.ts
@@ -1,4 +1,4 @@
-import type { UserConfig, UserConfigDefaults } from '@unocss/core'
+import type { UnoGenerator, UserConfig, UserConfigDefaults } from '@unocss/core'
 import type { Plugin } from 'vite'
 import type { SvelteScopedContext } from '../preprocess'
 import type { UnocssSvelteScopedViteOptions } from './types'
@@ -41,18 +41,28 @@ const defaults: UserConfigDefaults = {
 }
 
 function createSvelteScopedContext(configOrPath?: UserConfig | string): SvelteScopedContext {
-  const uno = createGenerator()
+  let uno: UnoGenerator
+  const _uno = createGenerator()
+    .then((r) => {
+      uno = r
+      return r
+    })
   const loadConfig = createRecoveryConfigLoader()
   const ready = reloadConfig()
 
   async function reloadConfig() {
+    await _uno
     const { config, sources } = await loadConfig(process.cwd(), configOrPath)
     uno.setConfig(config, defaults)
     return { config, sources }
   }
 
   return {
-    uno,
+    get uno() {
+      if (!uno)
+        throw new Error('Run `await ctx.ready` before accessing to `ctx.uno`')
+      return uno
+    },
     ready,
   }
 }

--- a/packages/vite/src/config-hmr.ts
+++ b/packages/vite/src/config-hmr.ts
@@ -2,17 +2,16 @@ import type { UnocssPluginContext } from '@unocss/core'
 import type { Plugin } from 'vite'
 
 export function ConfigHMRPlugin(ctx: UnocssPluginContext): Plugin | undefined {
-  const { ready, uno } = ctx
+  const { ready } = ctx
   return {
     name: 'unocss:config',
     async configResolved(config) {
       await ctx.updateRoot(config.root)
     },
     async configureServer(server) {
-      uno.config.envMode = 'dev'
-
       const { sources } = await ready
 
+      ctx.uno.config.envMode = 'dev'
       if (!sources.length)
         return
 

--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -26,7 +26,7 @@ function isLegacyChunk(chunk: RenderedChunk, options: NormalizedOutputOptions) {
 }
 
 export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>): Plugin[] {
-  const { uno, ready, extract, tokens, filter, getConfig, tasks, flushTasks } = ctx
+  const { ready, extract, tokens, filter, getConfig, tasks, flushTasks } = ctx
   const vfsLayers = new Set<string>()
   const layerImporterMap = new Map<string, string>()
   let viteConfig: ResolvedConfig
@@ -59,7 +59,7 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
     await flushTasks()
     if (lastResult && lastTokenSize === tokens.size)
       return lastResult
-    lastResult = await uno.generate(tokens, { minify: true })
+    lastResult = await ctx.uno.generate(tokens, { minify: true })
     lastTokenSize = tokens.size
     return lastResult
   }
@@ -224,6 +224,7 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
           this.warn('[unocss] failed to find vite:css-post plugin. It might be an internal bug of UnoCSS')
           return null
         }
+
         const result = await generateAll()
         const importsLayer = result.getLayer(LAYER_IMPORTS) ?? ''
         const fakeCssId = `${viteConfig.root}/${chunk.fileName}-unocss-hash.css`

--- a/packages/vite/src/modes/global/dev.ts
+++ b/packages/vite/src/modes/global/dev.ts
@@ -10,7 +10,8 @@ const WARN_TIMEOUT = 20000
 const WS_EVENT_PREFIX = 'unocss:hmr'
 const HASH_LENGTH = 6
 
-export function GlobalModeDevPlugin({ uno, tokens, tasks, flushTasks, affectedModules, onInvalidate, extract, filter, getConfig }: UnocssPluginContext): Plugin[] {
+export function GlobalModeDevPlugin(ctx: UnocssPluginContext): Plugin[] {
+  const { tokens, tasks, flushTasks, affectedModules, onInvalidate, extract, filter, getConfig } = ctx
   const servers: ViteDevServer[] = []
   const entries = new Set<string>()
 
@@ -25,7 +26,7 @@ export function GlobalModeDevPlugin({ uno, tokens, tasks, flushTasks, affectedMo
     let result: GenerateResult
     let tokensSize = tokens.size
     do {
-      result = await uno.generate(tokens)
+      result = await ctx.uno.generate(tokens)
       // to capture new tokens created during generation
       if (tokensSize === tokens.size)
         break
@@ -124,7 +125,7 @@ export function GlobalModeDevPlugin({ uno, tokens, tasks, flushTasks, affectedMo
       },
       buildStart() {
         // warm up for preflights
-        uno.generate([], { preflights: true })
+        ctx.uno.generate([], { preflights: true })
       },
       transform(code, id) {
         if (filter(code, id))

--- a/packages/vscode/src/contextLoader.ts
+++ b/packages/vscode/src/contextLoader.ts
@@ -205,8 +205,10 @@ export class ContextLoader {
 
       this.events.emit('contextLoaded', context)
 
+      const uno = await context.uno
+
       log.appendLine(`🛠 New configuration loaded from\n${sources.map(s => `  - ${s}`).join('\n')}`)
-      log.appendLine(`ℹ️ ${context.uno.config.presets.length} presets, ${context.uno.config.rulesSize} rules, ${context.uno.config.shortcuts.length} shortcuts, ${context.uno.config.variants.length} variants, ${context.uno.config.transformers?.length || 0} transformers loaded`)
+      log.appendLine(`ℹ️ ${uno.config.presets.length} presets, ${uno.config.rulesSize} rules, ${uno.config.shortcuts.length} shortcuts, ${uno.config.variants.length} variants, ${uno.config.transformers?.length || 0} transformers loaded`)
 
       if (!sources.some(i => unoConfigRE.test(i))) {
         log.appendLine('💡 To have the best IDE experience, it\'s recommended to move UnoCSS configurations into a standalone `uno.config.ts` file at the root of your project.')

--- a/playground/src/auto-imports.d.ts
+++ b/playground/src/auto-imports.d.ts
@@ -8,6 +8,7 @@ export {}
 declare global {
   const EffectScope: typeof import('vue')['EffectScope']
   const STORAGE_KEY: typeof import('./composables/constants')['STORAGE_KEY']
+  const __uno: typeof import('./composables/uno')['__uno']
   const annotations: typeof import('./composables/uno')['annotations']
   const asyncComputed: typeof import('@vueuse/core')['asyncComputed']
   const autoResetRef: typeof import('@vueuse/core')['autoResetRef']
@@ -358,6 +359,7 @@ declare module 'vue' {
   interface ComponentCustomProperties {
     readonly EffectScope: UnwrapRef<typeof import('vue')['EffectScope']>
     readonly STORAGE_KEY: UnwrapRef<typeof import('./composables/constants')['STORAGE_KEY']>
+    readonly __uno: UnwrapRef<typeof import('./composables/uno')['__uno']>
     readonly annotations: UnwrapRef<typeof import('./composables/uno')['annotations']>
     readonly asyncComputed: UnwrapRef<typeof import('@vueuse/core')['asyncComputed']>
     readonly autoResetRef: UnwrapRef<typeof import('@vueuse/core')['autoResetRef']>
@@ -496,7 +498,6 @@ declare module 'vue' {
     readonly tryOnMounted: UnwrapRef<typeof import('@vueuse/core')['tryOnMounted']>
     readonly tryOnScopeDispose: UnwrapRef<typeof import('@vueuse/core')['tryOnScopeDispose']>
     readonly tryOnUnmounted: UnwrapRef<typeof import('@vueuse/core')['tryOnUnmounted']>
-    readonly uno: UnwrapRef<typeof import('./composables/uno')['uno']>
     readonly unref: UnwrapRef<typeof import('vue')['unref']>
     readonly unrefElement: UnwrapRef<typeof import('@vueuse/core')['unrefElement']>
     readonly until: UnwrapRef<typeof import('@vueuse/core')['until']>

--- a/playground/src/composables/uno.ts
+++ b/playground/src/composables/uno.ts
@@ -11,7 +11,7 @@ export const init = ref(false)
 export const customConfigError = ref<Error>()
 export const customCSSWarn = ref<Error>()
 
-export const __uno = createGenerator({}, defaultConfig.value)
+const __uno = createGenerator({}, defaultConfig.value)
 export const output = shallowRef<GenerateResult>()
 export const annotations = shallowRef<HighlightAnnotation[]>()
 

--- a/playground/src/composables/uno.ts
+++ b/playground/src/composables/uno.ts
@@ -11,32 +11,33 @@ export const init = ref(false)
 export const customConfigError = ref<Error>()
 export const customCSSWarn = ref<Error>()
 
-export const uno = createGenerator({}, defaultConfig.value)
+export const __uno = createGenerator({}, defaultConfig.value)
 export const output = shallowRef<GenerateResult>()
 export const annotations = shallowRef<HighlightAnnotation[]>()
 
 let customConfig: UserConfig = {}
-let autocomplete = createAutocomplete(uno)
+let autocomplete = (async () => createAutocomplete(await __uno))()
 let initial = true
 
 const { transformedHTML, transformed, getTransformed, transformedCSS } = useTransformer()
 
 export async function generate() {
-  output.value = await uno.generate(transformedHTML.value || '')
+  output.value = await (await __uno).generate(transformedHTML.value || '')
   annotations.value = transformed.value?.annotations || []
   init.value = true
 }
 
 async function reGenerate() {
+  const uno = await __uno
   uno.setConfig(customConfig, defaultConfig.value)
   await detectTransformer()
   generate()
-  autocomplete = createAutocomplete(uno)
+  autocomplete = Promise.resolve(createAutocomplete(uno))
 }
 
 export async function getHint(context: CompletionContext): Promise<CompletionResult | null> {
   const cursor = context.pos
-  const result = await autocomplete.suggestInFile(context.state.doc.toString(), cursor)
+  const result = await (await autocomplete).suggestInFile(context.state.doc.toString(), cursor)
 
   if (!result?.suggestions?.length)
     return null
@@ -58,6 +59,7 @@ export async function getHint(context: CompletionContext): Promise<CompletionRes
 debouncedWatch(
   [customConfigRaw, customCSS],
   async () => {
+    const uno = await __uno
     customConfigError.value = undefined
     customCSSWarn.value = undefined
     try {
@@ -101,6 +103,7 @@ function useTransformer() {
   const transformedCSS = computedAsync(async () => (await getTransformed('css')).output)
 
   async function applyTransformers(code: MagicString, id: string, enforce?: 'pre' | 'post') {
+    const uno = await __uno
     let { transformers } = uno.config
     transformers = (transformers ?? []).filter(i => i.enforce === enforce)
 
@@ -135,6 +138,7 @@ function useTransformer() {
 }
 
 async function detectTransformer() {
+  const uno = await __uno
   const { transformers = [] } = uno.config
   if (!transformers.some(t => t.name === '@unocss/transformer-directives')) {
     const msg = 'Using directives requires \'@unocss/transformer-directives\' to be installed.'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,8 +370,8 @@ catalogs:
       specifier: ^0.26.2
       version: 0.26.2
     vite-plugin-inspect:
-      specifier: ^0.8.7
-      version: 0.8.7
+      specifier: ^0.8.8
+      version: 0.8.8
     vite-plugin-pages:
       specifier: ^0.32.3
       version: 0.32.3
@@ -725,7 +725,7 @@ importers:
         version: 5.4.10(@types/node@22.8.7)(terser@5.36.0)
       vite-plugin-inspect:
         specifier: 'catalog:'
-        version: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.3)(webpack-sources@3.2.3))(rollup@4.24.3)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))
+        version: 0.8.8(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.3)(webpack-sources@3.2.3))(rollup@4.24.3)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))
       vite-plugin-pages:
         specifier: 'catalog:'
         version: 0.32.3(@vue/compiler-sfc@3.5.12)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))(vue-router@4.4.5(vue@3.5.12(typescript@5.6.3)))
@@ -1823,6 +1823,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-create-regexp-features-plugin@7.25.2':
+    resolution: {integrity: sha512-+wqVGP+DFmqwFD3EH6TMTfUNeqDehV3E/dl+Sd54eaXqm17tEUNbEIn4sVivVowbvUpOtIGxdo3GoXyDH9N/9g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-create-regexp-features-plugin@7.25.9':
     resolution: {integrity: sha512-ORPNZ3h6ZRkOyAa/SaHU+XsLZr0UQzRwuDQ0cczIA17nAzZ+85G5cVkOJIj7QavLZGSe8QXUmNFxSZzjcZF9bw==}
     engines: {node: '>=6.9.0'}
@@ -2248,8 +2254,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-runtime@7.25.9':
-    resolution: {integrity: sha512-nZp7GlEl+yULJrClz0SwHPqir3lc0zsPrDHQUcxGspSL7AKrexNSEfTbfqnDNJUO13bgKyfuOLMF8Xqtu8j3YQ==}
+  '@babel/plugin-transform-runtime@7.25.4':
+    resolution: {integrity: sha512-8hsyG+KUYGY0coX6KUCDancA0Vw225KJ2HJO0yCNr1vq5r+lJTleDaJf0K7iOhjw4SWhu03TMBzYTJ9krmzULQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2331,6 +2337,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/regjsgen@0.8.0':
+    resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
+
   '@babel/runtime@7.26.0':
     resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
     engines: {node: '>=6.9.0'}
@@ -2363,16 +2372,16 @@ packages:
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
     engines: {node: '>=16.13'}
 
-  '@codemirror/autocomplete@6.18.2':
-    resolution: {integrity: sha512-wJGylKtMFR/Ds6Gh01+OovXE/pncPiKZNNBKuC39pKnH+XK5d9+WsNqcrdxPjFPFTigRBqse0rfxw9UxrfyhPg==}
+  '@codemirror/autocomplete@6.18.1':
+    resolution: {integrity: sha512-iWHdj/B1ethnHRTwZj+C1obmmuCzquH29EbcKr0qIjA9NfDeBDJ7vs+WOHsFeLeflE4o+dHfYndJloMKHUkWUA==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
       '@lezer/common': ^1.0.0
 
-  '@codemirror/commands@6.7.1':
-    resolution: {integrity: sha512-llTrboQYw5H4THfhN4U3qCnSZ1SOJ60ohhz+SzU0ADGtwlc533DtklQP0vSFaQuCPDn3BPpOd1GbbnUtwNjsrw==}
+  '@codemirror/commands@6.6.2':
+    resolution: {integrity: sha512-Fq7eWOl1Rcbrfn6jD8FPCj9Auaxdm5nIK5RYOeW7ughnd/rY5AmPg6b+CfsG39ZHdwiwe8lde3q8uR7CF5S0yQ==}
 
   '@codemirror/lang-css@6.3.0':
     resolution: {integrity: sha512-CyR4rUNG9OYcXDZwMPvJdtb6PHbBDKUc/6Na2BIwZ6dKab1JQqKa4di+RNRY9Myn7JB81vayKwJeQ7jEdmNVDA==}
@@ -2392,8 +2401,8 @@ packages:
   '@codemirror/lint@6.8.2':
     resolution: {integrity: sha512-PDFG5DjHxSEjOXk9TQYYVjZDqlZTFaDBfhQixHnQOEVDDNHUbEh/hstAjcQJaA6FQdZTD1hquXTK0rVBLADR1g==}
 
-  '@codemirror/search@6.5.7':
-    resolution: {integrity: sha512-6+iLsXvITWKHYlkgHPCs/qiX4dNzn8N78YfhOFvPtPYCkuXqZq10rAfsUMhOq7O/1VjJqdXRflyExlfVcu/9VQ==}
+  '@codemirror/search@6.5.6':
+    resolution: {integrity: sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==}
 
   '@codemirror/state@6.4.1':
     resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
@@ -3300,8 +3309,8 @@ packages:
   '@lezer/html@1.3.10':
     resolution: {integrity: sha512-dqpT8nISx/p9Do3AchvYGV3qYc4/rKr3IBZxlHmpIKam56P47RSHkSF5f13Vu9hebS1jM0HmtJIwLbWz1VIY6w==}
 
-  '@lezer/javascript@1.4.19':
-    resolution: {integrity: sha512-j44kbR1QL26l6dMunZ1uhKBFteVGLVCBGNUD2sUaMnic+rbTviVuoK0CD1l9FTW31EueWvFFswCKMH7Z+M3JRA==}
+  '@lezer/javascript@1.4.18':
+    resolution: {integrity: sha512-Y8BeHOt4LtcxJgXwadtfSeWPrh0XzklcCHnCVT+vOsxqH4gWmunP2ykX+VVOlM/dusyVyiNfG3lv0f10UK+mgA==}
 
   '@lezer/lr@1.4.2':
     resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
@@ -3737,11 +3746,20 @@ packages:
   '@shikijs/core@1.22.2':
     resolution: {integrity: sha512-bvIQcd8BEeR1yFvOYv6HDiyta2FFVePbzeowf5pPS1avczrPK+cjmaxxh0nx5QzbON7+Sv0sQfQVciO7bN72sg==}
 
+  '@shikijs/core@1.23.1':
+    resolution: {integrity: sha512-NuOVgwcHgVC6jBVH5V7iblziw6iQbWWHrj5IlZI3Fqu2yx9awH7OIQkXIcsHsUmY19ckwSgUMgrqExEyP5A0TA==}
+
   '@shikijs/engine-javascript@1.22.2':
     resolution: {integrity: sha512-iOvql09ql6m+3d1vtvP8fLCVCK7BQD1pJFmHIECsujB0V32BJ0Ab6hxk1ewVSMFA58FI0pR2Had9BKZdyQrxTw==}
 
+  '@shikijs/engine-javascript@1.23.1':
+    resolution: {integrity: sha512-i/LdEwT5k3FVu07SiApRFwRcSJs5QM9+tod5vYCPig1Ywi8GR30zcujbxGQFJHwYD7A5BUqagi8o5KS+LEVgBg==}
+
   '@shikijs/engine-oniguruma@1.22.2':
     resolution: {integrity: sha512-GIZPAGzQOy56mGvWMoZRPggn0dTlBf1gutV5TdceLCZlFNqWmuc7u+CzD0Gd9vQUTgLbrt0KLzz6FNprqYAxlA==}
+
+  '@shikijs/engine-oniguruma@1.23.1':
+    resolution: {integrity: sha512-KQ+lgeJJ5m2ISbUZudLR1qHeH3MnSs2mjFg7bnencgs5jDVPeJ2NVDJ3N5ZHbcTsOIh0qIueyAJnwg7lg7kwXQ==}
 
   '@shikijs/markdown-it@1.22.2':
     resolution: {integrity: sha512-PgNY3s350UijOWLaoeAXHcYUeDqJKM2De9t8DMkBnQHi6tibo4eoV6sfnsULiJu47TwD1d4VG2YsH0Lxp/VM7A==}
@@ -3749,11 +3767,14 @@ packages:
   '@shikijs/transformers@1.22.2':
     resolution: {integrity: sha512-8f78OiBa6pZDoZ53lYTmuvpFPlWtevn23bzG+azpPVvZg7ITax57o/K3TC91eYL3OMJOO0onPbgnQyZjRos8XQ==}
 
-  '@shikijs/twoslash@1.22.2':
-    resolution: {integrity: sha512-4R3A7aH/toZgtlveXHKk01nIsvn8hjAfPJ1aT550zcV4qK6vK/tfaEyYtaljOaY1wig2l5+8sKjNSEz3PcSiEw==}
+  '@shikijs/twoslash@1.23.1':
+    resolution: {integrity: sha512-Qj/+CGAF6TdcRjPDQn1bxyKD8ejnV7VJLqCHzob1uCbwQlJTI5z0gUVAgpqS55z4vdV1Mrx2IpCTl9glhC0l3A==}
 
   '@shikijs/types@1.22.2':
     resolution: {integrity: sha512-NCWDa6LGZqTuzjsGfXOBWfjS/fDIbDdmVDug+7ykVe1IKT4c1gakrvlfFYp5NhAXH/lyqLM8wsAPo5wNy73Feg==}
+
+  '@shikijs/types@1.23.1':
+    resolution: {integrity: sha512-98A5hGyEhzzAgQh2dAeHKrWW4HfCMeoFER2z16p5eJ+vmPeF6lZ/elEne6/UCU551F/WqkopqRsr1l2Yu6+A0g==}
 
   '@shikijs/vitepress-twoslash@1.22.2':
     resolution: {integrity: sha512-F4cS9l6QTt/ILlz+S871bOido2CK8Xwdnl4q9gHdnTuZlN1PHAMRZbAOvYAtokvouPp9aZ2W7NtNa+CNCn3yPQ==}
@@ -3802,8 +3823,8 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.4.10
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1':
-    resolution: {integrity: sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==}
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3':
+    resolution: {integrity: sha512-kuGJ2CZ5lAw3gKF8Kw0AfKtUJWbwdlDHY14K413B0MCyrzvQvsKTorwmwZcky0+QqY6RnVIZ/5FttB9bQmkLXg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^4.0.0-next.0||^4.0.0
@@ -3868,9 +3889,6 @@ packages:
 
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
-
-  '@types/express-serve-static-core@5.0.1':
-    resolution: {integrity: sha512-CRICJIl0N5cXDONAdlTv5ShATZ4HEwk6kDDIW2/w9qOWKg+NU/5F8wYRWCrONad0/UKkloNSmmyN/wX4rtpbVA==}
 
   '@types/express@4.17.21':
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
@@ -4864,6 +4882,10 @@ packages:
     peerDependencies:
       esbuild: '>=0.18'
 
+  bytes@3.0.0:
+    resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
+    engines: {node: '>= 0.8'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -5156,8 +5178,8 @@ packages:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
 
-  compression@1.7.5:
-    resolution: {integrity: sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==}
+  compression@1.7.4:
+    resolution: {integrity: sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==}
     engines: {node: '>= 0.8.0'}
 
   concat-map@0.0.1:
@@ -5369,10 +5391,6 @@ packages:
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
-    engines: {node: '>= 0.6'}
-
-  cookie@0.7.1:
-    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
@@ -5816,6 +5834,9 @@ packages:
   electron-to-chromium@1.5.50:
     resolution: {integrity: sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==}
 
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
 
@@ -6171,8 +6192,8 @@ packages:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
     engines: {node: '>=12.0.0'}
 
-  express@4.21.1:
-    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
+  express@4.21.0:
+    resolution: {integrity: sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==}
     engines: {node: '>= 0.10.0'}
 
   extend-shallow@2.0.1:
@@ -6626,8 +6647,8 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  html-webpack-plugin@5.6.3:
-    resolution: {integrity: sha512-QSf1yjtSAsmf7rYBV7XX86uua4W/vkhIt0xNXKbsi2foEeW7vjJQz4bhnpL3xH+l1ryl1680uNv968Z+X6jSYg==}
+  html-webpack-plugin@5.6.0:
+    resolution: {integrity: sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -6662,8 +6683,8 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
-  http-proxy-middleware@2.0.7:
-    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
+  http-proxy-middleware@2.0.6:
+    resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -7520,8 +7541,8 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  mini-css-extract-plugin@2.9.2:
-    resolution: {integrity: sha512-GJuACcS//jtq4kCtd5ii/M0SZf7OZRH+BxdqXZHaJfb8TJiVl+NgQRPwiYt2EuqeSkNydn/7vP+bcE27C5mb9w==}
+  mini-css-extract-plugin@2.9.1:
+    resolution: {integrity: sha512-+Vyi+GCCOHnrJ2VPS+6aPoXN2k2jgUzDRhTFLjjTBn23qyXJXkjUWQgTL+mXpF5/A8ixLdCc6kWsoeOjKGejKQ==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
@@ -7660,10 +7681,6 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
-    engines: {node: '>= 0.6'}
-
-  negotiator@0.6.4:
-    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -7833,6 +7850,9 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  oniguruma-to-es@0.4.1:
+    resolution: {integrity: sha512-rNcEohFz095QKGRovP/yqPIKc+nP+Sjs4YTHMv33nMePGKrq/r2eu9Yh4646M5XluGJsUnmwoXuiXE69KDs+fQ==}
 
   oniguruma-to-js@0.4.3:
     resolution: {integrity: sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==}
@@ -8730,8 +8750,17 @@ packages:
   regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
 
+  regex-recursion@4.2.1:
+    resolution: {integrity: sha512-QHNZyZAeKdndD1G3bKAbBEKOSSK4KOHQrAJ01N1LJeb0SoH4DJIeFhp0uUpETgONifS4+P3sOgoA1dhzgrQvhA==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
   regex@4.4.0:
     resolution: {integrity: sha512-uCUSuobNVeqUupowbdZub6ggI5/JZkYyJdDogddJr60L764oxC2pMZov1fQ3wM9bdyzUILDG+Sqx6NAKAz9rKQ==}
+
+  regex@5.0.1:
+    resolution: {integrity: sha512-gIS00E8eHNWONxofNKOhtlkwBQj/K39ZJamnvMEFH3pNKc06Zz2jtFXF/4ldAaJTzQNhMJU7b5+C7tTq2ukV7Q==}
 
   regexp-ast-analysis@0.7.1:
     resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
@@ -8740,6 +8769,10 @@ packages:
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
+
+  regexpu-core@5.3.2:
+    resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
+    engines: {node: '>=4'}
 
   regexpu-core@6.1.1:
     resolution: {integrity: sha512-k67Nb9jvwJcJmVpw0jPttR1/zVfnKf8Km0IPatrU/zJ5XeG3+Slx0xLXs9HByJSzXzrlz5EDvN6yLNMDc2qdnw==}
@@ -8754,6 +8787,10 @@ packages:
 
   regjsparser@0.11.2:
     resolution: {integrity: sha512-3OGZZ4HoLJkkAZx/48mTXJNlmqTGOzc0o9OWQPuWpkOlXXPbyN6OafCcoXUnBqE2D3f/T5L+pWc1kdEmnfnRsA==}
+    hasBin: true
+
+  regjsparser@0.9.1:
+    resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
     hasBin: true
 
   rehype-parse@9.0.1:
@@ -8988,8 +9025,8 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
-  set-cookie-parser@2.7.1:
-    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+  set-cookie-parser@2.7.0:
+    resolution: {integrity: sha512-lXLOiqpkUumhRdFF3k1osNXCy9akgx/dyPZ5p8qAg9seJzXr5ZrlqZuWIMuY6ejOsVLE6flJ5/h3lsn57fQ/PQ==}
 
   setprototypeof@1.1.0:
     resolution: {integrity: sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==}
@@ -9900,8 +9937,8 @@ packages:
       vue-tsc:
         optional: true
 
-  vite-plugin-inspect@0.8.7:
-    resolution: {integrity: sha512-/XXou3MVc13A5O9/2Nd6xczjrUwt7ZyI9h8pTnUMkr5SshLcb0PJUOVq2V+XVkdeU4njsqAtmK87THZuO2coGA==}
+  vite-plugin-inspect@0.8.8:
+    resolution: {integrity: sha512-aZlBuXsWUPJFmMK92GIv6lH7LrwG2POu4KJ+aEdcqnu92OAf+rhBnfMDQvxIJPEB7hE2t5EyY/PMgf5aDLT8EA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@nuxt/kit': '*'
@@ -10753,6 +10790,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-regexp-features-plugin@7.25.2(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.25.9
+      regexpu-core: 5.3.2
+      semver: 6.3.1
+
   '@babel/helper-create-regexp-features-plugin@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
@@ -10949,7 +10993,7 @@ snapshots:
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.25.9(@babel/core@7.26.0)
+      '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-arrow-functions@7.25.9(@babel/core@7.26.0)':
@@ -11235,7 +11279,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-transform-runtime@7.25.9(@babel/core@7.26.0)':
+  '@babel/plugin-transform-runtime@7.25.4(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-module-imports': 7.25.9
@@ -11402,6 +11446,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/regjsgen@0.8.0': {}
+
   '@babel/runtime@7.26.0':
     dependencies:
       regenerator-runtime: 0.14.1
@@ -11446,14 +11492,14 @@ snapshots:
     dependencies:
       mime: 3.0.0
 
-  '@codemirror/autocomplete@6.18.2(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)':
+  '@codemirror/autocomplete@6.18.1(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)':
     dependencies:
       '@codemirror/language': 6.10.3
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.34.1
       '@lezer/common': 1.2.3
 
-  '@codemirror/commands@6.7.1':
+  '@codemirror/commands@6.6.2':
     dependencies:
       '@codemirror/language': 6.10.3
       '@codemirror/state': 6.4.1
@@ -11462,7 +11508,7 @@ snapshots:
 
   '@codemirror/lang-css@6.3.0(@codemirror/view@6.34.1)':
     dependencies:
-      '@codemirror/autocomplete': 6.18.2(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
+      '@codemirror/autocomplete': 6.18.1(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
       '@codemirror/language': 6.10.3
       '@codemirror/state': 6.4.1
       '@lezer/common': 1.2.3
@@ -11472,7 +11518,7 @@ snapshots:
 
   '@codemirror/lang-html@6.4.9':
     dependencies:
-      '@codemirror/autocomplete': 6.18.2(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
+      '@codemirror/autocomplete': 6.18.1(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
       '@codemirror/lang-css': 6.3.0(@codemirror/view@6.34.1)
       '@codemirror/lang-javascript': 6.2.2
       '@codemirror/language': 6.10.3
@@ -11484,17 +11530,17 @@ snapshots:
 
   '@codemirror/lang-javascript@6.2.2':
     dependencies:
-      '@codemirror/autocomplete': 6.18.2(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
+      '@codemirror/autocomplete': 6.18.1(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
       '@codemirror/language': 6.10.3
       '@codemirror/lint': 6.8.2
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.34.1
       '@lezer/common': 1.2.3
-      '@lezer/javascript': 1.4.19
+      '@lezer/javascript': 1.4.18
 
   '@codemirror/lang-xml@6.1.0':
     dependencies:
-      '@codemirror/autocomplete': 6.18.2(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
+      '@codemirror/autocomplete': 6.18.1(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
       '@codemirror/language': 6.10.3
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.34.1
@@ -11516,7 +11562,7 @@ snapshots:
       '@codemirror/view': 6.34.1
       crelt: 1.0.6
 
-  '@codemirror/search@6.5.7':
+  '@codemirror/search@6.5.6':
     dependencies:
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.34.1
@@ -12160,7 +12206,7 @@ snapshots:
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
 
-  '@lezer/javascript@1.4.19':
+  '@lezer/javascript@1.4.18':
     dependencies:
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
@@ -12208,7 +12254,7 @@ snapshots:
   '@mswjs/cookies@0.2.2':
     dependencies:
       '@types/set-cookie-parser': 2.4.10
-      set-cookie-parser: 2.7.1
+      set-cookie-parser: 2.7.0
 
   '@mswjs/interceptors@0.17.10':
     dependencies:
@@ -12339,7 +12385,7 @@ snapshots:
       tinyglobby: 0.2.10
       unimport: 3.13.1(rollup@4.24.3)(webpack-sources@3.2.3)
       vite: 5.4.10(@types/node@22.8.7)(terser@5.36.0)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.3)(webpack-sources@3.2.3))(rollup@4.24.3)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))
+      vite-plugin-inspect: 0.8.8(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.3)(webpack-sources@3.2.3))(rollup@4.24.3)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))
       vite-plugin-vue-inspector: 5.1.3(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))
       which: 3.0.1
       ws: 8.18.0
@@ -12736,15 +12782,35 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.3
 
+  '@shikijs/core@1.23.1':
+    dependencies:
+      '@shikijs/engine-javascript': 1.23.1
+      '@shikijs/engine-oniguruma': 1.23.1
+      '@shikijs/types': 1.23.1
+      '@shikijs/vscode-textmate': 9.3.0
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.3
+
   '@shikijs/engine-javascript@1.22.2':
     dependencies:
       '@shikijs/types': 1.22.2
       '@shikijs/vscode-textmate': 9.3.0
       oniguruma-to-js: 0.4.3
 
+  '@shikijs/engine-javascript@1.23.1':
+    dependencies:
+      '@shikijs/types': 1.23.1
+      '@shikijs/vscode-textmate': 9.3.0
+      oniguruma-to-es: 0.4.1
+
   '@shikijs/engine-oniguruma@1.22.2':
     dependencies:
       '@shikijs/types': 1.22.2
+      '@shikijs/vscode-textmate': 9.3.0
+
+  '@shikijs/engine-oniguruma@1.23.1':
+    dependencies:
+      '@shikijs/types': 1.23.1
       '@shikijs/vscode-textmate': 9.3.0
 
   '@shikijs/markdown-it@1.22.2':
@@ -12756,10 +12822,10 @@ snapshots:
     dependencies:
       shiki: 1.22.2
 
-  '@shikijs/twoslash@1.22.2(typescript@5.6.3)':
+  '@shikijs/twoslash@1.23.1(typescript@5.6.3)':
     dependencies:
-      '@shikijs/core': 1.22.2
-      '@shikijs/types': 1.22.2
+      '@shikijs/core': 1.23.1
+      '@shikijs/types': 1.23.1
       twoslash: 0.2.12(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
@@ -12770,9 +12836,14 @@ snapshots:
       '@shikijs/vscode-textmate': 9.3.0
       '@types/hast': 3.0.4
 
+  '@shikijs/types@1.23.1':
+    dependencies:
+      '@shikijs/vscode-textmate': 9.3.0
+      '@types/hast': 3.0.4
+
   '@shikijs/vitepress-twoslash@1.22.2(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.3)(webpack-sources@3.2.3))(typescript@5.6.3)':
     dependencies:
-      '@shikijs/twoslash': 1.22.2(typescript@5.6.3)
+      '@shikijs/twoslash': 1.23.1(typescript@5.6.3)
       floating-vue: 5.2.2(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.3)(webpack-sources@3.2.3))(vue@3.5.12(typescript@5.6.3))
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.0.0
@@ -12834,13 +12905,13 @@ snapshots:
       magic-string: 0.30.12
       mrmime: 2.0.0
       sade: 1.8.1
-      set-cookie-parser: 2.7.1
+      set-cookie-parser: 2.7.0
       sirv: 3.0.0
       svelte: 4.2.19
       tiny-glob: 0.2.9
       vite: 5.4.10(@types/node@22.8.7)(terser@5.36.0)
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))
       debug: 4.3.7(supports-color@9.4.0)
@@ -12851,7 +12922,7 @@ snapshots:
 
   '@sveltejs/vite-plugin-svelte@4.0.0(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))
       debug: 4.3.7(supports-color@9.4.0)
       deepmerge: 4.3.1
       kleur: 4.1.5
@@ -12896,7 +12967,7 @@ snapshots:
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
-      '@types/express-serve-static-core': 5.0.1
+      '@types/express-serve-static-core': 4.19.6
       '@types/node': 22.8.7
 
   '@types/connect@3.4.38':
@@ -12926,13 +12997,6 @@ snapshots:
   '@types/estree@1.0.6': {}
 
   '@types/express-serve-static-core@4.19.6':
-    dependencies:
-      '@types/node': 22.8.7
-      '@types/qs': 6.9.16
-      '@types/range-parser': 1.2.7
-      '@types/send': 0.17.4
-
-  '@types/express-serve-static-core@5.0.1':
     dependencies:
       '@types/node': 22.8.7
       '@types/qs': 6.9.16
@@ -13205,8 +13269,8 @@ snapshots:
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.11
       '@rollup/pluginutils': 4.2.1
-      acorn: 8.12.1
-      acorn-import-attributes: 1.9.5(acorn@8.12.1)
+      acorn: 8.14.0
+      acorn-import-attributes: 1.9.5(acorn@8.14.0)
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
@@ -13381,7 +13445,7 @@ snapshots:
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.0)
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-transform-runtime': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-runtime': 7.25.4(@babel/core@7.26.0)
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.26.0
       '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.26.0)
@@ -13517,12 +13581,12 @@ snapshots:
       fs-extra: 9.1.0
       globby: 11.1.0
       hash-sum: 2.0.0
-      html-webpack-plugin: 5.6.3(webpack@5.96.1(esbuild@0.23.1))
+      html-webpack-plugin: 5.6.0(webpack@5.96.1(esbuild@0.23.1))
       is-file-esm: 1.0.0
       launch-editor-middleware: 2.9.1
       lodash.defaultsdeep: 4.6.1
       lodash.mapvalues: 4.6.0
-      mini-css-extract-plugin: 2.9.2(webpack@5.96.1(esbuild@0.23.1))
+      mini-css-extract-plugin: 2.9.1(webpack@5.96.1(esbuild@0.23.1))
       minimist: 1.2.8
       module-alias: 2.2.3
       portfinder: 1.0.32
@@ -13749,7 +13813,7 @@ snapshots:
 
   '@vue/devtools-core@7.4.4(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0))(vue@3.5.12(typescript@5.6.3))':
     dependencies:
-      '@vue/devtools-kit': 7.4.4
+      '@vue/devtools-kit': 7.6.2
       '@vue/devtools-shared': 7.6.2
       mitt: 3.0.1
       nanoid: 3.3.7
@@ -13994,9 +14058,9 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-import-attributes@1.9.5(acorn@8.12.1):
+  acorn-import-attributes@1.9.5(acorn@8.14.0):
     dependencies:
-      acorn: 8.12.1
+      acorn: 8.14.0
 
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
@@ -14460,6 +14524,8 @@ snapshots:
       esbuild: 0.24.0
       load-tsconfig: 0.2.5
 
+  bytes@3.0.0: {}
+
   bytes@3.1.2: {}
 
   c12@1.11.2(magicast@0.3.5):
@@ -14689,11 +14755,11 @@ snapshots:
 
   codemirror@6.0.1(@lezer/common@1.2.3):
     dependencies:
-      '@codemirror/autocomplete': 6.18.2(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
-      '@codemirror/commands': 6.7.1
+      '@codemirror/autocomplete': 6.18.1(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
+      '@codemirror/commands': 6.6.2
       '@codemirror/language': 6.10.3
       '@codemirror/lint': 6.8.2
-      '@codemirror/search': 6.5.7
+      '@codemirror/search': 6.5.6
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.34.1
     transitivePeerDependencies:
@@ -14767,14 +14833,14 @@ snapshots:
     dependencies:
       mime-db: 1.53.0
 
-  compression@1.7.5:
+  compression@1.7.4:
     dependencies:
-      bytes: 3.1.2
+      accepts: 1.3.8
+      bytes: 3.0.0
       compressible: 2.0.18
       debug: 2.6.9
-      negotiator: 0.6.4
       on-headers: 1.0.2
-      safe-buffer: 5.2.1
+      safe-buffer: 5.1.2
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -14817,8 +14883,6 @@ snapshots:
   cookie@0.4.2: {}
 
   cookie@0.6.0: {}
-
-  cookie@0.7.1: {}
 
   cookie@0.7.2: {}
 
@@ -15244,6 +15308,8 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.50: {}
+
+  emoji-regex-xs@1.0.0: {}
 
   emoji-regex@10.4.0: {}
 
@@ -15787,14 +15853,14 @@ snapshots:
 
   expect-type@1.1.0: {}
 
-  express@4.21.1:
+  express@4.21.0:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
       body-parser: 1.20.3
       content-disposition: 0.5.4
       content-type: 1.0.5
-      cookie: 0.7.1
+      cookie: 0.6.0
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 2.0.0
@@ -16351,7 +16417,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.96.1(esbuild@0.23.1)):
+  html-webpack-plugin@5.6.0(webpack@5.96.1(esbuild@0.23.1)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -16396,7 +16462,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.7(@types/express@4.17.21)(debug@4.3.7):
+  http-proxy-middleware@2.0.6(@types/express@4.17.21)(debug@4.3.7):
     dependencies:
       '@types/http-proxy': 1.17.15
       http-proxy: 1.18.1(debug@4.3.7)
@@ -16523,7 +16589,7 @@ snapshots:
   inquirer@8.2.6:
     dependencies:
       ansi-escapes: 4.3.2
-      chalk: 4.1.1
+      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       external-editor: 3.1.0
@@ -16963,7 +17029,7 @@ snapshots:
 
   log-symbols@4.1.0:
     dependencies:
-      chalk: 4.1.1
+      chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
   log-symbols@6.0.0:
@@ -17419,7 +17485,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.96.1(esbuild@0.23.1)):
+  mini-css-extract-plugin@2.9.1(webpack@5.96.1(esbuild@0.23.1)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
@@ -17558,8 +17624,6 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
-
-  negotiator@0.6.4: {}
 
   neo-async@2.6.2: {}
 
@@ -17899,6 +17963,12 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  oniguruma-to-es@0.4.1:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 5.0.1
+      regex-recursion: 4.2.1
+
   oniguruma-to-js@0.4.3:
     dependencies:
       regex: 4.4.0
@@ -17942,7 +18012,7 @@ snapshots:
   ora@5.4.1:
     dependencies:
       bl: 4.1.0
-      chalk: 4.1.1
+      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.9.2
       is-interactive: 1.0.0
@@ -18801,7 +18871,15 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.0
 
+  regex-recursion@4.2.1:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
   regex@4.4.0: {}
+
+  regex@5.0.1: {}
 
   regexp-ast-analysis@0.7.1:
     dependencies:
@@ -18809,6 +18887,15 @@ snapshots:
       refa: 0.12.1
 
   regexp-tree@0.1.27: {}
+
+  regexpu-core@5.3.2:
+    dependencies:
+      '@babel/regjsgen': 0.8.0
+      regenerate: 1.4.2
+      regenerate-unicode-properties: 10.2.0
+      regjsparser: 0.9.1
+      unicode-match-property-ecmascript: 2.0.0
+      unicode-match-property-value-ecmascript: 2.2.0
 
   regexpu-core@6.1.1:
     dependencies:
@@ -18828,6 +18915,10 @@ snapshots:
   regjsparser@0.11.2:
     dependencies:
       jsesc: 3.0.2
+
+  regjsparser@0.9.1:
+    dependencies:
+      jsesc: 0.5.0
 
   rehype-parse@9.0.1:
     dependencies:
@@ -19145,7 +19236,7 @@ snapshots:
 
   set-blocking@2.0.0: {}
 
-  set-cookie-parser@2.7.1: {}
+  set-cookie-parser@2.7.0: {}
 
   setprototypeof@1.1.0: {}
 
@@ -19885,7 +19976,7 @@ snapshots:
 
   unctx@2.3.1(webpack-sources@3.2.3):
     dependencies:
-      acorn: 8.12.1
+      acorn: 8.14.0
       estree-walker: 3.0.3
       magic-string: 0.30.12
       unplugin: 1.15.0(webpack-sources@3.2.3)
@@ -20222,7 +20313,7 @@ snapshots:
       optionator: 0.9.4
       typescript: 5.6.3
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.3)(webpack-sources@3.2.3))(rollup@4.24.3)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0)):
+  vite-plugin-inspect@0.8.8(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.3)(webpack-sources@3.2.3))(rollup@4.24.3)(vite@5.4.10(@types/node@22.8.7)(terser@5.36.0)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.3(rollup@4.24.3)
@@ -20232,7 +20323,7 @@ snapshots:
       open: 10.1.0
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
-      sirv: 2.0.4
+      sirv: 3.0.0
       vite: 5.4.10(@types/node@22.8.7)(terser@5.36.0)
     optionalDependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.24.3)(webpack-sources@3.2.3)
@@ -20649,13 +20740,13 @@ snapshots:
       bonjour-service: 1.2.1
       chokidar: 3.6.0
       colorette: 2.0.20
-      compression: 1.7.5
+      compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.21.1
+      express: 4.21.0
       graceful-fs: 4.2.11
       html-entities: 2.5.2
-      http-proxy-middleware: 2.0.7(@types/express@4.17.21)(debug@4.3.7)
+      http-proxy-middleware: 2.0.6(@types/express@4.17.21)(debug@4.3.7)
       ipaddr.js: 2.2.0
       launch-editor: 2.9.1
       open: 8.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -138,7 +138,7 @@ catalog:
   unplugin-vue-components: ^0.27.4
   unplugin-vue-markdown: ^0.26.2
   vite: ^5.4.10
-  vite-plugin-inspect: ^0.8.7
+  vite-plugin-inspect: ^0.8.8
   vite-plugin-pages: ^0.32.3
   vite-plugin-windicss: ^1.9.3
   vitepress: ^1.5.0

--- a/test/assets/output/preset-web-fonts-local.css
+++ b/test/assets/output/preset-web-fonts-local.css
@@ -6,8 +6,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-f57e826d.woff2) format('woff2');
-  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  src: url(/__base__/fonts/firamono-944bfd46.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
 @font-face {
@@ -15,7 +15,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-48fc2728.woff2) format('woff2');
+  src: url(/__base__/fonts/firamono-6b624095.woff2) format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -24,7 +24,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-af6ea395.woff2) format('woff2');
+  src: url(/__base__/fonts/firamono-6075b455.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -33,7 +33,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-b3de9a4b.woff2) format('woff2');
+  src: url(/__base__/fonts/firamono-56c7a302.woff2) format('woff2');
   unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
 }
 /* latin-ext */
@@ -42,8 +42,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-0e0b8fd0.woff2) format('woff2');
-  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  src: url(/__base__/fonts/firamono-a7b8bdbc.woff2) format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
 @font-face {
@@ -51,8 +51,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-fc358b7b.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  src: url(/__base__/fonts/firamono-4455d5ca.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* latin-ext */
 @font-face {
@@ -60,8 +60,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/lato-39645429.woff2) format('woff2');
-  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  src: url(/__base__/fonts/lato-60fdf8b6.woff2) format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
 @font-face {
@@ -69,8 +69,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/lato-61972548.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  src: url(/__base__/fonts/lato-0d740737.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* layer: default */

--- a/test/assets/output/preset-web-fonts-local.css
+++ b/test/assets/output/preset-web-fonts-local.css
@@ -6,8 +6,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-944bfd46.woff2) format('woff2');
-  unicode-range: U+0460-052F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  src: url(/__base__/fonts/firamono-f57e826d.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
 @font-face {
@@ -15,7 +15,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-6b624095.woff2) format('woff2');
+  src: url(/__base__/fonts/firamono-48fc2728.woff2) format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -24,7 +24,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-6075b455.woff2) format('woff2');
+  src: url(/__base__/fonts/firamono-af6ea395.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -33,7 +33,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-56c7a302.woff2) format('woff2');
+  src: url(/__base__/fonts/firamono-b3de9a4b.woff2) format('woff2');
   unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
 }
 /* latin-ext */
@@ -42,8 +42,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-a7b8bdbc.woff2) format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  src: url(/__base__/fonts/firamono-0e0b8fd0.woff2) format('woff2');
+  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
 @font-face {
@@ -51,8 +51,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/firamono-4455d5ca.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  src: url(/__base__/fonts/firamono-fc358b7b.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* latin-ext */
 @font-face {
@@ -60,8 +60,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/lato-60fdf8b6.woff2) format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  src: url(/__base__/fonts/lato-39645429.woff2) format('woff2');
+  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
 @font-face {
@@ -69,8 +69,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(/__base__/fonts/lato-0d740737.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  src: url(/__base__/fonts/lato-61972548.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* layer: default */

--- a/test/emojis.test.ts
+++ b/test/emojis.test.ts
@@ -2,7 +2,7 @@ import { createGenerator } from '@unocss/core'
 import presetAttributify from '@unocss/preset-attributify'
 import { describe, expect, it } from 'vitest'
 
-describe('emojis', () => {
+describe('emojis', async () => {
   const fixture1 = `
     <button 
     🦉 class="🦉" 🦉="1" 🥝-2 type="button"
@@ -10,7 +10,7 @@ describe('emojis', () => {
     Button
     </button>
   `
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetAttributify({ strict: true }),
     ],

--- a/test/eslint-plugin-worker.test.ts
+++ b/test/eslint-plugin-worker.test.ts
@@ -6,7 +6,7 @@ import { runAsync, setGenerator } from '../packages/eslint-plugin/src/worker'
 
 describe('worker', () => {
   it('blocklist', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -26,7 +26,7 @@ describe('worker', () => {
     ])
   })
   it('sort', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -37,12 +37,12 @@ describe('worker', () => {
   })
 
   it('sort presetMini should be same as presetUno', async () => {
-    const uno1 = createGenerator({
+    const uno1 = await createGenerator({
       presets: [
         presetMini(),
       ],
     })
-    const uno2 = createGenerator({
+    const uno2 = await createGenerator({
       presets: [
         presetUno(),
       ],

--- a/test/pos.test.ts
+++ b/test/pos.test.ts
@@ -11,7 +11,7 @@ import { getMatchedPositionsFromCode as match } from '../packages/shared-common/
 
 describe('matched-positions', async () => {
   it('attributify', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetAttributify({ strict: true }),
         presetUno({ attributifyPseudo: true }),
@@ -56,7 +56,7 @@ describe('matched-positions', async () => {
   })
 
   it('attributify position', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetAttributify({ strict: true }),
         presetUno({ attributifyPseudo: true }),
@@ -86,7 +86,7 @@ describe('matched-positions', async () => {
   })
 
   it('css-directive', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -116,7 +116,7 @@ describe('matched-positions', async () => {
   })
 
   it('class-based', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -158,7 +158,7 @@ describe('matched-positions', async () => {
   })
 
   it('arbitrary property', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -187,7 +187,7 @@ describe('matched-positions', async () => {
   })
 
   it('variant-group', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -232,7 +232,7 @@ describe('matched-positions', async () => {
   })
 
   it('colon highlighting #2460', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -251,7 +251,7 @@ describe('matched-positions', async () => {
   })
 
   it('with include and exclude', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
       ],
@@ -360,7 +360,7 @@ let transition = 'ease-in-out duration-300'
   })
 
   it('with include and exclude in attributify', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
         presetAttributify(),
@@ -437,7 +437,7 @@ describe('matched-positions-pug', async () => {
 </template>`, 'App.vue')
   }
 
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetUno(),
       presetAttributify({ strict: true }),
@@ -524,7 +524,7 @@ describe('matched-positions-pug', async () => {
   })
 
   it('attributify `><`', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetAttributify(),
         presetUno(),

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -4,7 +4,7 @@ import presetUno from '@unocss/preset-uno'
 import { describe, expect, it } from 'vitest'
 
 describe('attributify', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetAttributify({ strict: true }),
       presetUno({ attributifyPseudo: true }),
@@ -68,7 +68,7 @@ describe('attributify', async () => {
   })
 
   it('prefixedOnly', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetAttributify({ strict: true, prefix: 'un-', prefixedOnly: true }),
         presetUno({ attributifyPseudo: true }),
@@ -189,7 +189,7 @@ describe('attributify', async () => {
   })
 
   it('with trueToNonValued', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetAttributify({ trueToNonValued: true }),
         presetUno(),
@@ -215,7 +215,7 @@ describe('attributify', async () => {
   })
 
   it('support inline arrow functions', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetAttributify(),
         presetUno(),

--- a/test/preset-icons.test.ts
+++ b/test/preset-icons.test.ts
@@ -3,21 +3,21 @@ import presetIcons from '@unocss/preset-icons'
 import presetUno from '@unocss/preset-uno'
 import { describe, expect, it } from 'vitest'
 
-describe('preset-icons', () => {
+describe('preset-icons', async () => {
   const fixtures = [
     '<button class="i-carbon-sun dark:i-carbon-moon" />',
     '<button class="i-carbon-sun?bg dark:i-carbon-moon?bg" />',
     '<button class="i-carbon-sun?bg dark:i-carbon-moon?auto" />',
   ]
 
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetIcons(),
       presetUno(),
     ],
   })
 
-  const unoWithUnit = createGenerator({
+  const unoWithUnit = await createGenerator({
     presets: [
       presetIcons({
         unit: 'rem',
@@ -64,7 +64,7 @@ describe('preset-icons', () => {
   })
 
   it('custom the usedProps in propsProcessor', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno(),
         presetIcons({

--- a/test/preset-legacy-compat.test.ts
+++ b/test/preset-legacy-compat.test.ts
@@ -14,7 +14,7 @@ function generateUno(options: LegacyCompatOptions = {}) {
 
 describe('preset-legacy-compat', () => {
   it('with commaStyleColorFunction', async () => {
-    const uno = generateUno({
+    const uno = await generateUno({
       commaStyleColorFunction: true,
     })
 

--- a/test/preset-mini.test.ts
+++ b/test/preset-mini.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { presetMiniNonTargets, presetMiniTargets, specialPresetMiniTargets } from './assets/preset-mini-targets'
 import { presetWindTargets } from './assets/preset-wind-targets'
 
-const uno = createGenerator({
+const uno = await createGenerator({
   presets: [
     presetMini({
       dark: 'media',
@@ -36,7 +36,7 @@ const uno = createGenerator({
 
 describe('preset-mini', () => {
   it('dark customizing selector', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini({
           dark: {
@@ -112,7 +112,7 @@ describe('preset-mini', () => {
   })
 
   it('custom var prefix', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini({
           variablePrefix: 'hi-',
@@ -130,7 +130,7 @@ describe('preset-mini', () => {
   })
 
   it('empty prefix', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini({
           variablePrefix: '',
@@ -178,7 +178,7 @@ describe('preset-mini', () => {
   })
 
   it('fontSize theme', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -205,7 +205,7 @@ describe('preset-mini', () => {
   })
 
   it('fontWeight theme', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -228,7 +228,7 @@ describe('preset-mini', () => {
   })
 
   it('dark class', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -245,7 +245,7 @@ describe('preset-mini', () => {
   })
 
   it('the :active pseudo is sorted and separated after other pseudo', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -263,7 +263,7 @@ describe('preset-mini', () => {
   })
 
   it('css variable with `{` `}` will not generate css ', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -280,7 +280,7 @@ describe('preset-mini', () => {
   })
 
   it('define breakpoints with other unit', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -318,7 +318,7 @@ describe('preset-mini', () => {
   })
 
   it('theme for zIndex', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -337,7 +337,7 @@ describe('preset-mini', () => {
   })
 
   it('theme font-size with letter-space', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -365,7 +365,7 @@ describe('preset-mini', () => {
   })
 
   it('override colors differently', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -392,7 +392,7 @@ describe('preset-mini', () => {
   })
 
   it('account custom color for shadow theme', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -423,7 +423,7 @@ describe('preset-mini', () => {
   })
 
   it('support new color notation using css variables for compatibility', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],
@@ -462,7 +462,7 @@ describe('preset-mini', () => {
   })
 
   it('`containers` key of theme', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
       ],

--- a/test/preset-prefixes.test.ts
+++ b/test/preset-prefixes.test.ts
@@ -10,7 +10,7 @@ const targets = [
 ]
 
 it('options properties does not override each other', async () => {
-  const uno1 = createGenerator({
+  const uno1 = await createGenerator({
     presets: [
       presetAttributify({ prefix: 'uno-' }),
       presetUno(),
@@ -22,7 +22,7 @@ it('options properties does not override each other', async () => {
 
   expect(css1).toMatchFileSnapshot('./assets/output/preset-prefixes-1.css')
 
-  const uno2 = createGenerator({
+  const uno2 = await createGenerator({
     presets: [
       presetIcons({ prefix: 'icon-' }),
       presetUno(),

--- a/test/preset-rem-to-px.test.ts
+++ b/test/preset-rem-to-px.test.ts
@@ -3,8 +3,8 @@ import presetMini from '@unocss/preset-mini'
 import presetRemToPx from '@unocss/preset-rem-to-px'
 import { describe, expect, it } from 'vitest'
 
-describe('rem-to-px', () => {
-  const uno = createGenerator({
+describe('rem-to-px', async () => {
+  const uno = await createGenerator({
     presets: [
       presetMini(),
       presetRemToPx(),

--- a/test/preset-tagify.test.ts
+++ b/test/preset-tagify.test.ts
@@ -25,7 +25,7 @@ describe('tagify', () => {
   })
 
   it('preset', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       shortcuts: [
         ['btn', 'px-4 py-1 rounded inline-block bg-teal-600 text-white cursor-pointer hover:bg-teal-700 disabled:cursor-default disabled:bg-gray-600 disabled:opacity-50'],
       ],
@@ -68,7 +68,7 @@ describe('tagify', () => {
   })
 
   it('exclude tags', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
         presetTagify({
@@ -95,7 +95,7 @@ describe('tagify', () => {
   })
 
   it('extraProperties', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetIcons(),
         presetTagify({
@@ -113,7 +113,7 @@ describe('tagify', () => {
   })
 
   it('prefix', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
         presetTagify({

--- a/test/preset-typography.test.ts
+++ b/test/preset-typography.test.ts
@@ -127,7 +127,7 @@ const testConfigs: {
 describe('typography', () => {
   for (const tc of testConfigs) {
     it(tc.name, async () => {
-      const generator = createGenerator({
+      const generator = await createGenerator({
         presets: [
           presetAttributify(tc.attributifyOptions),
           presetUno({ preflight: false }),

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -3,7 +3,7 @@ import presetUno from '@unocss/preset-uno'
 import { expect, it } from 'vitest'
 import { nonTargets, targets, targets2 } from './assets/preset-uno-targets'
 
-const uno = createGenerator({
+const uno = await createGenerator({
   presets: [
     presetUno({
       dark: 'media',
@@ -57,7 +57,7 @@ it('non-targets', async () => {
 })
 
 it('custom var prefix', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetUno({
         variablePrefix: 'hi-',
@@ -75,7 +75,7 @@ it('custom var prefix', async () => {
 })
 
 it('empty prefix', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetUno({
         variablePrefix: '',
@@ -93,7 +93,7 @@ it('empty prefix', async () => {
 })
 
 it('define breakpoints with irregular sorting', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetUno(),
     ],

--- a/test/preset-web-fonts.test.ts
+++ b/test/preset-web-fonts.test.ts
@@ -34,7 +34,7 @@ const classes = new Set([
 ])
 
 it('web-fonts (inline: false)', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetMini(),
       presetWebFonts({
@@ -49,7 +49,7 @@ it('web-fonts (inline: false)', async () => {
 })
 
 it('web-fonts (inline: true)', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetMini(),
       presetWebFonts({
@@ -64,7 +64,7 @@ it('web-fonts (inline: true)', async () => {
 })
 
 it('web-fonts weight sort', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetMini(),
       presetWebFonts({
@@ -90,7 +90,7 @@ it('web-fonts weight sort', async () => {
 })
 
 it('web-fonts weight deduplicate', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetMini(),
       presetWebFonts({
@@ -116,7 +116,7 @@ it('web-fonts weight deduplicate', async () => {
 })
 
 it('createLocalFontProcessor', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetMini(),
       presetWebFonts({
@@ -155,7 +155,7 @@ describe('fontsource provider', async () => {
   }
 
   it.each(Object.entries(fontMap))('%s', async (_, fonts) => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
         presetWebFonts({
@@ -174,7 +174,7 @@ describe('fontsource provider', async () => {
   })
 
   it('custom wght', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
         presetWebFonts({
@@ -199,7 +199,7 @@ describe('fontsource provider', async () => {
   })
 
   it('custom variable', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetMini(),
         presetWebFonts({

--- a/test/preset-wind.test.ts
+++ b/test/preset-wind.test.ts
@@ -3,7 +3,7 @@ import presetWind from '@unocss/preset-wind'
 import { describe, expect, it } from 'vitest'
 import { presetWindNonTargets, presetWindTargets } from './assets/preset-wind-targets'
 
-const uno = createGenerator({
+const uno = await createGenerator({
   presets: [
     presetWind({
       dark: 'media',
@@ -71,7 +71,7 @@ describe('preset-wind', () => {
   })
 
   it('centered containers', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetWind(),
       ],
@@ -94,7 +94,7 @@ describe('preset-wind', () => {
   })
 
   it('containers with max width', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetWind(),
       ],
@@ -124,7 +124,7 @@ describe('preset-wind', () => {
   })
 
   it('custom var prefix', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetWind({
           variablePrefix: 'hi-',
@@ -143,7 +143,7 @@ describe('preset-wind', () => {
 
   describe('important', () => {
     it(`should add " !important" at the end when "true" unless it's already marked important`, async () => {
-      const uno = createGenerator({
+      const uno = await createGenerator({
         presets: [
           presetWind({
             important: true,
@@ -162,7 +162,7 @@ describe('preset-wind', () => {
     })
 
     it(`should prefix selector with provided important string and wrap the original selector in ":is()"`, async () => {
-      const uno = createGenerator({
+      const uno = await createGenerator({
         presets: [
           presetWind({
             important: '#app',
@@ -185,7 +185,7 @@ describe('preset-wind', () => {
 })
 
 it('empty prefix', async () => {
-  const uno = createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetWind({
         variablePrefix: '',

--- a/test/transformer-attributify-jsx.test.ts
+++ b/test/transformer-attributify-jsx.test.ts
@@ -63,8 +63,8 @@ const tagCouldBeAttrCode = `
 </div>
 `.trim()
 
-describe('transformerAttributifyJsx', () => {
-  const uno = createGenerator({
+describe('transformerAttributifyJsx', async () => {
+  const uno = await createGenerator({
     presets: [
       presetUno(),
       presetAttributify(),
@@ -286,8 +286,8 @@ describe('transformerAttributifyJsx', () => {
   })
 })
 
-describe('transformerAttributifyJsxBabel', () => {
-  const uno = createGenerator({
+describe('transformerAttributifyJsxBabel', async () => {
+  const uno = await createGenerator({
     presets: [
       presetUno(),
       presetAttributify(),

--- a/test/transformer-compile-class.test.ts
+++ b/test/transformer-compile-class.test.ts
@@ -20,7 +20,8 @@ describe('transformer-compile-class', () => {
     })
   }
 
-  async function transform(code: string, uno: UnoGenerator = createUno(), invalidate = () => 0) {
+  async function transform(code: string, uno?: UnoGenerator, invalidate = () => 0) {
+    uno ||= await createUno()
     const s = new MagicString(code)
     invalidate = invalidate || vi.fn()
 
@@ -76,7 +77,7 @@ describe('transformer-compile-class', () => {
   it('custom class name trigger (without class name)', async () => {
     const result = await transform(
       '<div class=":custom: bg-red-500 text-xl">'.trim(),
-      createUno({ trigger: CUSTOM_TRIGGER }),
+      await createUno({ trigger: CUSTOM_TRIGGER }),
     )
 
     expect(result.code.trim()).toMatchInlineSnapshot(`"<div class="uno-trmz0g">"`)
@@ -90,7 +91,7 @@ describe('transformer-compile-class', () => {
   it('custom class name trigger (with basic class name)', async () => {
     const result = await transform(
       '<div class=":custom-foo: bg-red-500 text-xl">'.trim(),
-      createUno({
+      await createUno({
         trigger: CUSTOM_TRIGGER,
         classPrefix: 'something-',
       }),
@@ -107,7 +108,7 @@ describe('transformer-compile-class', () => {
   it('custom class name trigger (with complex class name)', async () => {
     const result = await transform(
       '<div class=":custom-foo_bar-baz: bg-red-500 text-xl">'.trim(),
-      createUno({ trigger: CUSTOM_TRIGGER }),
+      await createUno({ trigger: CUSTOM_TRIGGER }),
     )
 
     expect(result.code.trim()).toMatchInlineSnapshot(`"<div class="uno-foo_bar-baz">"`)
@@ -160,7 +161,7 @@ describe('transformer-compile-class', () => {
 
   it('css should be updated exact times when compiled class changes', async () => {
     const invalidateFn = vi.fn()
-    const uno = createUno()
+    const uno = await createUno()
 
     await transform(`
     <div class=":uno: w-1 h-1"/>

--- a/test/transformer-directives.test.ts
+++ b/test/transformer-directives.test.ts
@@ -10,8 +10,8 @@ import prettier from 'prettier/standalone'
 import { describe, expect, it } from 'vitest'
 import { transformDirectives } from '../packages/transformer-directives/src/transform'
 
-describe('transformer-directives', () => {
-  const uno = createGenerator({
+describe('transformer-directives', async () => {
+  const uno = await createGenerator({
     presets: [
       presetUno({
         dark: 'media',
@@ -247,7 +247,7 @@ describe('transformer-directives', () => {
   })
 
   it('dark class', async () => {
-    const uno = createGenerator({
+    const uno = await createGenerator({
       presets: [
         presetUno({
           dark: 'class',
@@ -679,8 +679,8 @@ div {
   })
 })
 
-describe('transformer-directives with important', () => {
-  const uno = createGenerator({
+describe('transformer-directives with important', async () => {
+  const uno = await createGenerator({
     presets: [
       presetUno({
         dark: 'media',
@@ -1389,7 +1389,7 @@ describe('icon directive', () => {
   }
 
   it('icon()', async () => {
-    const uno = createUno()
+    const uno = await createUno()
 
     const result = await transform(
       `.icon {
@@ -1414,7 +1414,7 @@ describe('icon directive', () => {
   })
 
   it('icon() without extra properties', async () => {
-    const uno = createUno({
+    const uno = await createUno({
       extraProperties: {
         'display': 'inline-block',
         'vertical-align': 'middle',


### PR DESCRIPTION
This is a breaking change that makes the creation of UnoGenerator async. This is a preparatory work for the future to support async presets and async configs resolution.

As class constructor does not support async, `new UnoGenerator` is deprecated in favor of the factory function `createGenerator()`.

⚠️ Breaking: `createGenerator()` now returns `Promise<UnoGenerator>` instead of `UnoGenerator`

This change should only affect programmatically usages, normal users with integrations should not be affected by this.

References:

- Projects that use `new UnoGenerator`: https://github.com/search?q=%22new+UnoGenerator%22++NOT+is%3Afork&type=code