### PR TITLE
fix(preset-icons): validate collection name before load icon svg data

### DIFF
--- a/packages/preset-icons/src/core.ts
+++ b/packages/preset-icons/src/core.ts
@@ -201,16 +201,30 @@ export async function parseIconWithLoader(body: string, loader: UniversalIconLoa
   let name = ''
   let svg: string | undefined
 
+  const allCollections = [
+    ...icons,
+    ...Object.keys(options.customCollections || {}),
+  ]
+
   if (body.includes(':')) {
     [collection, name] = body.split(':')
+
+    if (!allCollections.includes(collection))
+      return
+
     svg = await loader(collection, name, options)
   }
   else {
     const parts = body.split(/-/g)
     for (let i = COLLECTION_NAME_PARTS_MAX; i >= 1; i--) {
       collection = parts.slice(0, i).join('-')
+
+      if (!allCollections.includes(collection))
+        continue
+
       name = parts.slice(i).join('-')
       svg = await loader(collection, name, options)
+
       if (svg)
         break
     }


### PR DESCRIPTION
### Description

This PR checks if the collection name is valid before load icon SVG data.

### Context:

With class `i-foo-bar-baz`, presetIcons will try to install icon data order by order in bellow and got 3 errors.

1. `@iconify-json/foo-bar-baz`
2. `@iconify-json/foo-bar`
3. `@iconify-json/foo`

### Related issue

#2531
