### PR TITLE
docs: add css-fade preset to community.md

### DIFF
--- a/docs/presets/community.md
+++ b/docs/presets/community.md
@@ -30,6 +30,7 @@
 - [@unifydev/unify-preset](https://github.com/unify-ui-dev/unify-preset/blob/main/README.md) - Atomic Theming UI Libray Powered By UnoCSS, like DaisyUI but customizable. By [@johnkat-mj](https://github.com/Johnkat-Mj)
 - [unocss-preset-tailwindcss-motion](https://github.com/whatnickcodes/unocss-preset-tailwindcss-motion) - Ridiculously awesome animations via unoffical [Tailwind Motion](https://rombo.co/tailwind) port, by [@whatnicktweets](https://x.com/whatnicktweets)
 - [unocss-preset-magicss](https://github.com/unpreset/unocss-preset-magicss) - Integrate magic css animation preset by [@zyyv](https://github.com/zyyv)
+- [css-fade](https://www.npmjs.com/package/css-fade) - Fade out one or multiple sides of html elements using CSS mask in UnoCSS by [@dan-smt](https://github.com/dan-smt)
 
 # Community frameworks
 


### PR DESCRIPTION
More details on https://www.npmjs.com/package/css-fade 

css-fade has UnoCSS, TailwindCSS, and vanilla CSS exports which is why it doesn't have an unocss- prefix.