### PR TITLE
fix(shared-integration): defaultIdeMatchInclude regexp stuck in vscode

### DIFF
--- a/packages/shared-integration/src/defaults.ts
+++ b/packages/shared-integration/src/defaults.ts
@@ -18,7 +18,7 @@ export const defaultIdeMatchInclude: RegExp[] = [
   // eslint-disable-next-line no-control-regex
   /(['"`])[^\x01]*?\1/g,
   // HTML tags
-  /<[^/?<>0-9$_!](?:"[^"]*"|'[^']*'|[^>])+>/g,
+  /<[^/?<>0-9$_!"'](?:"[^"]*"|'[^']*'|[^>])+>/g,
   // CSS directives
   /(@apply|--uno|--at-apply)[^;]*;/g,
 ]


### PR DESCRIPTION
close: #4293

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/e706386a-9eff-4d9f-b09a-76f560920f61">
