### PR TITLE
feat(preset-icons,transformer-directives): allow add safe icons collections

### DIFF
--- a/docs/presets/icons.md
+++ b/docs/presets/icons.md
@@ -442,6 +442,13 @@ Extra CSS properties applied to the generated CSS.
 
 Emit warning when missing icons are matched.
 
+### iconifyCollectionsNames
+
+- Type: `string[]`
+- Default: `undefined`
+
+Additional `@iconify-json` collections to use. This option should be used when there are new `@iconify-json` collections not listed in the default icons preset collection names.
+
 ### collections
 
 - Type: `Record<string, (() => Awaitable<IconifyJSON>) | undefined | CustomIconLoader | InlineCollection>`

--- a/packages/preset-icons/src/core.ts
+++ b/packages/preset-icons/src/core.ts
@@ -32,7 +32,7 @@ export function createPresetIcons(lookupIconLoader: (options: IconsOptions) => P
       mode = 'auto',
       prefix = 'i-',
       warn = false,
-      safeCollectionsNames,
+      iconifyCollectionsNames,
       collections: customCollections,
       extraProperties = {},
       customizations = {},
@@ -92,7 +92,7 @@ export function createPresetIcons(lookupIconLoader: (options: IconsOptions) => P
             body,
             iconLoader,
             { ...loaderOptions, usedProps },
-            safeCollectionsNames,
+            iconifyCollectionsNames,
           )
 
           if (!parsed) {

--- a/packages/preset-icons/src/core.ts
+++ b/packages/preset-icons/src/core.ts
@@ -32,6 +32,7 @@ export function createPresetIcons(lookupIconLoader: (options: IconsOptions) => P
       mode = 'auto',
       prefix = 'i-',
       warn = false,
+      safeCollectionsNames,
       collections: customCollections,
       extraProperties = {},
       customizations = {},
@@ -87,7 +88,12 @@ export function createPresetIcons(lookupIconLoader: (options: IconsOptions) => P
           iconLoader = iconLoader || await lookupIconLoader(options)
 
           const usedProps = {}
-          const parsed = await parseIconWithLoader(body, iconLoader, { ...loaderOptions, usedProps })
+          const parsed = await parseIconWithLoader(
+            body,
+            iconLoader,
+            { ...loaderOptions, usedProps },
+            safeCollectionsNames,
+          )
 
           if (!parsed) {
             if (warn && !flags.isESLint)
@@ -196,20 +202,26 @@ export function getEnvFlags() {
   }
 }
 
-export async function parseIconWithLoader(body: string, loader: UniversalIconLoader, options: IconifyLoaderOptions = {}) {
+export async function parseIconWithLoader(
+  body: string,
+  loader: UniversalIconLoader,
+  options: IconifyLoaderOptions = {},
+  safeCollectionsNames: string[] = [],
+) {
   let collection = ''
   let name = ''
   let svg: string | undefined
 
-  const allCollections = [
+  const allCollections = new Set<string>([
     ...icons,
+    ...safeCollectionsNames,
     ...Object.keys(options.customCollections || {}),
-  ]
+  ])
 
   if (body.includes(':')) {
     [collection, name] = body.split(':')
 
-    if (!allCollections.includes(collection))
+    if (!allCollections.has(collection))
       return
 
     svg = await loader(collection, name, options)
@@ -219,7 +231,7 @@ export async function parseIconWithLoader(body: string, loader: UniversalIconLoa
     for (let i = COLLECTION_NAME_PARTS_MAX; i >= 1; i--) {
       collection = parts.slice(0, i).join('-')
 
-      if (!allCollections.includes(collection))
+      if (!allCollections.has(collection))
         continue
 
       name = parts.slice(i).join('-')

--- a/packages/preset-icons/src/types.ts
+++ b/packages/preset-icons/src/types.ts
@@ -56,7 +56,16 @@ export interface IconsOptions {
   warn?: boolean
 
   /**
-   * Safe collections to use (will be also auto installed when missing and `autoInstall` enabled).
+   * Safe `@iconify-json` collections to use (will be also auto installed when missing and `autoInstall` enabled).
+   *
+   * This should be used only when default there are new collections not listed in the default icons preset collections.
+   *
+   * Adding external collections will not work, you should use `FileSystemIconLoader` from
+   * `@iconify/utils/lib/loader/fs` or `createExternalPackageIconLoader` from
+   * `@iconify/utils/lib/loader/external-pkg` instead.
+   *
+   * @see https://unocss.dev/presets/icons#filesystemiconloader
+   * @see https://unocss.dev/presets/icons#externalpackageiconloader
    */
   safeCollectionsNames?: string[]
 

--- a/packages/preset-icons/src/types.ts
+++ b/packages/preset-icons/src/types.ts
@@ -58,7 +58,7 @@ export interface IconsOptions {
   /**
    * Safe `@iconify-json` collections to use (will be also auto installed when missing and `autoInstall` enabled).
    *
-   * This should be used only when default there are new collections not listed in the default icons preset collections.
+   * This options should be used only when there are new `@iconify-json` collections not listed in the default icons preset collection names.
    *
    * Adding external collections will not work, you should use `FileSystemIconLoader` from
    * `@iconify/utils/lib/loader/fs` or `createExternalPackageIconLoader` from

--- a/packages/preset-icons/src/types.ts
+++ b/packages/preset-icons/src/types.ts
@@ -56,6 +56,11 @@ export interface IconsOptions {
   warn?: boolean
 
   /**
+   * Safe collections to use (will be also auto installed when missing and `autoInstall` enabled).
+   */
+  safeCollectionsNames?: string[]
+
+  /**
    * In Node.js environment, the preset will search for the installed iconify dataset automatically.
    * When using in the browser, this options is provided to provide dataset with custom loading mechanism.
    */

--- a/packages/preset-icons/src/types.ts
+++ b/packages/preset-icons/src/types.ts
@@ -56,9 +56,9 @@ export interface IconsOptions {
   warn?: boolean
 
   /**
-   * Safe `@iconify-json` collections to use (will be also auto installed when missing and `autoInstall` enabled).
+   * `@iconify-json` collections to use (will be also auto installed when missing and `autoInstall` enabled).
    *
-   * This options should be used only when there are new `@iconify-json` collections not listed in the default icons preset collection names.
+   * This option should be used only when there are new `@iconify-json` collections not listed in the default icons preset collection names.
    *
    * Adding external collections will not work, you should use `FileSystemIconLoader` from
    * `@iconify/utils/lib/loader/fs` or `createExternalPackageIconLoader` from

--- a/packages/preset-icons/src/types.ts
+++ b/packages/preset-icons/src/types.ts
@@ -67,7 +67,7 @@ export interface IconsOptions {
    * @see https://unocss.dev/presets/icons#filesystemiconloader
    * @see https://unocss.dev/presets/icons#externalpackageiconloader
    */
-  safeCollectionsNames?: string[]
+  iconifyCollectionsNames?: string[]
 
   /**
    * In Node.js environment, the preset will search for the installed iconify dataset automatically.

--- a/packages/transformer-directives/src/icon.ts
+++ b/packages/transformer-directives/src/icon.ts
@@ -17,6 +17,7 @@ export async function transformIconString(uno: UnoGenerator, icon: string, color
     collections: customCollections,
     customizations = {},
     autoInstall = false,
+    safeCollectionsNames,
     collectionsNodeResolvePath,
     unit,
   } = presetIcons.options as IconsOptions
@@ -51,7 +52,12 @@ export async function transformIconString(uno: UnoGenerator, icon: string, color
   for (const p of toArray(prefix)) {
     if (icon.startsWith(p)) {
       icon = icon.slice(p.length)
-      const parsed = await api.parseIconWithLoader(icon, loader, loaderOptions)
+      const parsed = await api.parseIconWithLoader(
+        icon,
+        loader,
+        loaderOptions,
+        safeCollectionsNames,
+      )
       if (parsed)
         return `url("data:image/svg+xml;utf8,${color ? api.encodeSvgForCss(parsed.svg).replace(/currentcolor/gi, color) : api.encodeSvgForCss(parsed.svg)}")`
     }

--- a/packages/transformer-directives/src/icon.ts
+++ b/packages/transformer-directives/src/icon.ts
@@ -17,7 +17,7 @@ export async function transformIconString(uno: UnoGenerator, icon: string, color
     collections: customCollections,
     customizations = {},
     autoInstall = false,
-    safeCollectionsNames,
+    iconifyCollectionsNames,
     collectionsNodeResolvePath,
     unit,
   } = presetIcons.options as IconsOptions
@@ -56,7 +56,7 @@ export async function transformIconString(uno: UnoGenerator, icon: string, color
         icon,
         loader,
         loaderOptions,
-        safeCollectionsNames,
+        iconifyCollectionsNames,
       )
       if (parsed)
         return `url("data:image/svg+xml;utf8,${color ? api.encodeSvgForCss(parsed.svg).replace(/currentcolor/gi, color) : api.encodeSvgForCss(parsed.svg)}")`


### PR DESCRIPTION
Changes included in https://github.com/unocss/unocss/pull/4278 will prevent using/auto-installing iconify collections not listed in default collections. In that case we need to use `createExternalPackageIconLoader` from `@iconify/utils/lib/loader/external-pkg` or node `fs` loader, check https://github.com/unocss/unocss/discussions/4318#discussioncomment-11499122.

This PR adds `safeCollectionsNames` option to allow use external collections including `auto-install` support: I'll add some hint in the jsdocs since this will work only with `@iconify-json/*` collections (✔️ done).

When there are new `@iconify-json/*` collections missing in the `collections.json` file, the consumer can use this new option until we release a new version with the new iconify collections included in the json file (transient solution: instead using static import + custom icon loader the consumer can just add the new collection name to the new option).

Tested this PR on my local using https://github.com/nimiq/developer-center/tree/main (after updating UnoCSS to 0.65.1, using 0.64.0 just works without this PR).

@zyyv Feel free to close this PR since there is an option to use external packages, the user using some hack to move the `nimiq` collection under `@iconify-json/nimiq` package name (`pnpm` is adding the package inside `@iconify-json/nimiq` folder).