### PR TITLE
feat(vite): add option `checkImport`

### DIFF
--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -281,7 +281,7 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
           if (replaced)
             return
 
-          if (!(await getConfig() as VitePluginConfig).disableEntryCheck) {
+          if ((await getConfig() as VitePluginConfig).checkImport) {
             this.warn(MESSAGE_UNOCSS_ENTRY_NOT_FOUND)
           }
 

--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -19,6 +19,7 @@ import {
   resolveId,
   resolveLayer,
 } from '../../integration'
+import { MESSAGE_UNOCSS_ENTRY_NOT_FOUND } from './shared'
 
 // https://github.com/vitejs/vite/blob/main/packages/plugin-legacy/src/index.ts#L742-L744
 function isLegacyChunk(chunk: RenderedChunk, options: NormalizedOutputOptions) {
@@ -281,8 +282,7 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
             return
 
           if (!(await getConfig() as VitePluginConfig).disableEntryCheck) {
-            const msg = '[unocss] Entry module not found. Did you add `import \'uno.css\'` in your main entry?'
-            this.warn(msg)
+            this.warn(MESSAGE_UNOCSS_ENTRY_NOT_FOUND)
           }
 
           return

--- a/packages/vite/src/modes/global/build.ts
+++ b/packages/vite/src/modes/global/build.ts
@@ -279,8 +279,12 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
           // to replace on current build pipeline, we can skip the warning.
           if (replaced)
             return
-          const msg = '[unocss] Entry module not found. Did you add `import \'uno.css\'` in your main entry?'
-          this.warn(msg)
+
+          if (!(await getConfig() as VitePluginConfig).disableEntryCheck) {
+            const msg = '[unocss] Entry module not found. Did you add `import \'uno.css\'` in your main entry?'
+            this.warn(msg)
+          }
+
           return
         }
 

--- a/packages/vite/src/modes/global/dev.ts
+++ b/packages/vite/src/modes/global/dev.ts
@@ -87,7 +87,7 @@ export function GlobalModeDevPlugin(ctx: UnocssPluginContext): Plugin[] {
     if (
       !resolved
       && !resolvedWarnTimer
-      && !(await getConfig() as VitePluginConfig).disableEntryCheck
+      && (await getConfig() as VitePluginConfig).checkImport
     ) {
       resolvedWarnTimer = setTimeout(() => {
         if (process.env.TEST || process.env.NODE_ENV === 'test')

--- a/packages/vite/src/modes/global/dev.ts
+++ b/packages/vite/src/modes/global/dev.ts
@@ -5,6 +5,7 @@ import process from 'node:process'
 import { notNull } from '@unocss/core'
 import MagicString from 'magic-string'
 import { getHash, getPath, LAYER_MARK_ALL, resolveId, resolveLayer } from '../../integration'
+import { MESSAGE_UNOCSS_ENTRY_NOT_FOUND } from './shared'
 
 const WARN_TIMEOUT = 20000
 const WS_EVENT_PREFIX = 'unocss:hmr'
@@ -92,11 +93,10 @@ export function GlobalModeDevPlugin(ctx: UnocssPluginContext): Plugin[] {
         if (process.env.TEST || process.env.NODE_ENV === 'test')
           return
         if (!resolved) {
-          const msg = '[unocss] Entry module not found. Did you add `import \'uno.css\'` in your main entry?'
-          console.warn(msg)
+          console.warn(MESSAGE_UNOCSS_ENTRY_NOT_FOUND)
           servers.forEach(({ ws }) => ws.send({
             type: 'error',
-            err: { message: msg, stack: '' },
+            err: { message: MESSAGE_UNOCSS_ENTRY_NOT_FOUND, stack: '' },
           }))
         }
       }, WARN_TIMEOUT)

--- a/packages/vite/src/modes/global/shared.ts
+++ b/packages/vite/src/modes/global/shared.ts
@@ -1,1 +1,3 @@
 export const VIRTUAL_ENTRY_DEFAULT = '/__unocss_entry.css'
+
+export const MESSAGE_UNOCSS_ENTRY_NOT_FOUND = '[unocss] Entry module not found. Did you add `import \'uno.css\'` in your main entry?'

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -57,4 +57,11 @@ export interface VitePluginConfig<Theme extends object = object> extends UserCon
    * @default 'cors'
    */
   fetchMode?: 'cors' | 'navigate' | 'no-cors' | 'same-origin'
+
+  /**
+   * Disable `import 'uno.css'` existing check.
+   *
+   * @default false
+   */
+  disableEntryCheck?: boolean
 }

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -61,7 +61,7 @@ export interface VitePluginConfig<Theme extends object = object> extends UserCon
   /**
    * Disable `import 'uno.css'` existing check.
    *
-   * @default false
+   * @default true
    */
-  disableEntryCheck?: boolean
+  checkImport?: boolean
 }


### PR DESCRIPTION
This PR adds an option `checkImport` to vite plugin.

## why

Framework like [WXT](https://github.com/wxt-dev/wxt) supports dynamic entrypoints and only partial of them need style.

Using UnoCSS as a vite plugin will get the warning every time run dev and build.

It's kind of annoying.