### PR TITLE
fix(nuxt): use rootDir instead of srcDir to find the config files under the layer

### DIFF
--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -81,7 +81,7 @@ export default defineNuxtModule<UnocssNuxtOptions>({
         filename: 'uno.config.mjs',
         async getContents() {
           const configPaths = (await Promise.all(nuxt.options._layers.slice(1).map(layer =>
-            findPath(options.configFile || ['uno.config', 'unocss.config'], { cwd: layer.config.srcDir }),
+            findPath(options.configFile || ['uno.config', 'unocss.config'], { cwd: layer.config.rootDir }),
           )))
             .filter(Boolean)
             .reverse() as string[]


### PR DESCRIPTION
Because srcDir value may be modified