### PR TITLE
chore: bump node v22 for netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "docs/dist"
 command = "pnpm run deploy"
 
 [build.environment]
-NODE_VERSION = "20"
+NODE_VERSION = "22"
 NODE_OPTIONS = "--max_old_space_size=4096"
 
 [functions]


### PR DESCRIPTION
Since node version 22 is stable now, may be we may try node v22 here.