### PR TITLE
fix: use vite virtual id convention

### DIFF
--- a/virtual-shared/integration/src/layers.ts
+++ b/virtual-shared/integration/src/layers.ts
@@ -3,19 +3,17 @@ export const VIRTUAL_ENTRY_ALIAS = [
 ]
 export const LAYER_MARK_ALL = '__ALL__'
 
-export const RESOLVED_ID_WITH_QUERY_RE = /[/\\]__uno(_.*?)?\.css(\?.*)?$/
-export const RESOLVED_ID_RE = /[/\\]__uno(?:_(.*?))?\.css$/
+export const RESOLVED_ID_WITH_QUERY_RE = /\0[/\\]__uno(_.*?)?\.css(\?.*)?$/
+export const RESOLVED_ID_RE = /\0[/\\]__uno(?:_(.*?))?\.css$/
 
 export function resolveId(id: string) {
   if (id.match(RESOLVED_ID_WITH_QUERY_RE))
-    return id
+    return `\0${id}`
 
   for (const alias of VIRTUAL_ENTRY_ALIAS) {
     const match = id.match(alias)
     if (match) {
-      return match[1]
-        ? `/__uno_${match[1]}.css`
-        : '/__uno.css'
+      return `\0${match[1] ? `/__uno_${match[1]}.css` : '/__uno.css'}`
     }
   }
 }

--- a/virtual-shared/integration/src/layers.ts
+++ b/virtual-shared/integration/src/layers.ts
@@ -13,7 +13,9 @@ export function resolveId(id: string) {
   for (const alias of VIRTUAL_ENTRY_ALIAS) {
     const match = id.match(alias)
     if (match) {
-      return `\0${match[1] ? `/__uno_${match[1]}.css` : '/__uno.css'}`
+      return match[1]
+        ? `\0/__uno_${match[1]}.css`
+        : '\0/__uno.css'
     }
   }
 }


### PR DESCRIPTION
### Summary

This PR updates UnoCSS to prefix virtual `/__uno.css` files with a null byte (`\0`), aligning with Vite's conventions for virtual modules. The current implementation, which lacks the null-byte prefix, can lead to issues in downstream projects. `/__uno.css` may normalize to `/` (`C:/`), causing issues with file-watching.

### Changes

- Updated `resolveId` to prefix virtual file IDs with `\0`.
- Modified `RESOLVED_ID_WITH_QUERY_RE` and `RESOLVED_ID_RE` to handle the null-byte prefix.

### Benefits

- Resolves the issue at its source, reducing the need for downstream projects to patch or work around the problem.
- Aligns UnoCSS with Vite's virtual file conventions, improving compatibility with the Vite ecosystem.
- Most Vite-compatible projects and plugins already expect virtual files to have a `\0` prefix, ensuring compatibility in the majority of cases.

### Compatibility Considerations

While most downstream tools and plugins should already handle the `\0` prefix as part of Vite's conventions, some setups may rely only on the existing `/__uno.css` naming.

### Related Issues
 #### the `/__uno.css` path normalizes to `/`, causing the root directory `C:/` to be watched on windows systems, introducing errors.

- Resolves dcloudio/uni-app#3603  
- Resolves wxt-dev/wxt#1106
- vitejs/vite#13234
- #2829