### PR TITLE
docs: use git url in all package repository urls

### DIFF
--- a/packages-engine/autocomplete/package.json
+++ b/packages-engine/autocomplete/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-engine/autocomplete"
   },
   "bugs": {

--- a/packages-engine/cli/package.json
+++ b/packages-engine/cli/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-engine/cli"
   },
   "bugs": {

--- a/packages-engine/config/package.json
+++ b/packages-engine/config/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-engine/config"
   },
   "bugs": {

--- a/packages-engine/core/package.json
+++ b/packages-engine/core/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-engine/core"
   },
   "bugs": {

--- a/packages-integrations/astro/package.json
+++ b/packages-integrations/astro/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/astro"
   },
   "bugs": {

--- a/packages-integrations/eslint-config/package.json
+++ b/packages-integrations/eslint-config/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/eslint-config"
   },
   "bugs": {

--- a/packages-integrations/eslint-plugin/package.json
+++ b/packages-integrations/eslint-plugin/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/eslint-plugin"
   },
   "bugs": {

--- a/packages-integrations/inspector/package.json
+++ b/packages-integrations/inspector/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/inspector"
   },
   "bugs": {

--- a/packages-integrations/nuxt/package.json
+++ b/packages-integrations/nuxt/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/nuxt"
   },
   "bugs": {

--- a/packages-integrations/postcss/package.json
+++ b/packages-integrations/postcss/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/postcss"
   },
   "bugs": {

--- a/packages-integrations/runtime/package.json
+++ b/packages-integrations/runtime/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/runtime"
   },
   "bugs": {

--- a/packages-integrations/scope/package.json
+++ b/packages-integrations/scope/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/scope"
   },
   "exports": {

--- a/packages-integrations/svelte-scoped/package.json
+++ b/packages-integrations/svelte-scoped/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/svelte-scoped"
   },
   "bugs": {

--- a/packages-integrations/vite/package.json
+++ b/packages-integrations/vite/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/vite"
   },
   "bugs": {

--- a/packages-integrations/vscode/package.json
+++ b/packages-integrations/vscode/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/vscode"
   },
   "categories": [

--- a/packages-integrations/webpack/package.json
+++ b/packages-integrations/webpack/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-integrations/webpack"
   },
   "bugs": {

--- a/packages-presets/extractor-arbitrary-variants/package.json
+++ b/packages-presets/extractor-arbitrary-variants/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/extractor-arbitrary-variants"
   },
   "bugs": {

--- a/packages-presets/extractor-mdc/package.json
+++ b/packages-presets/extractor-mdc/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/extractor-mdc"
   },
   "bugs": {

--- a/packages-presets/extractor-pug/package.json
+++ b/packages-presets/extractor-pug/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/extractor-pug"
   },
   "bugs": {

--- a/packages-presets/extractor-svelte/package.json
+++ b/packages-presets/extractor-svelte/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/extractor-svelte"
   },
   "bugs": {

--- a/packages-presets/preset-attributify/package.json
+++ b/packages-presets/preset-attributify/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/preset-attributify"
   },
   "bugs": {

--- a/packages-presets/preset-icons/package.json
+++ b/packages-presets/preset-icons/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/preset-icons"
   },
   "bugs": {

--- a/packages-presets/preset-legacy-compat/package.json
+++ b/packages-presets/preset-legacy-compat/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/preset-legacy-compat"
   },
   "bugs": {

--- a/packages-presets/preset-mini/package.json
+++ b/packages-presets/preset-mini/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/preset-mini"
   },
   "bugs": {

--- a/packages-presets/preset-rem-to-px/package.json
+++ b/packages-presets/preset-rem-to-px/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/preset-rem-to-px"
   },
   "bugs": {

--- a/packages-presets/preset-tagify/package.json
+++ b/packages-presets/preset-tagify/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/preset-tagify"
   },
   "bugs": {

--- a/packages-presets/preset-typography/package.json
+++ b/packages-presets/preset-typography/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/preset-typography"
   },
   "bugs": {

--- a/packages-presets/preset-uno/package.json
+++ b/packages-presets/preset-uno/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/preset-uno"
   },
   "bugs": {

--- a/packages-presets/preset-web-fonts/package.json
+++ b/packages-presets/preset-web-fonts/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/preset-web-fonts"
   },
   "bugs": {

--- a/packages-presets/preset-wind/package.json
+++ b/packages-presets/preset-wind/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/preset-wind"
   },
   "bugs": {

--- a/packages-presets/reset/package.json
+++ b/packages-presets/reset/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/reset"
   },
   "bugs": {

--- a/packages-presets/rule-utils/package.json
+++ b/packages-presets/rule-utils/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/rule-utils"
   },
   "bugs": {

--- a/packages-presets/transformer-attributify-jsx-babel/package.json
+++ b/packages-presets/transformer-attributify-jsx-babel/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/transformer-attributify-jsx-babel"
   },
   "bugs": {

--- a/packages-presets/transformer-attributify-jsx/package.json
+++ b/packages-presets/transformer-attributify-jsx/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/transformer-attributify-jsx"
   },
   "bugs": {

--- a/packages-presets/transformer-compile-class/package.json
+++ b/packages-presets/transformer-compile-class/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/transformer-compile-class"
   },
   "bugs": {

--- a/packages-presets/transformer-directives/package.json
+++ b/packages-presets/transformer-directives/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/transformer-directives"
   },
   "bugs": {

--- a/packages-presets/transformer-variant-group/package.json
+++ b/packages-presets/transformer-variant-group/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/transformer-variant-group"
   },
   "bugs": {

--- a/packages-presets/unocss/package.json
+++ b/packages-presets/unocss/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://unocss.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/unocss/unocss",
+    "url": "git+https://github.com/unocss/unocss",
     "directory": "packages-presets/unocss"
   },
   "sponsor": {


### PR DESCRIPTION
We are using git repository type in package.json in all published packages, we must use a git URL.