### PR TITLE
ci: fix run npm scripts

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
-      - name: PNPM update
-        run: pnpm run update
+      - name: Update iconify-collections
+        run: pnpm run update:iconify-collections
 
       - name: Update iconify collections
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
This PR corrects the npm scripts for [workflow schedule](https://github.com/unocss/unocss/blob/main/.github/workflows/schedule.yml).

https://github.com/unocss/unocss/blob/2c42584eb2ff8396555db49979fa317103d62dfb/.github/workflows/schedule.yml#L30

which should be

https://github.com/unocss/unocss/blob/2c42584eb2ff8396555db49979fa317103d62dfb/package.json#L29

Introduced in https://github.com/unocss/unocss/pull/4364