### PR TITLE
fix(inspector): improve codemirror search extension style

### DIFF
--- a/packages-integrations/inspector/client/components/CodeMirror.vue
+++ b/packages-integrations/inspector/client/components/CodeMirror.vue
@@ -87,6 +87,13 @@ grammarly-desktop-integration {
   cursor: text !important;
 }
 
+:root:not(.dark) .cm-search .cm-button {
+  background-image: linear-gradient(#f5f6f7, #eee);
+}
+:root:not(.dark) .cm-search .cm-button:active {
+  background-image: linear-gradient(#eee, #f5f6f7);
+}
+
 :root {
   --cm-font-family: 'Fira Code', monospace;
   --cm-foreground: #393a3480;


### PR DESCRIPTION
This PR fixes codemirror search button color in light theme.

## Before

<img width="742" alt="Screenshot 2025-02-09 at 00 23 03" src="https://github.com/user-attachments/assets/24be86a8-87da-4db7-9b02-ff5822bbe02f" />

## After

light

<img width="649" alt="Screenshot 2025-02-09 at 00 30 49" src="https://github.com/user-attachments/assets/b3800457-dff7-432b-a502-8f480243b4fc" />

dark

<img width="644" alt="Screenshot 2025-02-09 at 00 31 01" src="https://github.com/user-attachments/assets/28e5bd0d-9e90-4960-bf1e-bad184f14963" />

