### PR TITLE
feat(preset-mini): add `container-type: size` support for `@container` rule

### DIFF
--- a/packages-presets/preset-mini/src/_rules/container.ts
+++ b/packages-presets/preset-mini/src/_rules/container.ts
@@ -1,7 +1,7 @@
 import type { Rule } from '@unocss/core'
 
 export const containerParent: Rule[] = [
-  [/^@container(?:\/(\w+))?(?:-(normal))?$/, ([, l, v]) => {
+  [/^@container(?:\/(\w+))?(?:-(normal|inline-size|size))?$/, ([, l, v]) => {
     return {
       'container-type': v ?? 'inline-size',
       'container-name': l,

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -1086,10 +1086,14 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .after\:content-\[quoted\:unocss\]::after{content:"unocss";}
 .content-empty{content:"";}
 .content-none{content:none;}
-.\@container{container-type:inline-size;}
+.\@container,
+.\@container-inline-size{container-type:inline-size;}
 .\@container-normal{container-type:normal;}
-.\@container\/label{container-type:inline-size;container-name:label;}
+.\@container-size{container-type:size;}
+.\@container\/label,
+.\@container\/label-inline-size{container-type:inline-size;container-name:label;}
 .\@container\/label-normal{container-type:normal;container-name:label;}
+.\@container\/label-size{container-type:size;container-name:label;}
 @layer base{
 .layer-base\:translate-0{--un-translate-x:0;--un-translate-y:0;transform:translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z)) rotate(var(--un-rotate)) rotateX(var(--un-rotate-x)) rotateY(var(--un-rotate-y)) rotateZ(var(--un-rotate-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z));}
 }

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -1237,6 +1237,10 @@ export const presetMiniTargets: string[] = [
   '@container/label',
   '@container-normal',
   '@container/label-normal',
+  '@container-inline-size',
+  '@container/label-inline-size',
+  '@container-size',
+  '@container/label-size',
 
   // variants - container query (@)
   '@sm:text-red',


### PR DESCRIPTION
The `@container` rule in `preset-mini` currently supports `container-type` values `normal` and `inline-size`. This PR adds support for the `size` value.

mdn `container-type` document: https://developer.mozilla.org/en-US/docs/Web/CSS/container-type