### PR TITLE
fix(eslint-plugin): fix plugin rules type assertion

### DIFF
--- a/packages-integrations/eslint-plugin/src/rules/blocklist.ts
+++ b/packages-integrations/eslint-plugin/src/rules/blocklist.ts
@@ -1,6 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types'
-import type { ESLintUtils } from '@typescript-eslint/utils'
-import type { RuleListener } from '@typescript-eslint/utils/ts-eslint'
+import type { AnyRuleModule, RuleListener } from '@typescript-eslint/utils/ts-eslint'
 import { CLASS_FIELDS } from '../constants'
 import { createRule, syncAction } from './_'
 import { IGNORE_ATTRIBUTES } from './order-attributify'
@@ -105,4 +104,4 @@ export default createRule({
       return parserServices?.defineTemplateBodyVisitor(templateBodyVisitor, scriptVisitor)
     }
   },
-}) as any as ESLintUtils.RuleWithMeta<[], ''>
+}) as any as AnyRuleModule

--- a/packages-integrations/eslint-plugin/src/rules/enforce-class-compile.ts
+++ b/packages-integrations/eslint-plugin/src/rules/enforce-class-compile.ts
@@ -1,6 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types'
-import type { ESLintUtils } from '@typescript-eslint/utils'
-import type { ReportFixFunction, RuleListener } from '@typescript-eslint/utils/ts-eslint'
+import type { AnyRuleModule, ReportFixFunction, RuleListener } from '@typescript-eslint/utils/ts-eslint'
 import type { AST } from 'vue-eslint-parser'
 import { createRule } from './_'
 
@@ -123,4 +122,4 @@ export default createRule<[{ prefix: string, enableFix: boolean }], 'missing'>({
       return parserServices?.defineTemplateBodyVisitor(templateBodyVisitor, scriptVisitor)
     }
   },
-}) as any as ESLintUtils.RuleWithMeta<[], ''>
+}) as any as AnyRuleModule

--- a/packages-integrations/eslint-plugin/src/rules/order-attributify.ts
+++ b/packages-integrations/eslint-plugin/src/rules/order-attributify.ts
@@ -1,6 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types'
-import type { ESLintUtils } from '@typescript-eslint/utils'
-import type { RuleListener } from '@typescript-eslint/utils/ts-eslint'
+import type { AnyRuleModule, RuleListener } from '@typescript-eslint/utils/ts-eslint'
 import MagicString from 'magic-string'
 import { createRule, syncAction } from './_'
 
@@ -74,4 +73,4 @@ export default createRule({
       return parserServices?.defineTemplateBodyVisitor(templateBodyVisitor, scriptVisitor)
     }
   },
-}) as any as ESLintUtils.RuleWithMeta<[], ''>
+}) as any as AnyRuleModule

--- a/packages-integrations/eslint-plugin/src/rules/order.ts
+++ b/packages-integrations/eslint-plugin/src/rules/order.ts
@@ -1,6 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types'
-import type { ESLintUtils } from '@typescript-eslint/utils'
-import type { RuleListener } from '@typescript-eslint/utils/ts-eslint'
+import type { AnyRuleModule, RuleListener } from '@typescript-eslint/utils/ts-eslint'
 import type { SvelteAttribute, SvelteLiteral, SvelteMustacheTag } from 'svelte-eslint-parser/lib/ast/html'
 import { AST_TOKEN_TYPES } from '@typescript-eslint/types'
 import { AST_NODES_WITH_QUOTES, CLASS_FIELDS } from '../constants'
@@ -116,4 +115,4 @@ export default createRule({
       return parserServices?.defineTemplateBodyVisitor(templateBodyVisitor, scriptVisitor)
     }
   },
-}) as any as ESLintUtils.RuleWithMeta<[], ''>
+}) as any as AnyRuleModule


### PR DESCRIPTION
This PR fixes: 

- #4402
- #4333

Type `create` method of type `RuleWithMeta` requires two parameters: `context` and `optionsWithDefault`:

https://github.com/typescript-eslint/typescript-eslint/blob/87d72ba76c055499ea233efb73cdaef1f0d2ac4a/packages/utils/src/eslint-utils/RuleCreator.ts#L22-L39

Which is not compatible with `LooseRuleDefinition` from:

https://github.com/typescript-eslint/typescript-eslint/blob/87d72ba76c055499ea233efb73cdaef1f0d2ac4a/packages/utils/src/ts-eslint/Rule.ts#L719-L728