### PR TITLE
fix: fixed height for presets in inspector

### DIFF
--- a/packages-integrations/inspector/client/components/Overview.vue
+++ b/packages-integrations/inspector/client/components/Overview.vue
@@ -32,7 +32,7 @@ const formatted = useCSSPrettify(computed(() => {
           <div text-amber op80>
             Presets
           </div>
-          <div op50 ws-pre>
+          <div h25 op50 ws-pre overflow="auto">
             {{ info?.config?.presets?.map(i => i.name).join('\n') }}
           </div>
         </div>


### PR DESCRIPTION
I'm trying to work on a project where each utility is extracted in its own preset. Thus, when using the inspector, the view results in something like:

![image](https://github.com/user-attachments/assets/25f3cc64-8a24-4773-bcb7-04723d203cae)

I'm unable to browse the source and analyzer tabs. Instead of this, the proposed changes will add a fixed height (100px) and set the overflow to auto for the list of presets, resulting in something like:

![image](https://github.com/user-attachments/assets/1f7f2fe4-011f-418b-8ca8-d33e61678be5)
