### PR TITLE
ci: replace node version `lts` to `22.14.0` temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [18.18.2, lts/*]
+        node_version: [18.18.2, 22.14.0]
         include:
           - os: macos-latest
-            node_version: lts/*
+            node_version: 22.14.0
           - os: windows-latest
-            node_version: lts/*
+            node_version: 22.14.0
       fail-fast: false
 
     steps:
@@ -45,7 +45,9 @@ jobs:
       # Those two can probably go away once the devcontainer is using a version of Node which includes a version corepack
       # with the fix.
 
-      - run: npm i -g corepack@latest --force
+      - run: echo "corepack version => $(corepack --version)"
+
+      # - run: npm i -g corepack@latest --force
       - run: corepack enable
 
       - name: Setup
@@ -64,5 +66,5 @@ jobs:
         run: nr typecheck
 
       - name: Check types
-        if: runner.os == 'Linux' && matrix.node_version == 'lts/*'
+        if: runner.os == 'Linux' && matrix.node_version == '22.14.0'
         run: nr test:attw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,6 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
-      # `npm i -g corepack@latest;` and  `corepack prepare pnpm@latest --activate;` are necessary to get the latest
-      # version of corepack, which has a fix for https://github.com/nodejs/corepack/issues/612
-      # (related https://github.com/pnpm/pnpm/issues/9029), so it can install pnpm.
-      # Those two can probably go away once the devcontainer is using a version of Node which includes a version corepack
-      # with the fix.
-
-      - run: echo "corepack version => $(corepack --version)"
-
-      # - run: npm i -g corepack@latest --force
       - run: corepack enable
 
       - name: Setup

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 22.14.0
           cache: pnpm
 
       - name: Install


### PR DESCRIPTION
https://github.com/pnpm/pnpm/issues/9029#issuecomment-2650658230

After my investigation, I found that `actions/setup-node@v4` did not update the node `lts` version in time, which caused the `corepack` version to be unable to be upgraded to `0.31.0`, resulting in a ci error.

Temporarily fix node to the latest lts version, wait for the upgrade of `actions/setup-node@v4`, and then revert this change.