### PR TITLE
ci: fix corepack issue

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -17,10 +17,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Use Node.js lts/*
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: pnpm
 
       - name: Setup
         run: npm i -g @antfu/ni

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,19 +34,13 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Set node ${{ matrix.node_version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
-
-      # `npm i -g corepack@latest;` and  `corepack prepare pnpm@latest --activate;` are necessary to get the latest
-      # version of corepack, which has a fix for https://github.com/nodejs/corepack/issues/612
-      # (related https://github.com/pnpm/pnpm/issues/9029), so it can install pnpm.
-      # Those two can probably go away once the devcontainer is using a version of Node which includes a version corepack
-      # with the fix.
-
-      - run: npm i -g corepack@latest --force
-      - run: corepack enable
 
       - name: Setup
         run: npm i -g @antfu/ni

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -18,14 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # `npm i -g corepack@latest;` and  `corepack prepare pnpm@latest --activate;` are necessary to get the latest
-      # version of corepack, which has a fix for https://github.com/nodejs/corepack/issues/612
-      # (related https://github.com/pnpm/pnpm/issues/9029), so it can install pnpm.
-      # Those two can probably go away once the devcontainer is using a version of Node which includes a version corepack
-      # with the fix.
-
-      - run: npm i -g corepack@latest
-      - run: corepack enable
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Set node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Fix corepack issue by using pnpm action to replace corepack enable, also since pnpm v10, pnpm has built-in corepack function, so I personally disabled corepack on my local machine too.