### PR TITLE
fix(rule-utils): replace all alpha placeholder occurrences in colors

### DIFF
--- a/packages-presets/preset-mini/test/color.test.ts
+++ b/packages-presets/preset-mini/test/color.test.ts
@@ -46,6 +46,9 @@ describe('preset-mini color utils', () => {
           info: 'hsl(200.1,100%,54.3%)',
           warning: 'hsl(42.4 100% 50%)',
           danger: 'hsl(var(--danger))',
+          colorMix: 'color-mix(in hsl, oklch(95% 0.10 var(--hue)), oklch(100% 0 360))',
+          colorMixUnoAlpha: 'color-mix(in hsl, oklch(95% 0.10 var(--hue) / %alpha), oklch(100% 0 360))',
+          colorMixDosAlpha: 'color-mix(in srgb, oklch(95% 0.10 var(--hue) / %alpha) 30%, oklch(100% 0 360 / %alpha))',
         },
       },
       symbols,
@@ -102,6 +105,32 @@ describe('preset-mini color utils', () => {
     expect(fn('#0000')).eql({
       '--un-v-opacity': 0,
       'prop': 'rgb(0 0 0 / var(--un-v-opacity))',
+    })
+
+    expect(fn('colorMix')).eql({
+      prop: 'color-mix(in hsl, oklch(95% 0.10 var(--hue)), oklch(100% 0 360))',
+    })
+
+    expect(fn('colorMix/20')).eql({
+      prop: 'color-mix(in hsl, oklch(95% 0.10 var(--hue)), oklch(100% 0 360))',
+    })
+
+    expect(fn('colorMixUnoAlpha')).eql({
+      '--un-v-opacity': 1,
+      'prop': 'color-mix(in hsl, oklch(95% 0.10 var(--hue) / var(--un-v-opacity)), oklch(100% 0 360))',
+    })
+
+    expect(fn('colorMixUnoAlpha/20')).eql({
+      prop: 'color-mix(in hsl, oklch(95% 0.10 var(--hue) / 0.2), oklch(100% 0 360))',
+    })
+
+    expect(fn('colorMixDosAlpha')).eql({
+      '--un-v-opacity': 1,
+      'prop': 'color-mix(in srgb, oklch(95% 0.10 var(--hue) / var(--un-v-opacity)) 30%, oklch(100% 0 360 / var(--un-v-opacity)))',
+    })
+
+    expect(fn('colorMixDosAlpha/20')).eql({
+      prop: 'color-mix(in srgb, oklch(95% 0.10 var(--hue) / 0.2) 30%, oklch(100% 0 360 / 0.2))',
     })
 
     // invalid

--- a/packages-presets/rule-utils/src/colors.ts
+++ b/packages-presets/rule-utils/src/colors.ts
@@ -39,7 +39,7 @@ export interface ParsedColorValue {
 /* eslint-disable no-case-declarations */
 export const cssColorFunctions = ['hsl', 'hsla', 'hwb', 'lab', 'lch', 'oklab', 'oklch', 'rgb', 'rgba']
 export const alphaPlaceholders = ['%alpha', '<alpha-value>']
-export const alphaPlaceholdersRE = new RegExp(alphaPlaceholders.map(v => escapeRegExp(v)).join('|'))
+export const alphaPlaceholdersRE = new RegExp(alphaPlaceholders.map(v => escapeRegExp(v)).join('|'), 'g')
 
 export function hex2rgba(hex = ''): RGBAColorValue | undefined {
   const color = parseHexColor(hex)


### PR DESCRIPTION
With the following theme color setup:

```yaml
DEFAULT: 'oklch(62% 0.20 var(--hue))'
50: 'color-mix(in srgb, oklch(95% 0.10 var(--hue) / %alpha) 30%, oklch(100% 0 360))'
100: 'color-mix(in srgb, oklch(95% 0.10 var(--hue) / %alpha) 30%, oklch(100% 0 360 / %alpha))'
```

…, it appears tokens like `text-primary-100/20` yields:

```css
.text-primary-100\/20 {
  color: color-mix(
    in srgb,
    oklch(95% 0.1 var(--hue) / 0.2) 30%,
    oklch(100% 0 360 / %alpha) // <-- untouched leftover
  );
}
```

…, which is not working correctly.

However, `text-primary-50/20` yields the correct output because primary-50 only have one `%alpha` placeholder: 

```css
.text-primary-50\/20 {
  color: color-mix(
    in srgb,
    oklch(95% 0.1 var(--hue) / 0.2) 30%,
    oklch(100% 0 360)
  );
}
```

[Test in the playground](https://unocss.dev/play/#html=DwEwlgbgBAxgNgQwM5ILwCIAuBTAHpgWgAcAnMAWwRIE8CBWABnSgHoA%2BAKFElkRQxz5iZSjXoMWAJiatO3aPGRoseQqQpVaARgYz2XcAr7LBakZoI6J05vqA&config=JYWwDg9gTgLgBAbzgEwKYDNgDtUGEJaYDmANHGFKgM6owCCMMUwARgK4zDoCeZF1tAJIBjAlT6UaMAKpYIcAL5x0UCCDgByNnOFUqGgFAHUAD0iwUGAIZsANvDSYc%2BQsCIAKBAbhwYAC1QQVAAuRG8fOFFbaCpQrwiIilArKG448ISfABEAUQAxOmkAGQAVUI0IAGtbYT93ADYAJgBSOAAGADpGtrgANxT3AFpBvzZUAEpxjRIMzIBWNvKo6EGQYBN3bDgqKCIWMiqauoBOOdbOgEYe-qghkbHxuAB6OGarWzA-K0eAZjbmg7VWruK7-dpwH71NqTabPF4EVBwd6fKzkWxWYSoPwQWxoKBUWYJUFLHErNYbLY7PaAo7uU7nDpXPoDYajCbPV7Ir6-f404Gg84QqEct4fblTMhPF4wADu8i5qLA6Mx2NxqHxhMUMwSCm1WoMCnGBiAA&css=PQKgBA6gTglgLgUzAYwK4Gc4HsC2YDCAyoWABYJQIA0YAhgHYAmYcUD6AZllDhWOqgAOg7nAB0YAGLcwCAB60cggDYIAXGBDAAUKDBi0mXGADe2sGC704AWgDuCGAHNScDQFYADJ4Dc5sAACtMLKAJ5gggCMLPK2ABR2pPBIcsoAlH4WAEa0yADWTlBYqEw2yFjK3Bpw5LxxAOTllVDoYpSMYgAs3vUZ2gC%2BmsBAA&options=N4XyA)

This pull request tries to fix this issue and adds more tests for this case.