### PR TITLE
docs: update 'plain' to 'inline' in configuration documentation

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -177,7 +177,7 @@ Options for sources to be extracted as utilities usages.
 Supported sources:
 
 - `filesystem` - extract from file system
-- `plain` - extract from plain inline text
+- `inline` - extract from plain inline text
 - `pipeline` - extract from build tools' transformation pipeline, such as Vite and Webpack
 
 The usage extracted from each source will be **merged** together.


### PR DESCRIPTION
Reason
https://github.com/unocss/unocss/blob/a4eea88297bd39d1959959c99c4b4eb194bba9e4/packages-engine/core/src/types.ts#L813-L816