### PR TITLE
feat(preset-wind4): add `utilityResolver ` option support utility convert

### DIFF
--- a/packages-engine/core/src/types.ts
+++ b/packages-engine/core/src/types.ts
@@ -143,7 +143,7 @@ export interface ExtractorContext {
   envMode?: 'dev' | 'build'
 }
 
-interface BaseContext<Theme extends object = object> {
+export interface BaseContext<Theme extends object = object> {
   /**
    * UnoCSS generator instance
    */

--- a/packages-presets/preset-wind4/src/index.ts
+++ b/packages-presets/preset-wind4/src/index.ts
@@ -1,4 +1,4 @@
-import type { PreflightContext, PresetOptions } from '@unocss/core'
+import type { Arrayable, CSSEntry, PreflightContext, PresetOptions } from '@unocss/core'
 import type { Theme } from './theme'
 import { definePreset } from '@unocss/core'
 import { extractorArbitraryVariants } from '@unocss/extractor-arbitrary-variants'
@@ -107,7 +107,14 @@ export interface PresetWind4Options extends PresetOptions {
    * @param ctx {@link PreflightContext}
    * @returns
    */
-  processThemeVars?: (vars: [string, string][], ctx: PreflightContext) => void | [string, string][]
+  processThemeVars?: (vars: CSSEntry[], ctx: PreflightContext) => void | CSSEntry[]
+
+  /**
+   * Resolve unit values.
+   *
+   * @param utility
+   */
+  unitResolver?: Arrayable<(utility: CSSEntry, layer: string) => void>
 }
 
 export const presetWind4 = definePreset<PresetWind4Options, Theme>((options = {}) => {

--- a/packages-presets/preset-wind4/src/index.ts
+++ b/packages-presets/preset-wind4/src/index.ts
@@ -1,4 +1,4 @@
-import type { Arrayable, CSSEntry, PreflightContext, PresetOptions } from '@unocss/core'
+import type { Arrayable, BaseContext, CSSEntry, PresetOptions } from '@unocss/core'
 import type { Theme } from './theme'
 import { definePreset } from '@unocss/core'
 import { extractorArbitraryVariants } from '@unocss/extractor-arbitrary-variants'
@@ -101,20 +101,14 @@ export interface PresetWind4Options extends PresetOptions {
   themePreflight?: boolean | 'on-demand'
 
   /**
-   * Process theme variables before generating CSS variables.
+   * Resolve the layer utilits with custom logic.
    *
-   * @param vars [key, value][]
-   * @param ctx {@link PreflightContext}
+   * @param utility [key, value] {@link CSSEntry}
+   * @param layer Layer name
+   * @param ctx base generator context {@link BaseContext<Theme>}
    * @returns
    */
-  processThemeVars?: (vars: CSSEntry[], ctx: PreflightContext) => void | CSSEntry[]
-
-  /**
-   * Resolve unit values.
-   *
-   * @param utility
-   */
-  unitResolver?: Arrayable<(utility: CSSEntry, layer: string) => void>
+  utilityResolver?: Arrayable<(utility: CSSEntry, layer: string, ctx: BaseContext<Theme>) => void>
 }
 
 export const presetWind4 = definePreset<PresetWind4Options, Theme>((options = {}) => {

--- a/packages-presets/preset-wind4/src/postprocess/default.ts
+++ b/packages-presets/preset-wind4/src/postprocess/default.ts
@@ -1,13 +1,13 @@
 import type { Postprocessor } from '@unocss/core'
 import type { PresetWind4Options } from '..'
 import { important } from './important'
-import { unit } from './unit'
+import { utility } from './utility'
 import { varPrefix } from './varPrefix'
 
 export function postprocessors(options: PresetWind4Options): Postprocessor[] {
   return [
     important,
     varPrefix,
-    unit,
+    utility,
   ].flatMap(i => i(options))
 }

--- a/packages-presets/preset-wind4/src/postprocess/default.ts
+++ b/packages-presets/preset-wind4/src/postprocess/default.ts
@@ -1,11 +1,13 @@
 import type { Postprocessor } from '@unocss/core'
 import type { PresetWind4Options } from '..'
 import { important } from './important'
+import { unit } from './unit'
 import { varPrefix } from './varPrefix'
 
 export function postprocessors(options: PresetWind4Options): Postprocessor[] {
   return [
-    ...important(options.important),
-    ...varPrefix(options.variablePrefix),
-  ]
+    important,
+    varPrefix,
+    unit,
+  ].flatMap(i => i(options))
 }

--- a/packages-presets/preset-wind4/src/postprocess/important.ts
+++ b/packages-presets/preset-wind4/src/postprocess/important.ts
@@ -1,7 +1,7 @@
 import type { Postprocessor } from '@unocss/core'
 import type { PresetWind4Options } from '..'
 
-export function important(option: PresetWind4Options['important']): Postprocessor[] {
+export function important({ important: option }: PresetWind4Options): Postprocessor[] {
   if (option == null || option === false)
     return []
 

--- a/packages-presets/preset-wind4/src/postprocess/index.ts
+++ b/packages-presets/preset-wind4/src/postprocess/index.ts
@@ -1,4 +1,4 @@
 export * from './default'
 export * from './important'
-export * from './unit'
+export * from './utility'
 export * from './varPrefix'

--- a/packages-presets/preset-wind4/src/postprocess/index.ts
+++ b/packages-presets/preset-wind4/src/postprocess/index.ts
@@ -1,3 +1,4 @@
 export * from './default'
 export * from './important'
+export * from './unit'
 export * from './varPrefix'

--- a/packages-presets/preset-wind4/src/postprocess/unit.ts
+++ b/packages-presets/preset-wind4/src/postprocess/unit.ts
@@ -1,0 +1,16 @@
+import type { Postprocessor } from '@unocss/core'
+import type { PresetWind4Options } from '..'
+import { toArray } from '@unocss/core'
+
+export function unit({ unitResolver }: PresetWind4Options): Postprocessor[] {
+  const processor: Postprocessor = (util) => {
+    const resolvers = toArray(unitResolver)
+    util.entries.forEach((i) => {
+      for (const resolver of resolvers) {
+        resolver(i, 'default')
+      }
+    })
+  }
+
+  return unitResolver ? [processor] : []
+}

--- a/packages-presets/preset-wind4/src/postprocess/unit.ts
+++ b/packages-presets/preset-wind4/src/postprocess/unit.ts
@@ -1,16 +1,16 @@
-import type { Postprocessor } from '@unocss/core'
+import type { BaseContext, Postprocessor } from '@unocss/core'
 import type { PresetWind4Options } from '..'
 import { toArray } from '@unocss/core'
 
-export function unit({ unitResolver }: PresetWind4Options): Postprocessor[] {
+export function unit({ utilityResolver }: PresetWind4Options): Postprocessor[] {
   const processor: Postprocessor = (util) => {
-    const resolvers = toArray(unitResolver)
+    const resolvers = toArray(utilityResolver)
     util.entries.forEach((i) => {
       for (const resolver of resolvers) {
-        resolver(i, 'default')
+        resolver(i, 'default', {} as BaseContext)
       }
     })
   }
 
-  return unitResolver ? [processor] : []
+  return utilityResolver ? [processor] : []
 }

--- a/packages-presets/preset-wind4/src/postprocess/utility.ts
+++ b/packages-presets/preset-wind4/src/postprocess/utility.ts
@@ -2,7 +2,7 @@ import type { BaseContext, Postprocessor } from '@unocss/core'
 import type { PresetWind4Options } from '..'
 import { toArray } from '@unocss/core'
 
-export function unit({ utilityResolver }: PresetWind4Options): Postprocessor[] {
+export function utility({ utilityResolver }: PresetWind4Options): Postprocessor[] {
   const processor: Postprocessor = (util) => {
     const resolvers = toArray(utilityResolver)
     util.entries.forEach((i) => {

--- a/packages-presets/preset-wind4/src/postprocess/varPrefix.ts
+++ b/packages-presets/preset-wind4/src/postprocess/varPrefix.ts
@@ -1,7 +1,7 @@
 import type { Postprocessor } from '@unocss/core'
 import type { PresetWind4Options } from '..'
 
-export function varPrefix(prefix: PresetWind4Options['variablePrefix']): Postprocessor[] {
+export function varPrefix({ variablePrefix: prefix }: PresetWind4Options): Postprocessor[] {
   const processor: Postprocessor = (obj) => {
     obj.entries.forEach((i) => {
       i[0] = i[0].replace(/^--un-/, `--${prefix}`)

--- a/packages-presets/preset-wind4/src/preflights/theme.ts
+++ b/packages-presets/preset-wind4/src/preflights/theme.ts
@@ -67,18 +67,16 @@ export function theme(options: PresetWind4Options): Preflight<Theme> {
 
       let deps
       const generateCSS = (deps: CSSEntry[]) => {
-        if (options.processThemeVars) {
-          deps = options.processThemeVars(deps, ctx) ?? deps
-        }
-        if (deps.length === 0)
-          return undefined
-        if (options.unitResolver) {
-          for (const resolver of toArray(options.unitResolver)) {
-            deps.forEach(utility => resolver(utility, 'theme'))
+        if (options.utilityResolver) {
+          const resolver = toArray(options.utilityResolver)
+          for (const utility of deps) {
+            for (const r of resolver) {
+              r(utility, 'theme', ctx)
+            }
           }
         }
 
-        const depCSS = deps.map(([key, value]) => `${key}: ${value};`).join('\n')
+        const depCSS = deps.map(([key, value]) => (key && value) ? `${key}: ${value};` : undefined).filter(Boolean).join('\n')
 
         return compressCSS(`
 :root, :host {

--- a/packages-presets/preset-wind4/src/preflights/theme.ts
+++ b/packages-presets/preset-wind4/src/preflights/theme.ts
@@ -76,7 +76,11 @@ export function theme(options: PresetWind4Options): Preflight<Theme> {
           }
         }
 
-        const depCSS = deps.map(([key, value]) => (key && value) ? `${key}: ${value};` : undefined).filter(Boolean).join('\n')
+        const resovledDeps = deps.map(([key, value]) => (key && value) ? `${key}: ${value};` : undefined).filter(Boolean)
+        if (resovledDeps.length === 0) {
+          return undefined
+        }
+        const depCSS = resovledDeps.join('\n')
 
         return compressCSS(`
 :root, :host {

--- a/packages-presets/preset-wind4/src/rules/position.ts
+++ b/packages-presets/preset-wind4/src/rules/position.ts
@@ -130,7 +130,6 @@ function handleInsetValues([, d, v]: string[]): CSSEntries | undefined {
   const r = handleInsetValue(v)
   if (r != null && d in insetMap) {
     return insetMap[d].map(i => [i.slice(1), r])
-    // return insetMap[d].map(i => [`inset${i}` , r])
   }
 }
 

--- a/packages-presets/preset-wind4/src/utils/index.ts
+++ b/packages-presets/preset-wind4/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './constant'
 export * from './handlers'
 export * from './mappings'
+export * from './unit-resolver'
 export * from './utilities'
 export * from '@unocss/rule-utils'

--- a/packages-presets/preset-wind4/src/utils/unit-resolver.ts
+++ b/packages-presets/preset-wind4/src/utils/unit-resolver.ts
@@ -1,0 +1,9 @@
+import type { CSSEntry } from '@unocss/core'
+
+export function createRemToPxResolver(base: number = 16) {
+  return (utility: CSSEntry) => {
+    const remRE = /(-?[.\d]+)rem/g
+    if (typeof utility[1] === 'string' && remRE.test(utility[1]))
+      utility[1] = utility[1].replace(remRE, (_, p1) => `${p1 * base}px`)
+  }
+}

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -1,5 +1,6 @@
 import { createGenerator, escapeSelector } from '@unocss/core'
 import presetWind4 from '@unocss/preset-wind4'
+import { createRemToPxResolver } from '@unocss/preset-wind4/utils'
 import { describe, expect, it } from 'vitest'
 import { presetWind4Targets } from './assets/preset-wind4-targets'
 
@@ -185,8 +186,8 @@ describe('preset-wind4', () => {
                 k = k.replace('colors', 'ui')
               }
 
-              if (v.includes('rem')) {
-                v = v.replace('rem', 'px')
+              if ((v as string).includes('rem')) {
+                v = (v as string).replace('rem', 'px')
               }
 
               return [k, v]
@@ -205,6 +206,28 @@ describe('preset-wind4', () => {
       --spacing: 0.25px;
       --ui-red: oklch(0.704 0.191 22.216);
       }"
+    `)
+  })
+
+  it('unitResolver', async () => {
+    const uno = await createGenerator({
+      envMode: 'dev',
+      presets: [
+        presetWind4({
+          reset: false,
+          unitResolver: createRemToPxResolver(),
+        }),
+      ],
+    })
+    const { css } = await uno.generate('p-4 m-5rem')
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: theme */
+      :root, :host {
+      --spacing: 4px;
+      }
+      /* layer: default */
+      .m-5rem{margin:80px;}
+      .p-4{padding:calc(var(--spacing) * 4);}"
     `)
   })
 })

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -174,24 +174,22 @@ describe('preset-wind4', () => {
     `)
   })
 
-  it('processThemeVars', async () => {
+  it('custom theme vars', async () => {
     const uno = await createGenerator({
       envMode: 'dev',
       presets: [
         presetWind4({
           reset: false,
-          processThemeVars(vars) {
-            return vars.map(([k, v]) => {
-              if (k.includes('colors')) {
-                k = k.replace('colors', 'ui')
+          utilityResolver(vars, layer) {
+            if (layer === 'theme') {
+              const [key, value] = vars
+              if (key.includes('colors')) {
+                vars[0] = key.replace('colors', 'ui')
               }
-
-              if ((v as string).includes('rem')) {
-                v = (v as string).replace('rem', 'px')
+              if ((value as string).includes('rem')) {
+                vars[1] = (value as string).replace('rem', 'px')
               }
-
-              return [k, v]
-            })
+            }
           },
         }),
       ],
@@ -215,7 +213,7 @@ describe('preset-wind4', () => {
       presets: [
         presetWind4({
           reset: false,
-          unitResolver: createRemToPxResolver(),
+          utilityResolver: createRemToPxResolver(),
         }),
       ],
     })


### PR DESCRIPTION
This PR changes are as follows:
- Added `utilityResolver` option to support users to modify utility with css entry. Currently it works on `postprocessor` and `theme preflight`, you can modify the corresponding `layer name` explicitly
- Removed `processThemeVars`（`beta.7`'s option） and replaced it by `utilityResolver`

close #4509 , close #4531 
related to #4533 
