### PR TITLE
feat(preset-wind4): hoist css properties

### DIFF
--- a/docs/config/rules.md
+++ b/docs/config/rules.md
@@ -156,6 +156,7 @@ Will generate:
 - `symbols.layer`: A string/function/regex match that sets the UnoCSS layer of the generated CSS rule
 - `symbols.variants`: An array of variant handler that are applied to the current CSS object
 - `symbols.shortcutsNoMerge`: A boolean to disable the merging of the current rule in shortcuts
+- `symbols.noMerge`: A boolean to disable the merging of the current rule in shortcuts
 - `symbols.sort`: A number to overwrite sorting order of the current CSS object
 
 ## Multi-selector rules

--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -7,6 +7,7 @@ import { createNanoEvents } from './utils/events'
 
 export const symbols: ControlSymbols = {
   shortcutsNoMerge: '$$symbol-shortcut-no-merge' as unknown as ControlSymbols['shortcutsNoMerge'],
+  noMerge: '$$symbol-no-merge' as unknown as ControlSymbols['noMerge'],
   variants: '$$symbol-variants' as unknown as ControlSymbols['variants'],
   parent: '$$symbol-parent' as unknown as ControlSymbols['parent'],
   selector: '$$symbol-selector' as unknown as ControlSymbols['selector'],
@@ -503,10 +504,13 @@ class UnoGeneratorInternal<Theme extends object = object> {
           const parents: [string | undefined, number | undefined] = Array.isArray(v.parent)
             ? v.parent
             : [v.parent, undefined]
+
+          const selector = v.selector?.(input.selector, entries)
+
           return (v.handle ?? defaultVariantHandler)({
             ...input,
             entries,
-            selector: v.selector?.(input.selector, entries) || input.selector,
+            selector: selector || input.selector,
             parent: parents[0] || input.parent,
             parentOrder: parents[1] || input.parentOrder,
             layer: v.layer || input.layer,
@@ -668,10 +672,15 @@ class UnoGeneratorInternal<Theme extends object = object> {
             let entryMeta = meta
             for (const entry of css) {
               if (entry[0] === symbols.variants) {
-                variants = [
-                  ...toArray(entry[1]),
-                  ...variants,
-                ]
+                if (typeof entry[1] === 'function') {
+                  variants = entry[1](variants) || variants
+                }
+                else {
+                  variants = [
+                    ...toArray(entry[1]),
+                    ...variants,
+                  ]
+                }
               }
               else if (entry[0] === symbols.parent) {
                 variants = [
@@ -695,6 +704,12 @@ class UnoGeneratorInternal<Theme extends object = object> {
                 entryMeta = {
                   ...entryMeta,
                   sort: entry[1],
+                }
+              }
+              else if (entry[0] === symbols.noMerge) {
+                entryMeta = {
+                  ...entryMeta,
+                  noMerge: entry[1],
                 }
               }
             }

--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -335,7 +335,7 @@ class UnoGeneratorInternal<Theme extends object = object> {
             })
           if (!sorted.length)
             return undefined
-          const rules = sorted
+          const ruleLines = sorted
             .reverse()
             .map(([selectorSortPair, body, noMerge], idx) => {
               if (!noMerge && this.config.mergeSelectors) {
@@ -362,6 +362,8 @@ class UnoGeneratorInternal<Theme extends object = object> {
                 : body
             })
             .filter(Boolean)
+
+          const rules = Array.from(new Set(ruleLines))
             .reverse()
             .join(nl)
 

--- a/packages-engine/core/src/types.ts
+++ b/packages-engine/core/src/types.ts
@@ -74,6 +74,7 @@ export interface RuleContext<Theme extends object = object> {
 }
 
 declare const SymbolShortcutsNoMerge: unique symbol
+declare const SymbolNoMerge: unique symbol
 declare const SymbolVariants: unique symbol
 declare const SymbolParent: unique symbol
 declare const SymbolSelector: unique symbol
@@ -85,6 +86,10 @@ export interface ControlSymbols {
    * Prevent merging in shortcuts
    */
   shortcutsNoMerge: typeof SymbolShortcutsNoMerge
+  /**
+   * Prevent merging in rules
+   */
+  noMerge: typeof SymbolNoMerge
   /**
    * Additional variants applied to this rule
    */
@@ -109,7 +114,8 @@ export interface ControlSymbols {
 
 export interface ControlSymbolsValue {
   [SymbolShortcutsNoMerge]: true
-  [SymbolVariants]: VariantHandler[]
+  [SymbolNoMerge]: true
+  [SymbolVariants]: VariantHandler[] | ((handlers: VariantHandler[]) => VariantHandler[])
   [SymbolParent]: string
   [SymbolSelector]: (selector: string) => string
   [SymbolLayer]: string

--- a/packages-engine/core/test/__snapshots__/extended-info.test.ts.snap
+++ b/packages-engine/core/test/__snapshots__/extended-info.test.ts.snap
@@ -30,6 +30,7 @@ Map {
           ],
           "symbols": {
             "layer": "$$symbol-layer",
+            "noMerge": "$$symbol-no-merge",
             "parent": "$$symbol-parent",
             "selector": "$$symbol-selector",
             "shortcutsNoMerge": "$$symbol-shortcut-no-merge",
@@ -78,6 +79,7 @@ Map {
           ],
           "symbols": {
             "layer": "$$symbol-layer",
+            "noMerge": "$$symbol-no-merge",
             "parent": "$$symbol-parent",
             "selector": "$$symbol-selector",
             "shortcutsNoMerge": "$$symbol-shortcut-no-merge",
@@ -124,6 +126,7 @@ Map {
           ],
           "symbols": {
             "layer": "$$symbol-layer",
+            "noMerge": "$$symbol-no-merge",
             "parent": "$$symbol-parent",
             "selector": "$$symbol-selector",
             "shortcutsNoMerge": "$$symbol-shortcut-no-merge",

--- a/packages-presets/preset-wind4/src/index.ts
+++ b/packages-presets/preset-wind4/src/index.ts
@@ -124,7 +124,8 @@ export const presetWind4 = definePreset<PresetWind4Options, Theme>((options = {}
     shortcuts,
     theme,
     layers: {
-      theme: -150,
+      'cssvar-property': -200,
+      'theme': -150,
     },
     preflights: preflights(options),
     variants: variants(options),

--- a/packages-presets/preset-wind4/src/preflights/theme.ts
+++ b/packages-presets/preset-wind4/src/preflights/theme.ts
@@ -76,11 +76,11 @@ export function theme(options: PresetWind4Options): Preflight<Theme> {
           }
         }
 
-        const resovledDeps = deps.map(([key, value]) => (key && value) ? `${key}: ${value};` : undefined).filter(Boolean)
-        if (resovledDeps.length === 0) {
+        const resolvedDeps = deps.map(([key, value]) => (key && value) ? `${key}: ${value};` : undefined).filter(Boolean)
+        if (resolvedDeps.length === 0) {
           return undefined
         }
-        const depCSS = resovledDeps.join('\n')
+        const depCSS = resolvedDeps.join('\n')
 
         return compressCSS(`
 :root, :host {

--- a/packages-presets/preset-wind4/src/rules/background.ts
+++ b/packages-presets/preset-wind4/src/rules/background.ts
@@ -97,7 +97,8 @@ function bgGradientColorResolver() {
           }
           break
       }
-      yield Object.values(properties).join('\n')
+      for (const p of Object.values(properties))
+        yield p
     }
   }
 }
@@ -107,7 +108,8 @@ function bgGradientPositionResolver() {
     yield {
       [`--un-gradient-${mode}-position`]: `${h.bracket.cssvar.percent(body)}`,
     }
-    yield Object.values(properties).join('\n')
+    for (const p of Object.values(properties))
+      yield p
   }
 }
 

--- a/packages-presets/preset-wind4/src/rules/filters.ts
+++ b/packages-presets/preset-wind4/src/rules/filters.ts
@@ -13,7 +13,7 @@ const filterBaseKeys = [
   'sepia',
   'drop-shadow',
 ]
-const filterProperties = filterBaseKeys.map(i => defineProperty(`--un-${i}`)).join('\n')
+const filterProperties = filterBaseKeys.map(i => defineProperty(`--un-${i}`))
 const filterCSS = filterBaseKeys.map(i => `var(--un-${i},)`).join(' ')
 
 const backdropBaseKeys = [
@@ -27,7 +27,7 @@ const backdropBaseKeys = [
   'backdrop-saturate',
   'backdrop-sepia',
 ]
-const backdropProperties = backdropBaseKeys.map(i => defineProperty(`--un-${i}`)).join('\n')
+const backdropProperties = backdropBaseKeys.map(i => defineProperty(`--un-${i}`))
 const backdropCSS = backdropBaseKeys.map(i => `var(--un-${i},)`).join(' ')
 
 function percentWithDefault(str?: string) {
@@ -51,7 +51,7 @@ function toFilter(varName: string, resolver: (str: string, theme: Theme) => stri
             '-webkit-backdrop-filter': backdropCSS,
             'backdrop-filter': backdropCSS,
           },
-          backdropProperties,
+          ...backdropProperties,
         ]
       }
       else {
@@ -60,7 +60,7 @@ function toFilter(varName: string, resolver: (str: string, theme: Theme) => stri
             [`--un-${varName}`]: `${varName}(${value})`,
             filter: filterCSS,
           },
-          filterProperties,
+          ...filterProperties,
         ]
       }
     }
@@ -76,7 +76,7 @@ function dropShadowResolver([, s]: string[], { theme }: RuleContext<Theme>) {
         '--un-drop-shadow': `drop-shadow(${shadows.join(') drop-shadow(')})`,
         'filter': filterCSS,
       },
-      filterProperties,
+      ...filterProperties,
     ]
   }
 
@@ -87,7 +87,7 @@ function dropShadowResolver([, s]: string[], { theme }: RuleContext<Theme>) {
         '--un-drop-shadow': v ? `drop-shadow(${v})` : v,
         'filter': filterCSS,
       },
-      filterProperties,
+      ...filterProperties,
     ]
   }
 }

--- a/packages-presets/preset-wind4/src/rules/ring.ts
+++ b/packages-presets/preset-wind4/src/rules/ring.ts
@@ -13,7 +13,7 @@ export const rings: Rule<Theme>[] = [
           '--un-ring-shadow': `var(--un-ring-inset,) 0 0 0 calc(${v} + var(--un-ring-offset-width)) var(--un-ring-color, currentColor)`,
           'box-shadow': 'var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow)',
         },
-        Object.values(shadowProperties).join('\n'),
+        ...Object.values(shadowProperties),
       ]
     }
   }],
@@ -29,7 +29,7 @@ export const rings: Rule<Theme>[] = [
           '--un-inset-ring-shadow': `inset 0 0 0 ${v} var(--un-inset-ring-color, currentColor)`,
           'box-shadow': 'var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow)',
         },
-        Object.values(shadowProperties).join('\n'),
+        ...Object.values(shadowProperties),
       ]
     }
   }],

--- a/packages-presets/preset-wind4/src/rules/shadow.ts
+++ b/packages-presets/preset-wind4/src/rules/shadow.ts
@@ -25,7 +25,6 @@ export const boxShadows: Rule<Theme>[] = [
   // inset shadow
   [/^inset-shadow(?:-(.+))?$/, handleShadow('insetShadow'), { autocomplete: ['inset-shadow-$colors', 'inset-shadow-$insetShadow'] }],
   [/^inset-shadow-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-inset-shadow-opacity': h.bracket.percent.cssvar(opacity) }), { autocomplete: 'shadow-(op|opacity)-<percent>' }],
-
 ]
 
 function handleShadow(themeKey: 'shadow' | 'insetShadow') {

--- a/packages-presets/preset-wind4/src/rules/shadow.ts
+++ b/packages-presets/preset-wind4/src/rules/shadow.ts
@@ -42,7 +42,7 @@ function handleShadow(themeKey: 'shadow' | 'insetShadow') {
           '--un-shadow': colorableShadows((v || c)!, `--un-${colorVar}-color`).join(','),
           'box-shadow': 'var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow)',
         },
-        Object.values(shadowProperties).join('\n'),
+        ...Object.values(shadowProperties),
       ]
     }
     return colorResolver(`--un-${colorVar}-color`, colorVar)(match, ctx)

--- a/packages-presets/preset-wind4/src/rules/static.ts
+++ b/packages-presets/preset-wind4/src/rules/static.ts
@@ -44,7 +44,7 @@ export const contains: Rule<Theme>[] = [
             '--un-contain-size': d,
             'contain': containValues.map(i => `var(--un-contain-${i})`).join(' '),
           },
-          containValues.map(i => defineProperty(`--un-contain-${i}`)).join('\n'),
+          ...containValues.map(i => defineProperty(`--un-contain-${i}`)),
         ]
       : undefined
   }],

--- a/packages-presets/preset-wind4/src/rules/table.ts
+++ b/packages-presets/preset-wind4/src/rules/table.ts
@@ -28,7 +28,8 @@ export const tables: Rule<Theme>[] = [
         '--un-border-spacing-y': v,
         'border-spacing': 'var(--un-border-spacing-x) var(--un-border-spacing-y)',
       }
-      yield ['x', 'y'].map(d => defineProperty(`--un-border-spacing-${d}`, { syntax: '<length>', initialValue: '0' })).join('\n')
+      for (const d of ['x', 'y'])
+        yield defineProperty(`--un-border-spacing-${d}`, { syntax: '<length>', initialValue: '0' })
     }
   }, { autocomplete: ['border-spacing', 'border-spacing-$spacing'] }],
 
@@ -39,7 +40,8 @@ export const tables: Rule<Theme>[] = [
         [`--un-border-spacing-${d}`]: v,
         'border-spacing': 'var(--un-border-spacing-x) var(--un-border-spacing-y)',
       }
-      yield ['x', 'y'].map(d => defineProperty(`--un-border-spacing-${d}`, { syntax: '<length>', initialValue: '0' })).join('\n')
+      for (const d of ['x', 'y'])
+        yield defineProperty(`--un-border-spacing-${d}`, { syntax: '<length>', initialValue: '0' })
     }
   }, { autocomplete: ['border-spacing-(x|y)', 'border-spacing-(x|y)-$spacing'] }],
 

--- a/packages-presets/preset-wind4/src/rules/touch-actions.ts
+++ b/packages-presets/preset-wind4/src/rules/touch-actions.ts
@@ -3,7 +3,7 @@ import type { Theme } from '../theme'
 import { defineProperty, makeGlobalStaticRules } from '../utils'
 
 const touchActionValue = 'var(--un-pan-x) var(--un-pan-y) var(--un-pinch-zoom)'
-const touchActionProperty = ['pan-x', 'pan-y', 'pinch-zoom'].map(d => defineProperty(`--un-${d}`)).join('\n')
+const touchActionProperties = ['pan-x', 'pan-y', 'pinch-zoom'].map(d => defineProperty(`--un-${d}`))
 
 export const touchActions: Rule<Theme>[] = [
   [/^touch-pan-(x|left|right)$/, function* ([, d]) {
@@ -11,21 +11,24 @@ export const touchActions: Rule<Theme>[] = [
       '--un-pan-x': `pan-${d}`,
       'touch-action': touchActionValue,
     }
-    yield touchActionProperty
+    for (const p of touchActionProperties)
+      yield p
   }, { autocomplete: ['touch-pan', 'touch-pan-(x|left|right|y|up|down)'] }],
   [/^touch-pan-(y|up|down)$/, function* ([, d]) {
     yield {
       '--un-pan-y': `pan-${d}`,
       'touch-action': touchActionValue,
     }
-    yield touchActionProperty
+    for (const p of touchActionProperties)
+      yield p
   }],
   [/^touch-pinch-zoom$/, function* () {
     yield {
       '--un-pinch-zoom': 'pinch-zoom',
       'touch-action': touchActionValue,
     }
-    yield touchActionProperty
+    for (const p of touchActionProperties)
+      yield p
   }],
 
   ['touch-auto', { 'touch-action': 'auto' }],

--- a/packages-presets/preset-wind4/src/rules/transform.ts
+++ b/packages-presets/preset-wind4/src/rules/transform.ts
@@ -112,7 +112,7 @@ function handleTranslate([, d, b]: string[]): CSSValues | (CSSValueInput | strin
         ...transformXYZ(d, typeof v === 'number' ? `calc(var(--spacing) * ${v})` : v, 'translate'),
         ['translate', `var(--un-translate-x) var(--un-translate-y)${d === 'z' ? ' var(--un-translate-z)' : ''}`],
       ],
-      ['x', 'y', 'z'].map(d => defineProperty(`--un-translate-${d}`, { initialValue: 0 })).join('\n'),
+      ...['x', 'y', 'z'].map(d => defineProperty(`--un-translate-${d}`, { initialValue: 0 })),
     ]
   }
 }
@@ -132,7 +132,7 @@ function handleScale([, d, b]: string[]): CSSValues | (CSSValueInput | string)[]
         ...transformXYZ(d, v, 'scale'),
         ['scale', `var(--un-scale-x) var(--un-scale-y)${d === 'z' ? ' var(--un-scale-z)' : ''}`],
       ],
-      ['x', 'y', 'z'].map(d => defineProperty(`--un-scale-${d}`, { initialValue: 1 })).join('\n'),
+      ...['x', 'y', 'z'].map(d => defineProperty(`--un-scale-${d}`, { initialValue: 1 })),
     ]
   }
 }
@@ -152,8 +152,8 @@ function handleRotate([, d = '', b]: string[]): CSSValues | (CSSValueInput | str
           ...transformXYZ(d, v.endsWith('deg') ? `rotate${d.toUpperCase()}(${v})` : v, 'rotate'),
           ['transform', transform],
         ],
-        ['x', 'y', 'z'].map(d => defineProperty(`--un-rotate-${d}`, { initialValue: `rotate${d.toUpperCase()}(0)` })).join('\n'),
-        ['x', 'y'].map(d => defineProperty(`--un-skew-${d}`, { initialValue: `skew${d.toUpperCase()}(0)` })).join('\n'),
+        ...['x', 'y', 'z'].map(d => defineProperty(`--un-rotate-${d}`, { initialValue: `rotate${d.toUpperCase()}(0)` })),
+        ...['x', 'y'].map(d => defineProperty(`--un-skew-${d}`, { initialValue: `skew${d.toUpperCase()}(0)` })),
       ]
     }
     else {
@@ -173,8 +173,8 @@ function handleSkew([, d, b]: string[]): CSSValues | (CSSValueInput | string)[] 
         ...ds.map(_d => [`--un-skew${_d}`, v.endsWith('deg') ? `skew${_d.slice(1).toUpperCase()}(${v})` : v]) as any,
         ['transform', transform],
       ],
-      ['x', 'y', 'z'].map(d => defineProperty(`--un-rotate-${d}`, { initialValue: `rotate${d.toUpperCase()}(0)` })).join('\n'),
-      ['x', 'y'].map(d => defineProperty(`--un-skew-${d}`, { initialValue: `skew${d.toUpperCase()}(0)` })).join('\n'),
+      ...['x', 'y', 'z'].map(d => defineProperty(`--un-rotate-${d}`, { initialValue: `rotate${d.toUpperCase()}(0)` })),
+      ...['x', 'y'].map(d => defineProperty(`--un-skew-${d}`, { initialValue: `skew${d.toUpperCase()}(0)` })),
     ]
   }
 }

--- a/packages-presets/preset-wind4/src/rules/typography.ts
+++ b/packages-presets/preset-wind4/src/rules/typography.ts
@@ -233,20 +233,20 @@ const fontVariantNumericProperties = [
   defineProperty('--un-numeric-figure'),
   defineProperty('--un-numeric-spacing'),
   defineProperty('--un-numeric-fraction'),
-].join('\n')
+]
 const baseFontVariantNumeric = {
   'font-variant-numeric': 'var(--un-ordinal) var(--un-slashed-zero) var(--un-numeric-figure) var(--un-numeric-spacing) var(--un-numeric-fraction)',
 }
 
 export const fontVariantNumeric: Rule<Theme>[] = [
-  ['ordinal', [{ '--un-ordinal': 'ordinal', ...baseFontVariantNumeric }, fontVariantNumericProperties]],
-  ['slashed-zero', [{ '--un-slashed-zero': 'slashed-zero', ...baseFontVariantNumeric }, fontVariantNumericProperties]],
-  ['lining-nums', [{ '--un-numeric-figure': 'lining-nums', ...baseFontVariantNumeric }, fontVariantNumericProperties]],
-  ['oldstyle-nums', [{ '--un-numeric-figure': 'oldstyle-nums', ...baseFontVariantNumeric }, fontVariantNumericProperties]],
-  ['proportional-nums', [{ '--un-numeric-spacing': 'proportional-nums', ...baseFontVariantNumeric }, fontVariantNumericProperties]],
-  ['tabular-nums', [{ '--un-numeric-spacing': 'tabular-nums', ...baseFontVariantNumeric }, fontVariantNumericProperties]],
-  ['diagonal-fractions', [{ '--un-numeric-fraction': 'diagonal-fractions', ...baseFontVariantNumeric }, fontVariantNumericProperties]],
-  ['stacked-fractions', [{ '--un-numeric-fraction': 'stacked-fractions', ...baseFontVariantNumeric }, fontVariantNumericProperties]],
+  ['ordinal', [{ '--un-ordinal': 'ordinal', ...baseFontVariantNumeric }, ...fontVariantNumericProperties]],
+  ['slashed-zero', [{ '--un-slashed-zero': 'slashed-zero', ...baseFontVariantNumeric }, ...fontVariantNumericProperties]],
+  ['lining-nums', [{ '--un-numeric-figure': 'lining-nums', ...baseFontVariantNumeric }, ...fontVariantNumericProperties]],
+  ['oldstyle-nums', [{ '--un-numeric-figure': 'oldstyle-nums', ...baseFontVariantNumeric }, ...fontVariantNumericProperties]],
+  ['proportional-nums', [{ '--un-numeric-spacing': 'proportional-nums', ...baseFontVariantNumeric }, ...fontVariantNumericProperties]],
+  ['tabular-nums', [{ '--un-numeric-spacing': 'tabular-nums', ...baseFontVariantNumeric }, ...fontVariantNumericProperties]],
+  ['diagonal-fractions', [{ '--un-numeric-fraction': 'diagonal-fractions', ...baseFontVariantNumeric }, ...fontVariantNumericProperties]],
+  ['stacked-fractions', [{ '--un-numeric-fraction': 'stacked-fractions', ...baseFontVariantNumeric }, ...fontVariantNumericProperties]],
   ['normal-nums', [{ 'font-variant-numeric': 'normal' }]],
 ]
 

--- a/packages-presets/preset-wind4/src/utils/utilities.ts
+++ b/packages-presets/preset-wind4/src/utils/utilities.ts
@@ -292,7 +292,6 @@ export function getThemeByKey(theme: Theme, themeKey: keyof Theme, keys: string[
       const camel = camelize(keys.slice(index).join('-'))
       if (obj[camel])
         return obj[camel]
-
       const hyphen = keys.slice(index).join('-')
       if (obj[hyphen])
         return obj[hyphen]
@@ -403,7 +402,7 @@ export function defineProperty(
     inherits: inherits ? 'true' : 'false',
   }
   if (initialValue != null)
-    value.initialValue = JSON.stringify(initialValue)
+    value['initial-value'] = JSON.stringify(initialValue)
   return value
 }
 

--- a/packages-presets/preset-wind4/src/utils/utilities.ts
+++ b/packages-presets/preset-wind4/src/utils/utilities.ts
@@ -1,6 +1,6 @@
-import type { CSSEntries, CSSObject, CSSValueInput, DynamicMatcher, RuleContext, StaticRule, VariantContext } from '@unocss/core'
+import type { CSSEntries, CSSObject, CSSObjectInput, CSSValueInput, DynamicMatcher, RuleContext, StaticRule, VariantContext } from '@unocss/core'
 import type { Theme } from '../theme'
-import { toArray } from '@unocss/core'
+import { symbols, toArray } from '@unocss/core'
 import { colorToString, getStringComponent, getStringComponents, parseCssColor } from '@unocss/rule-utils'
 import { themeTracking } from './constant'
 import { h } from './handlers'
@@ -128,7 +128,12 @@ export function colorableShadows(shadows: string | string[], colorVar: string) {
   return colored
 }
 
-export function colorCSSGenerator(data: ReturnType<typeof parseColor>, property: string, varName: string, ctx?: RuleContext<Theme>): [CSSObject, string?] | undefined {
+export function colorCSSGenerator(
+  data: ReturnType<typeof parseColor>,
+  property: string,
+  varName: string,
+  ctx?: RuleContext<Theme>,
+): CSSValueInput[] | undefined {
   if (!data)
     return
 
@@ -137,7 +142,7 @@ export function colorCSSGenerator(data: ReturnType<typeof parseColor>, property:
   const css: CSSObject = {}
 
   if (color) {
-    const result: [CSSObject, string?] = [css]
+    const result: CSSValueInput[] = [css]
 
     if (Object.values(SpecialColorKey).includes(color)) {
       css[property] = color
@@ -377,14 +382,29 @@ export function compressCSS(css: string, isDev = false) {
 export function defineProperty(
   property: string,
   options: { syntax?: string, inherits?: boolean, initialValue?: unknown } = {},
-) {
+): CSSValueInput {
   const {
     syntax = '*',
     inherits = false,
     initialValue,
   } = options
 
-  return `@property ${property} {syntax: "${syntax}";inherits: ${inherits};${initialValue != null ? `initial-value: ${initialValue};` : ''}}`
+  const value: CSSObjectInput = {
+    [symbols.shortcutsNoMerge]: true,
+    [symbols.noMerge]: true,
+    [symbols.variants]: () => [
+      {
+        parent: '',
+        layer: 'cssvar-property',
+        selector: () => `@property ${property}`,
+      },
+    ],
+    syntax: JSON.stringify(syntax),
+    inherits: inherits ? 'true' : 'false',
+  }
+  if (initialValue != null)
+    value.initialValue = JSON.stringify(initialValue)
+  return value
 }
 
 export function detectThemeValue(value: string, theme: Theme) {

--- a/packages-presets/preset-wind4/src/utils/utilities.ts
+++ b/packages-presets/preset-wind4/src/utils/utilities.ts
@@ -133,7 +133,7 @@ export function colorCSSGenerator(
   property: string,
   varName: string,
   ctx?: RuleContext<Theme>,
-): CSSValueInput[] | undefined {
+): [CSSObject, ...CSSValueInput[]] | undefined {
   if (!data)
     return
 
@@ -142,7 +142,7 @@ export function colorCSSGenerator(
   const css: CSSObject = {}
 
   if (color) {
-    const result: CSSValueInput[] = [css]
+    const result: [CSSObject, ...CSSValueInput[]] = [css]
 
     if (Object.values(SpecialColorKey).includes(color)) {
       css[property] = color

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -1,206 +1,16 @@
 /* layer: cssvar-property */
 @property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-leading{syntax:"*";inherits:false;}
-@property --un-leading{syntax:"*";inherits:false;}
-@property --un-leading{syntax:"*";inherits:false;}
-@property --un-leading{syntax:"*";inherits:false;}
-@property --un-leading{syntax:"*";inherits:false;}
-@property --un-leading{syntax:"*";inherits:false;}
 @property --un-leading{syntax:"*";inherits:false;}
 @property --un-text-stroke-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-text-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-accent-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-caret-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-line-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-line-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-line-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-line-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
 @property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
 @property --un-ring-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-inset-ring-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-inset-shadow-color{syntax:"*";inherits:false;}
-@property --un-ring-color{syntax:"*";inherits:false;}
-@property --un-ring-inset{syntax:"*";inherits:false;}
-@property --un-ring-offset-color{syntax:"*";inherits:false;}
-@property --un-ring-offset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-ring-offset-width{syntax:"<length>";inherits:false;initial-value:"0px";}
-@property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-shadow-color{syntax:"*";inherits:false;}
 @property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-inset-ring-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-inset-shadow-color{syntax:"*";inherits:false;}
-@property --un-ring-color{syntax:"*";inherits:false;}
-@property --un-ring-inset{syntax:"*";inherits:false;}
-@property --un-ring-offset-color{syntax:"*";inherits:false;}
-@property --un-ring-offset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-ring-offset-width{syntax:"<length>";inherits:false;initial-value:"0px";}
-@property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-shadow-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-inset-shadow-color{syntax:"*";inherits:false;}
-@property --un-ring-color{syntax:"*";inherits:false;}
-@property --un-ring-inset{syntax:"*";inherits:false;}
-@property --un-ring-offset-color{syntax:"*";inherits:false;}
-@property --un-ring-offset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-ring-offset-width{syntax:"<length>";inherits:false;initial-value:"0px";}
-@property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-shadow-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-inset-shadow-color{syntax:"*";inherits:false;}
-@property --un-ring-color{syntax:"*";inherits:false;}
-@property --un-ring-inset{syntax:"*";inherits:false;}
-@property --un-ring-offset-color{syntax:"*";inherits:false;}
-@property --un-ring-offset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-ring-offset-width{syntax:"<length>";inherits:false;initial-value:"0px";}
-@property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-shadow-color{syntax:"*";inherits:false;}
-@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-inset-ring-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-inset-shadow-color{syntax:"*";inherits:false;}
-@property --un-ring-color{syntax:"*";inherits:false;}
-@property --un-ring-inset{syntax:"*";inherits:false;}
-@property --un-ring-offset-color{syntax:"*";inherits:false;}
-@property --un-ring-offset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-ring-offset-width{syntax:"<length>";inherits:false;initial-value:"0px";}
-@property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
-@property --un-shadow-color{syntax:"*";inherits:false;}
 @property --un-inset-ring-color{syntax:"*";inherits:false;}
 @property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
@@ -214,48 +24,18 @@
 @property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-shadow-color{syntax:"*";inherits:false;}
 @property --un-ease{syntax:"*";inherits:false;}
-@property --un-ease{syntax:"*";inherits:false;}
-@property --un-ease{syntax:"*";inherits:false;}
-@property --un-ease{syntax:"*";inherits:false;}
-@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-fill-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-stroke-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-stroke-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-from-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-from-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-from-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-from-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-from-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-stops-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-to-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-to-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-to-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-to-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-to-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-via-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-via-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-via-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-via-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-via-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-drop-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-placeholder-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-scroll-snap-strictness{syntax:"*";inherits:false;initial-value:"proximity";}
-@property --un-scroll-snap-strictness{syntax:"*";inherits:false;initial-value:"proximity";}
-@property --un-scroll-snap-strictness{syntax:"*";inherits:false;initial-value:"proximity";}
-@property --un-space-x-reverse{syntax:"*";inherits:false;initial-value:0;}
-@property --un-space-x-reverse{syntax:"*";inherits:false;initial-value:0;}
-@property --un-space-x-reverse{syntax:"*";inherits:false;initial-value:0;}
-@property --un-space-x-reverse{syntax:"*";inherits:false;initial-value:0;}
 @property --un-space-y-reverse{syntax:"*";inherits:false;initial-value:0;}
 @property --un-space-x-reverse{syntax:"*";inherits:false;initial-value:0;}
 @property --un-divide-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-divide-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
-@property --un-border-style{syntax:"*";inherits:false;initial-value:"solid";}
-@property --un-divide-x-reverse{syntax:"*";inherits:false;initial-value:0;}
-@property --un-border-style{syntax:"*";inherits:false;initial-value:"solid";}
-@property --un-divide-x-reverse{syntax:"*";inherits:false;initial-value:0;}
 @property --un-border-style{syntax:"*";inherits:false;initial-value:"solid";}
 @property --un-divide-y-reverse{syntax:"*";inherits:false;initial-value:0;}
 @property --un-divide-x-reverse{syntax:"*";inherits:false;initial-value:0;}

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -8,6 +8,10 @@
 @property --un-caret-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-line-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-contain-layout{syntax:"*";inherits:false;}
+@property --un-contain-paint{syntax:"*";inherits:false;}
+@property --un-contain-size{syntax:"*";inherits:false;}
+@property --un-contain-style{syntax:"*";inherits:false;}
 @property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
 @property --un-ring-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
@@ -23,6 +27,17 @@
 @property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-shadow-color{syntax:"*";inherits:false;}
+@property --un-translate-x{syntax:"*";inherits:false;initial-value:0;}
+@property --un-translate-y{syntax:"*";inherits:false;initial-value:0;}
+@property --un-translate-z{syntax:"*";inherits:false;initial-value:0;}
+@property --un-rotate-x{syntax:"*";inherits:false;initial-value:"rotateX(0)";}
+@property --un-rotate-y{syntax:"*";inherits:false;initial-value:"rotateY(0)";}
+@property --un-rotate-z{syntax:"*";inherits:false;initial-value:"rotateZ(0)";}
+@property --un-skew-x{syntax:"*";inherits:false;initial-value:"skewX(0)";}
+@property --un-skew-y{syntax:"*";inherits:false;initial-value:"skewY(0)";}
+@property --un-scale-x{syntax:"*";inherits:false;initial-value:1;}
+@property --un-scale-y{syntax:"*";inherits:false;initial-value:1;}
+@property --un-scale-z{syntax:"*";inherits:false;initial-value:1;}
 @property --un-ease{syntax:"*";inherits:false;}
 @property --un-fill-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-stroke-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
@@ -30,9 +45,41 @@
 @property --un-stops-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-to-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-via-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-gradient-from{syntax:"<color>";inherits:false;initial-value:"#0000";}
+@property --un-gradient-from-position{syntax:"<length-percentage>";inherits:false;initial-value:"0%";}
+@property --un-gradient-position{syntax:"*";inherits:false;}
+@property --un-gradient-stops{syntax:"*";inherits:false;}
+@property --un-gradient-to{syntax:"<color>";inherits:false;initial-value:"#0000";}
+@property --un-gradient-to-position{syntax:"<length-percentage>";inherits:false;initial-value:"100%";}
+@property --un-gradient-via{syntax:"<color>";inherits:false;initial-value:"#0000";}
+@property --un-gradient-via-position{syntax:"<length-percentage>";inherits:false;initial-value:"50%";}
+@property --un-gradient-via-stops{syntax:"*";inherits:false;}
 @property --un-drop-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-backdrop-blur{syntax:"*";inherits:false;}
+@property --un-backdrop-brightness{syntax:"*";inherits:false;}
+@property --un-backdrop-contrast{syntax:"*";inherits:false;}
+@property --un-backdrop-grayscale{syntax:"*";inherits:false;}
+@property --un-backdrop-hue-rotate{syntax:"*";inherits:false;}
+@property --un-backdrop-invert{syntax:"*";inherits:false;}
+@property --un-backdrop-opacity{syntax:"*";inherits:false;}
+@property --un-backdrop-saturate{syntax:"*";inherits:false;}
+@property --un-backdrop-sepia{syntax:"*";inherits:false;}
+@property --un-blur{syntax:"*";inherits:false;}
+@property --un-brightness{syntax:"*";inherits:false;}
+@property --un-contrast{syntax:"*";inherits:false;}
+@property --un-drop-shadow{syntax:"*";inherits:false;}
+@property --un-grayscale{syntax:"*";inherits:false;}
+@property --un-hue-rotate{syntax:"*";inherits:false;}
+@property --un-invert{syntax:"*";inherits:false;}
+@property --un-saturate{syntax:"*";inherits:false;}
+@property --un-sepia{syntax:"*";inherits:false;}
 @property --un-placeholder-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-scroll-snap-strictness{syntax:"*";inherits:false;initial-value:"proximity";}
+@property --un-border-spacing-x{syntax:"<length>";inherits:false;initial-value:"0";}
+@property --un-border-spacing-y{syntax:"<length>";inherits:false;initial-value:"0";}
+@property --un-pan-x{syntax:"*";inherits:false;}
+@property --un-pan-y{syntax:"*";inherits:false;}
+@property --un-pinch-zoom{syntax:"*";inherits:false;}
 @property --un-space-y-reverse{syntax:"*";inherits:false;initial-value:0;}
 @property --un-space-x-reverse{syntax:"*";inherits:false;initial-value:0;}
 @property --un-divide-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
@@ -849,10 +896,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .contain-\[size_layout_paint\]{contain:size layout paint;}
 .contain-\[size_layout\]{contain:size layout;}
 .contain-layout{--un-contain-size:layout;contain:var(--un-contain-size) var(--un-contain-layout) var(--un-contain-paint) var(--un-contain-style);}
-[object Object]
-[object Object]
-[object Object]
-[object Object]
 .pointer-events-auto{pointer-events:auto;}
 .pointer-events-none{pointer-events:none;}
 .pointer-events-unset{pointer-events:unset;}
@@ -906,18 +949,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;}
 .ring,
 .ring-px{--un-ring-shadow:var(--un-ring-inset,) 0 0 0 calc(1px + var(--un-ring-offset-width)) var(--un-ring-color, currentColor);box-shadow:var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
 .ring-10{--un-ring-shadow:var(--un-ring-inset,) 0 0 0 calc(10px + var(--un-ring-offset-width)) var(--un-ring-color, currentColor);box-shadow:var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}
 .ring-\[calc\(1rem-1px\)\]{--un-ring-color:color-mix(in oklch, calc(1rem - 1px) var(--un-ring-opacity), transparent) /* calc(1rem - 1px) */;}
 .ring-op-\$opacity-variable{--un-ring-opacity:var(--opacity-variable);}
@@ -956,9 +987,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .perspect-origin-center{perspective-origin:center;}
 .perspect-origin-top-right{perspective-origin:top right;}
 .translate-\[var\(--x\)\,var\(--y\)\,25\%\]{--un-translate-x:var(--x);--un-translate-y:var(--y);--un-translate-z:25%;translate:var(--un-translate-x) var(--un-translate-y);}
-[object Object]
-[object Object]
-[object Object]
 .translate-\[var\(--x\)\,var\(--y\)\]{--un-translate-x:var(--x);--un-translate-y:var(--y);translate:var(--un-translate-x) var(--un-translate-y);}
 .scope_class .scope-\[\.scope\\_class\]\:translate-0{--un-translate-x:calc(var(--spacing) * 0);--un-translate-y:calc(var(--spacing) * 0);translate:var(--un-translate-x) var(--un-translate-y);}
 .translate-none{translate:none;}
@@ -971,8 +999,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .rotate-1deg{rotate:1deg;}
 .-rotate-2{rotate:-2deg;}
 .rotate-x-\$variable{--un-rotate-x:var(--variable);transform:var(--un-rotate-x) var(--un-rotate-y) var(--un-rotate-z) var(--un-skew-x) var(--un-skew-y);}
-[object Object]
-[object Object]
 .rotate-x-1deg{--un-rotate-x:rotateX(1deg);transform:var(--un-rotate-x) var(--un-rotate-y) var(--un-rotate-z) var(--un-skew-x) var(--un-skew-y);}
 .rotate-y-1,
 .transform-rotate-y-1{--un-rotate-y:rotateY(1deg);transform:var(--un-rotate-x) var(--un-rotate-y) var(--un-rotate-z) var(--un-skew-x) var(--un-skew-y);}
@@ -1239,15 +1265,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .animate-unset{animation:unset;}
 .bg-linear-\[70deg\,blue\,pink\]{--un-gradient-position:70deg,blue,pink;background-image:linear-gradient(var(--un-gradient-stops));}
 .from-\$bg-from{--un-gradient-from:color-mix(in oklab, var(--bg-from) var(--un-from-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
 .from-current{--un-gradient-from:currentColor;--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
 .from-green-500{--un-gradient-from:color-mix(in oklab, var(--colors-green-500) var(--un-from-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
 .from-green-500\/50{--un-from-opacity:50%;--un-gradient-from:color-mix(in oklab, var(--colors-green-500) var(--un-from-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
@@ -1462,11 +1479,8 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .touch-none{touch-action:none;}
 .touch-initial{touch-action:initial;}
 .lining-nums{--un-numeric-figure:lining-nums;font-variant-numeric:var(--un-ordinal) var(--un-slashed-zero) var(--un-numeric-figure) var(--un-numeric-spacing) var(--un-numeric-fraction);}
-[object Object]
-[object Object]
-[object Object]
-[object Object]
-[object Object]
+.lining-nums,
+.tabular-nums{syntax:"*";inherits:false;}
 .tabular-nums{--un-numeric-spacing:tabular-nums;font-variant-numeric:var(--un-ordinal) var(--un-slashed-zero) var(--un-numeric-figure) var(--un-numeric-spacing) var(--un-numeric-fraction);}
 .normal-nums{font-variant-numeric:normal;}
 .view-transition-foo{view-transition-name:foo;}

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -901,6 +901,18 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .ring-offset-4{--un-ring-offset-width:4px;}
 .ring-inset{--un-ring-inset:inset;}
 .shadow{--un-shadow:0 1px 3px 0 var(--un-shadow-color, rgb(0 0 0 / 0.1)),0 1px 2px -1px var(--un-shadow-color, rgb(0 0 0 / 0.1));box-shadow:var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}
+@property --un-inset-ring-color {syntax: "*";inherits: false;}
+@property --un-inset-ring-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
+@property --un-inset-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
+@property --un-inset-shadow-color {syntax: "*";inherits: false;}
+@property --un-ring-color {syntax: "*";inherits: false;}
+@property --un-ring-inset {syntax: "*";inherits: false;}
+@property --un-ring-offset-color {syntax: "*";inherits: false;}
+@property --un-ring-offset-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
+@property --un-ring-offset-width {syntax: "<length>";inherits: false;initial-value: 0px;}
+@property --un-ring-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
+@property --un-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
+@property --un-shadow-color {syntax: "*";inherits: false;}
 .shadow-\[\#fff\]{--un-shadow-color:color-mix(in oklch, #fff var(--un-shadow-opacity), transparent) /* #fff */;}
 @property --un-shadow-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .shadow-\[0px_4px_4px_0px_rgba\(237\,_0\,_0\,_1\)\]{--un-shadow:0px 4px 4px 0px var(--un-shadow-color, rgba(237, 0, 0, 1));box-shadow:var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -6,6 +6,7 @@
 @property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-accent-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-caret-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-border-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-line-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-contain-layout{syntax:"*";inherits:false;}
@@ -516,7 +517,6 @@
 .border-s-width-\$variable{border-inline-start-width:var(--variable);}
 .border-t-width-3{border-top-width:3px;}
 .b-block-size-\$variable{border-block-start-width:var(--variable);border-block-end-width:var(--variable);}
-[object Object]
 .border-\[\#124\]{border-color:color-mix(in oklch, #124 var(--un-border-opacity), transparent) /* #124 */;}
 .border-\[calc\(10px\+1px\)\]{border-width:calc(10px + 1px);}
 .border-\[calc\(var\(--border-width\)\*1px\)\]{border-width:calc(var(--border-width) * 1px);}

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -1,75 +1,75 @@
 /* layer: cssvar-property */
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-leading{syntax:"*";inherits:false;}
 @property --un-leading{syntax:"*";inherits:false;}
 @property --un-leading{syntax:"*";inherits:false;}
@@ -77,188 +77,188 @@
 @property --un-leading{syntax:"*";inherits:false;}
 @property --un-leading{syntax:"*";inherits:false;}
 @property --un-leading{syntax:"*";inherits:false;}
-@property --un-text-stroke-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-text-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-accent-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-caret-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-line-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-line-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-line-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-line-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
-@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
-@property --un-ring-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-stroke-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-text-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-accent-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-caret-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-line-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-line-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-line-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-line-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initial-value:"\"\"";}
+@property --un-ring-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-inset-ring-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-inset-shadow-color{syntax:"*";inherits:false;}
 @property --un-ring-color{syntax:"*";inherits:false;}
 @property --un-ring-inset{syntax:"*";inherits:false;}
 @property --un-ring-offset-color{syntax:"*";inherits:false;}
-@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
-@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initial-value:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-shadow-color{syntax:"*";inherits:false;}
-@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
 @property --un-inset-ring-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-inset-shadow-color{syntax:"*";inherits:false;}
 @property --un-ring-color{syntax:"*";inherits:false;}
 @property --un-ring-inset{syntax:"*";inherits:false;}
 @property --un-ring-offset-color{syntax:"*";inherits:false;}
-@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
-@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-shadow-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-inset-shadow-color{syntax:"*";inherits:false;}
-@property --un-ring-color{syntax:"*";inherits:false;}
-@property --un-ring-inset{syntax:"*";inherits:false;}
-@property --un-ring-offset-color{syntax:"*";inherits:false;}
-@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
-@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initial-value:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-shadow-color{syntax:"*";inherits:false;}
 @property --un-inset-ring-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-inset-shadow-color{syntax:"*";inherits:false;}
 @property --un-ring-color{syntax:"*";inherits:false;}
 @property --un-ring-inset{syntax:"*";inherits:false;}
 @property --un-ring-offset-color{syntax:"*";inherits:false;}
-@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
-@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-shadow-color{syntax:"*";inherits:false;}
-@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-inset-ring-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-inset-shadow-color{syntax:"*";inherits:false;}
-@property --un-ring-color{syntax:"*";inherits:false;}
-@property --un-ring-inset{syntax:"*";inherits:false;}
-@property --un-ring-offset-color{syntax:"*";inherits:false;}
-@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
-@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initial-value:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-shadow-color{syntax:"*";inherits:false;}
 @property --un-inset-ring-color{syntax:"*";inherits:false;}
-@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-inset-shadow-color{syntax:"*";inherits:false;}
 @property --un-ring-color{syntax:"*";inherits:false;}
 @property --un-ring-inset{syntax:"*";inherits:false;}
 @property --un-ring-offset-color{syntax:"*";inherits:false;}
-@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
-@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
-@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initial-value:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-shadow-color{syntax:"*";inherits:false;}
+@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-inset-ring-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-inset-shadow-color{syntax:"*";inherits:false;}
+@property --un-ring-color{syntax:"*";inherits:false;}
+@property --un-ring-inset{syntax:"*";inherits:false;}
+@property --un-ring-offset-color{syntax:"*";inherits:false;}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initial-value:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-shadow-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-inset-shadow-color{syntax:"*";inherits:false;}
+@property --un-ring-color{syntax:"*";inherits:false;}
+@property --un-ring-inset{syntax:"*";inherits:false;}
+@property --un-ring-offset-color{syntax:"*";inherits:false;}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initial-value:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initial-value:"0 0 #0000";}
 @property --un-shadow-color{syntax:"*";inherits:false;}
 @property --un-ease{syntax:"*";inherits:false;}
 @property --un-ease{syntax:"*";inherits:false;}
 @property --un-ease{syntax:"*";inherits:false;}
 @property --un-ease{syntax:"*";inherits:false;}
-@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-stroke-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-stroke-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-from-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-from-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-from-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-from-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-from-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-stops-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-to-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-to-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-to-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-to-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-to-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-via-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-via-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-via-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-via-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-via-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-drop-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-placeholder-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-scroll-snap-strictness{syntax:"*";inherits:false;initialValue:"proximity";}
-@property --un-scroll-snap-strictness{syntax:"*";inherits:false;initialValue:"proximity";}
-@property --un-scroll-snap-strictness{syntax:"*";inherits:false;initialValue:"proximity";}
-@property --un-space-x-reverse{syntax:"*";inherits:false;initialValue:0;}
-@property --un-space-x-reverse{syntax:"*";inherits:false;initialValue:0;}
-@property --un-space-x-reverse{syntax:"*";inherits:false;initialValue:0;}
-@property --un-space-x-reverse{syntax:"*";inherits:false;initialValue:0;}
-@property --un-space-y-reverse{syntax:"*";inherits:false;initialValue:0;}
-@property --un-space-x-reverse{syntax:"*";inherits:false;initialValue:0;}
-@property --un-divide-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-divide-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
-@property --un-border-style{syntax:"*";inherits:false;initialValue:"solid";}
-@property --un-divide-x-reverse{syntax:"*";inherits:false;initialValue:0;}
-@property --un-border-style{syntax:"*";inherits:false;initialValue:"solid";}
-@property --un-divide-x-reverse{syntax:"*";inherits:false;initialValue:0;}
-@property --un-border-style{syntax:"*";inherits:false;initialValue:"solid";}
-@property --un-divide-y-reverse{syntax:"*";inherits:false;initialValue:0;}
-@property --un-divide-x-reverse{syntax:"*";inherits:false;initialValue:0;}
+@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-stroke-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-stroke-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-from-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-from-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-from-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-from-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-from-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-stops-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-to-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-to-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-to-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-to-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-to-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-via-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-via-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-via-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-via-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-via-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-drop-shadow-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-placeholder-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-scroll-snap-strictness{syntax:"*";inherits:false;initial-value:"proximity";}
+@property --un-scroll-snap-strictness{syntax:"*";inherits:false;initial-value:"proximity";}
+@property --un-scroll-snap-strictness{syntax:"*";inherits:false;initial-value:"proximity";}
+@property --un-space-x-reverse{syntax:"*";inherits:false;initial-value:0;}
+@property --un-space-x-reverse{syntax:"*";inherits:false;initial-value:0;}
+@property --un-space-x-reverse{syntax:"*";inherits:false;initial-value:0;}
+@property --un-space-x-reverse{syntax:"*";inherits:false;initial-value:0;}
+@property --un-space-y-reverse{syntax:"*";inherits:false;initial-value:0;}
+@property --un-space-x-reverse{syntax:"*";inherits:false;initial-value:0;}
+@property --un-divide-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-divide-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
+@property --un-border-style{syntax:"*";inherits:false;initial-value:"solid";}
+@property --un-divide-x-reverse{syntax:"*";inherits:false;initial-value:0;}
+@property --un-border-style{syntax:"*";inherits:false;initial-value:"solid";}
+@property --un-divide-x-reverse{syntax:"*";inherits:false;initial-value:0;}
+@property --un-border-style{syntax:"*";inherits:false;initial-value:"solid";}
+@property --un-divide-y-reverse{syntax:"*";inherits:false;initial-value:0;}
+@property --un-divide-x-reverse{syntax:"*";inherits:false;initial-value:0;}
 /* layer: theme */
 :root, :host {
 --colors-gray: oklch(0.707 0.022 261.325);

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -1,3 +1,264 @@
+/* layer: cssvar-property */
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-leading{syntax:"*";inherits:false;}
+@property --un-leading{syntax:"*";inherits:false;}
+@property --un-leading{syntax:"*";inherits:false;}
+@property --un-leading{syntax:"*";inherits:false;}
+@property --un-leading{syntax:"*";inherits:false;}
+@property --un-leading{syntax:"*";inherits:false;}
+@property --un-leading{syntax:"*";inherits:false;}
+@property --un-text-stroke-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-text-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-outline-color-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-accent-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-caret-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-bg-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-line-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-line-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-line-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-line-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
+@property --un-content{syntax:"*";inherits:false;initialValue:"\"\"";}
+@property --un-ring-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-inset-ring-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow-color{syntax:"*";inherits:false;}
+@property --un-ring-color{syntax:"*";inherits:false;}
+@property --un-ring-inset{syntax:"*";inherits:false;}
+@property --un-ring-offset-color{syntax:"*";inherits:false;}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow-color{syntax:"*";inherits:false;}
+@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-inset-ring-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow-color{syntax:"*";inherits:false;}
+@property --un-ring-color{syntax:"*";inherits:false;}
+@property --un-ring-inset{syntax:"*";inherits:false;}
+@property --un-ring-offset-color{syntax:"*";inherits:false;}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow-color{syntax:"*";inherits:false;}
+@property --un-ring-color{syntax:"*";inherits:false;}
+@property --un-ring-inset{syntax:"*";inherits:false;}
+@property --un-ring-offset-color{syntax:"*";inherits:false;}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow-color{syntax:"*";inherits:false;}
+@property --un-ring-color{syntax:"*";inherits:false;}
+@property --un-ring-inset{syntax:"*";inherits:false;}
+@property --un-ring-offset-color{syntax:"*";inherits:false;}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow-color{syntax:"*";inherits:false;}
+@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-inset-ring-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow-color{syntax:"*";inherits:false;}
+@property --un-ring-color{syntax:"*";inherits:false;}
+@property --un-ring-inset{syntax:"*";inherits:false;}
+@property --un-ring-offset-color{syntax:"*";inherits:false;}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-color{syntax:"*";inherits:false;}
+@property --un-inset-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-inset-shadow-color{syntax:"*";inherits:false;}
+@property --un-ring-color{syntax:"*";inherits:false;}
+@property --un-ring-inset{syntax:"*";inherits:false;}
+@property --un-ring-offset-color{syntax:"*";inherits:false;}
+@property --un-ring-offset-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-ring-offset-width{syntax:"<length>";inherits:false;initialValue:"0px";}
+@property --un-ring-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow{syntax:"*";inherits:false;initialValue:"0 0 #0000";}
+@property --un-shadow-color{syntax:"*";inherits:false;}
+@property --un-ease{syntax:"*";inherits:false;}
+@property --un-ease{syntax:"*";inherits:false;}
+@property --un-ease{syntax:"*";inherits:false;}
+@property --un-ease{syntax:"*";inherits:false;}
+@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-fill-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-stroke-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-stroke-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-from-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-from-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-from-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-from-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-from-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-stops-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-to-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-to-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-to-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-to-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-to-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-via-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-via-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-via-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-via-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-via-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-drop-shadow-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-placeholder-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-scroll-snap-strictness{syntax:"*";inherits:false;initialValue:"proximity";}
+@property --un-scroll-snap-strictness{syntax:"*";inherits:false;initialValue:"proximity";}
+@property --un-scroll-snap-strictness{syntax:"*";inherits:false;initialValue:"proximity";}
+@property --un-space-x-reverse{syntax:"*";inherits:false;initialValue:0;}
+@property --un-space-x-reverse{syntax:"*";inherits:false;initialValue:0;}
+@property --un-space-x-reverse{syntax:"*";inherits:false;initialValue:0;}
+@property --un-space-x-reverse{syntax:"*";inherits:false;initialValue:0;}
+@property --un-space-y-reverse{syntax:"*";inherits:false;initialValue:0;}
+@property --un-space-x-reverse{syntax:"*";inherits:false;initialValue:0;}
+@property --un-divide-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-divide-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+@property --un-border-style{syntax:"*";inherits:false;initialValue:"solid";}
+@property --un-divide-x-reverse{syntax:"*";inherits:false;initialValue:0;}
+@property --un-border-style{syntax:"*";inherits:false;initialValue:"solid";}
+@property --un-divide-x-reverse{syntax:"*";inherits:false;initialValue:0;}
+@property --un-border-style{syntax:"*";inherits:false;initialValue:"solid";}
+@property --un-divide-y-reverse{syntax:"*";inherits:false;initialValue:0;}
+@property --un-divide-x-reverse{syntax:"*";inherits:false;initialValue:0;}
 /* layer: theme */
 :root, :host {
 --colors-gray: oklch(0.707 0.022 261.325);
@@ -94,7 +355,6 @@
 .font-size-1\.5rem{font-size:1.5rem;}
 .text-size-1em{font-size:1em;}
 .text-size-unset{font-size:unset;}
-@property --un-text-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .text-\[--variable\],
 .text-\[color\:--variable\],
 .text-\$variable{color:color-mix(in oklch, var(--variable) var(--un-text-opacity), transparent) /* var(--variable) */;}
@@ -204,7 +464,6 @@
 .group\/label:hover .group-hover\/label\:font-15{--un-font-weight:15;font-weight:15;}
 .font-leading-2,
 .leading-2{--un-leading:calc(var(--spacing) * 2);line-height:calc(var(--spacing) * 2);}
-@property --un-leading {syntax: "*";inherits: false;}
 .leading-\$variable,
 .lh-\$variable{--un-leading:var(--variable);line-height:var(--variable);}
 .leading-inherit{--un-leading:inherit;line-height:inherit;}
@@ -242,7 +501,6 @@
 .text-stroke-6{-webkit-text-stroke-width:6px;}
 .text-stroke-sm{-webkit-text-stroke-width:var(--text-stroke-width-sm);}
 .text-stroke-blue-500{-webkit-text-stroke-color:color-mix(in oklch, var(--colors-blue-500) var(--un-text-stroke-opacity), transparent) /* oklch(0.623 0.214 259.815) */;}
-@property --un-text-stroke-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .text-stroke-op-\$opacity-variable{--un-text-stroke-opacity:var(--opacity-variable);}
 .text-stroke-op-60{--un-text-stroke-opacity:60%;}
 .text-shadow{--un-text-shadow:0 0 1px var(--un-text-shadow-color, rgb(0 0 0 / 0.2)),0 0 1px var(--un-text-shadow-color, rgb(1 0 5 / 0.1));text-shadow:var(--un-text-shadow);}
@@ -250,7 +508,6 @@
 .text-shadow-lg{--un-text-shadow:3px 3px 6px var(--un-text-shadow-color, rgb(0 0 0 / 0.26)),0 0 5px var(--un-text-shadow-color, rgb(15 3 86 / 0.22));text-shadow:var(--un-text-shadow);}
 .text-shadow-none{--un-text-shadow:0 0 var(--un-text-shadow-color, rgb(0 0 0 / 0));text-shadow:var(--un-text-shadow);}
 .text-shadow-color-red-300{--un-text-shadow-color:color-mix(in oklch, var(--colors-red-300) var(--un-text-shadow-opacity), transparent) /* oklch(0.808 0.114 19.571) */;}
-@property --un-text-shadow-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .text-shadow-color-op-\$opacity-variable{--un-text-shadow-opacity:var(--opacity-variable);}
 .text-shadow-color-op-30{--un-text-shadow-opacity:30%;}
 .group:not([data-potato]) .group-not-\[\[data-potato\]\]\:m-1,
@@ -362,7 +619,6 @@
 .outline-width-10px{outline-style:var(--un-outline-style);outline-width:10px;}
 .outline-width-revert{outline-style:var(--un-outline-style);outline-width:revert;}
 .outline-\[calc\(1rem-1px\)\]{outline-style:var(--un-outline-style);outline-width:calc(1rem - 1px);}
-@property --un-outline-color-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .outline-\[var\(--red\)\]{outline-color:color-mix(in oklch, var(--red) var(--un-outline-color-opacity), transparent) /* var(--red) */;}
 .outline-\$variable{outline-color:color-mix(in oklch, var(--variable) var(--un-outline-color-opacity), transparent) /* var(--variable) */;}
 .outline-gray{outline-color:color-mix(in oklch, var(--colors-gray) var(--un-outline-color-opacity), transparent) /* oklch(0.707 0.022 261.325) */;}
@@ -396,10 +652,8 @@
 .list-image-\[url\(https\:\/\/test\.unocss\.png\)\]{list-style-image:url(https://test.unocss.png);}
 .list-image-none{list-style-image:none;}
 .list-inherit{list-style-type:inherit;}
-@property --un-accent-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .accent-red{accent-color:color-mix(in oklch, var(--colors-red) var(--un-accent-opacity), transparent) /* oklch(0.704 0.191 22.216) */;}
 .accent-op-90{--un-accent-opacity:90%;}
-@property --un-caret-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .caret-red{caret-color:color-mix(in oklch, var(--colors-red) var(--un-caret-opacity), transparent) /* oklch(0.704 0.191 22.216) */;}
 .caret-op-90{--un-caret-opacity:90%;}
 .image-render-pixel{-ms-interpolation-mode:nearest-neighbor;image-rendering:-webkit-optimize-contrast;image-rendering:-moz-crisp-edges;image-rendering:-o-pixelated;image-rendering:pixelated;}
@@ -435,7 +689,7 @@
 .border-s-width-\$variable{border-inline-start-width:var(--variable);}
 .border-t-width-3{border-top-width:3px;}
 .b-block-size-\$variable{border-block-start-width:var(--variable);border-block-end-width:var(--variable);}
-@property --un-border-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
+[object Object]
 .border-\[\#124\]{border-color:color-mix(in oklch, #124 var(--un-border-opacity), transparent);}
 .border-\[calc\(10px\+1px\)\]{border-width:calc(10px + 1px);}
 .border-\[calc\(var\(--border-width\)\*1px\)\]{border-width:calc(var(--border-width) * 1px);}
@@ -513,7 +767,6 @@
 .border-block-style-double{--un-border-style:double;border-block-start-style:double;border-block-end-style:double;}
 .border-ie-unset{--un-border-style:unset;border-inline-end-style:unset;}
 .border-is-style-double{--un-border-style:double;border-inline-start-style:double;}
-@property --un-bg-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .bg-\[--css-spacing\,theme\(spacing\.sm\)\]{background-color:color-mix(in oklch, var(--css-spacing,calc(var(--spacing) * 3.5)) var(--un-bg-opacity), transparent) /* var(--css-spacing,calc(var(--spacing) * 3.5)) */;}
 .bg-\[--test-variable\],
 .bg-\$test-variable{background-color:color-mix(in oklch, var(--test-variable) var(--un-bg-opacity), transparent) /* var(--test-variable) */;}
@@ -598,7 +851,6 @@
 .decoration-\[calc\(1rem-1px\)\],
 .underline-\[calc\(1rem-1px\)\]{text-decoration-thickness:calc(1rem - 1px);}
 .decoration-purple\/50{--un-line-opacity:50%;text-decoration-color:color-mix(in oklch, var(--colors-purple) var(--un-line-opacity), transparent) /* oklch(0.714 0.203 305.504) */;-webkit-text-decoration-color:color-mix(in oklch, var(--colors-purple) var(--un-line-opacity), transparent) /* oklch(0.714 0.203 305.504) */;}
-@property --un-line-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .decoration-transparent{text-decoration-color:transparent;-webkit-text-decoration-color:transparent;}
 .data-\[invalid\~\=grammar\]\:underline-green-600[data-invalid~=grammar]{text-decoration-color:color-mix(in oklch, var(--colors-green-600) var(--un-line-opacity), transparent) /* oklch(0.627 0.194 149.214) */;-webkit-text-decoration-color:color-mix(in oklch, var(--colors-green-600) var(--un-line-opacity), transparent) /* oklch(0.627 0.194 149.214) */;}
 .underline-red-500{text-decoration-color:color-mix(in oklch, var(--colors-red-500) var(--un-line-opacity), transparent) /* oklch(0.637 0.237 25.331) */;-webkit-text-decoration-color:color-mix(in oklch, var(--colors-red-500) var(--un-line-opacity), transparent) /* oklch(0.637 0.237 25.331) */;}
@@ -817,10 +1069,10 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .contain-\[size_layout_paint\]{contain:size layout paint;}
 .contain-\[size_layout\]{contain:size layout;}
 .contain-layout{--un-contain-size:layout;contain:var(--un-contain-size) var(--un-contain-layout) var(--un-contain-paint) var(--un-contain-style);}
-@property --un-contain-size {syntax: "*";inherits: false;}
-@property --un-contain-layout {syntax: "*";inherits: false;}
-@property --un-contain-paint {syntax: "*";inherits: false;}
-@property --un-contain-style {syntax: "*";inherits: false;}
+[object Object]
+[object Object]
+[object Object]
+[object Object]
 .pointer-events-auto{pointer-events:auto;}
 .pointer-events-none{pointer-events:none;}
 .pointer-events-unset{pointer-events:unset;}
@@ -843,7 +1095,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .content-visibility-auto{content-visibility:auto;}
 .content-visibility-unset{content-visibility:unset;}
 .content-\[\'quoted_with_space\'\]{--un-content:'quoted with space';content:var(--un-content);}
-@property --un-content {syntax: "*";inherits: false;initial-value: "";}
 .content-\[\'quoted1\'\]{--un-content:'quoted1';content:var(--un-content);}
 .content-\[\"quoted2\"\]{--un-content:"quoted2";content:var(--un-content);}
 .content-\[normal\]{--un-content:normal;content:var(--un-content);}
@@ -875,21 +1126,20 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;}
 .ring,
 .ring-px{--un-ring-shadow:var(--un-ring-inset,) 0 0 0 calc(1px + var(--un-ring-offset-width)) var(--un-ring-color, currentColor);box-shadow:var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}
-@property --un-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
-@property --un-shadow-color {syntax: "*";inherits: false;}
-@property --un-inset-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
-@property --un-inset-shadow-color {syntax: "*";inherits: false;}
-@property --un-ring-color {syntax: "*";inherits: false;}
-@property --un-ring-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
-@property --un-inset-ring-color {syntax: "*";inherits: false;}
-@property --un-inset-ring-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
-@property --un-ring-inset {syntax: "*";inherits: false;}
-@property --un-ring-offset-width {syntax: "<length>";inherits: false;initial-value: 0px;}
-@property --un-ring-offset-color {syntax: "*";inherits: false;}
-@property --un-ring-offset-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
 .ring-10{--un-ring-shadow:var(--un-ring-inset,) 0 0 0 calc(10px + var(--un-ring-offset-width)) var(--un-ring-color, currentColor);box-shadow:var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}
 .ring-\[calc\(1rem-1px\)\]{--un-ring-color:color-mix(in oklch, calc(1rem - 1px) var(--un-ring-opacity), transparent) /* calc(1rem - 1px) */;}
-@property --un-ring-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .ring-op-\$opacity-variable{--un-ring-opacity:var(--opacity-variable);}
 .ring-op-5{--un-ring-opacity:5%;}
 .ring-offset{--un-ring-offset-width:1px;--un-ring-offset-shadow:var(--un-ring-inset,) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);}
@@ -901,20 +1151,7 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .ring-offset-4{--un-ring-offset-width:4px;}
 .ring-inset{--un-ring-inset:inset;}
 .shadow{--un-shadow:0 1px 3px 0 var(--un-shadow-color, rgb(0 0 0 / 0.1)),0 1px 2px -1px var(--un-shadow-color, rgb(0 0 0 / 0.1));box-shadow:var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}
-@property --un-inset-ring-color {syntax: "*";inherits: false;}
-@property --un-inset-ring-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
-@property --un-inset-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
-@property --un-inset-shadow-color {syntax: "*";inherits: false;}
-@property --un-ring-color {syntax: "*";inherits: false;}
-@property --un-ring-inset {syntax: "*";inherits: false;}
-@property --un-ring-offset-color {syntax: "*";inherits: false;}
-@property --un-ring-offset-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
-@property --un-ring-offset-width {syntax: "<length>";inherits: false;initial-value: 0px;}
-@property --un-ring-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
-@property --un-shadow {syntax: "*";inherits: false;initial-value: 0 0 #0000;}
-@property --un-shadow-color {syntax: "*";inherits: false;}
 .shadow-\[\#fff\]{--un-shadow-color:color-mix(in oklch, #fff var(--un-shadow-opacity), transparent) /* #fff */;}
-@property --un-shadow-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .shadow-\[0px_4px_4px_0px_rgba\(237\,_0\,_0\,_1\)\]{--un-shadow:0px 4px 4px 0px var(--un-shadow-color, rgba(237, 0, 0, 1));box-shadow:var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}
 .shadow-\[0px_4px_4px_0px_rgba\(238_0_0\/1\)\]{--un-shadow:0px 4px 4px 0px var(--un-shadow-color, rgba(238, 0, 0, 1));box-shadow:var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}
 .shadow-\$variable{--un-shadow:var(--variable);box-shadow:var(--un-inset-shadow), var(--un-inset-ring-shadow), var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}
@@ -939,9 +1176,9 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .perspect-origin-center{perspective-origin:center;}
 .perspect-origin-top-right{perspective-origin:top right;}
 .translate-\[var\(--x\)\,var\(--y\)\,25\%\]{--un-translate-x:var(--x);--un-translate-y:var(--y);--un-translate-z:25%;translate:var(--un-translate-x) var(--un-translate-y);}
-@property --un-translate-x {syntax: "*";inherits: false;initial-value: 0;}
-@property --un-translate-y {syntax: "*";inherits: false;initial-value: 0;}
-@property --un-translate-z {syntax: "*";inherits: false;initial-value: 0;}
+[object Object]
+[object Object]
+[object Object]
 .translate-\[var\(--x\)\,var\(--y\)\]{--un-translate-x:var(--x);--un-translate-y:var(--y);translate:var(--un-translate-x) var(--un-translate-y);}
 .scope_class .scope-\[\.scope\\_class\]\:translate-0{--un-translate-x:calc(var(--spacing) * 0);--un-translate-y:calc(var(--spacing) * 0);translate:var(--un-translate-x) var(--un-translate-y);}
 .translate-none{translate:none;}
@@ -954,11 +1191,8 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .rotate-1deg{rotate:1deg;}
 .-rotate-2{rotate:-2deg;}
 .rotate-x-\$variable{--un-rotate-x:var(--variable);transform:var(--un-rotate-x) var(--un-rotate-y) var(--un-rotate-z) var(--un-skew-x) var(--un-skew-y);}
-@property --un-rotate-x {syntax: "*";inherits: false;initial-value: rotateX(0);}
-@property --un-rotate-y {syntax: "*";inherits: false;initial-value: rotateY(0);}
-@property --un-rotate-z {syntax: "*";inherits: false;initial-value: rotateZ(0);}
-@property --un-skew-x {syntax: "*";inherits: false;initial-value: skewX(0);}
-@property --un-skew-y {syntax: "*";inherits: false;initial-value: skewY(0);}
+[object Object]
+[object Object]
 .rotate-x-1deg{--un-rotate-x:rotateX(1deg);transform:var(--un-rotate-x) var(--un-rotate-y) var(--un-rotate-z) var(--un-skew-x) var(--un-skew-y);}
 .rotate-y-1,
 .transform-rotate-y-1{--un-rotate-y:rotateY(1deg);transform:var(--un-rotate-x) var(--un-rotate-y) var(--un-rotate-z) var(--un-skew-x) var(--un-skew-y);}
@@ -982,9 +1216,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .skew-y-2grad{--un-skew-y:2grad;transform:var(--un-rotate-x) var(--un-rotate-y) var(--un-rotate-z) var(--un-skew-x) var(--un-skew-y);}
 .skew-y-3\.14rad{--un-skew-y:3.14rad;transform:var(--un-rotate-x) var(--un-rotate-y) var(--un-rotate-z) var(--un-skew-x) var(--un-skew-y);}
 .scale-\[var\(--x\)\,var\(--y\)\,20\%\]{--un-scale-x:var(--x);--un-scale-y:var(--y);--un-scale-z:20%;scale:var(--un-scale-x) var(--un-scale-y);}
-@property --un-scale-x {syntax: "*";inherits: false;initial-value: 1;}
-@property --un-scale-y {syntax: "*";inherits: false;initial-value: 1;}
-@property --un-scale-z {syntax: "*";inherits: false;initial-value: 1;}
 .scale-\[var\(--x\)\,var\(--y\)\]{--un-scale-x:var(--x);--un-scale-y:var(--y);scale:var(--un-scale-x) var(--un-scale-y);}
 .scale-\$variable{--un-scale-x:var(--variable);--un-scale-y:var(--variable);scale:var(--un-scale-x) var(--un-scale-y);}
 .hover\:scale-4:hover{--un-scale-x:4%;--un-scale-y:4%;scale:var(--un-scale-x) var(--un-scale-y);}
@@ -1014,7 +1245,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .transition-delay-\$variable{transition-delay:var(--variable);}
 .transition-delay-300{transition-delay:300ms;}
 .ease-\$variable{--un-ease:var(--variable);transition-timing-function:var(--variable);}
-@property --un-ease {syntax: "*";inherits: false;}
 .ease-linear{--un-ease:var(--ease-linear);transition-timing-function:var(--ease-linear);}
 .ease-out{--un-ease:var(--ease-out);transition-timing-function:var(--ease-out);}
 .transition-ease-in{--un-ease:var(--ease-in);transition-timing-function:var(--ease-in);}
@@ -1144,7 +1374,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .of-y-visible{overflow-y:visible;}
 .overflow-x-scroll{overflow-x:scroll;}
 .overflow-y-clip{overflow-y:clip;}
-@property --un-fill-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .fill-\[\#123\]{fill:color-mix(in oklch, #123 var(--un-fill-opacity), transparent) /* #123 */;}
 .fill-current{fill:currentColor;}
 .fill-green-400{fill:color-mix(in oklch, var(--colors-green-400) var(--un-fill-opacity), transparent) /* oklch(0.792 0.209 151.711) */;}
@@ -1169,7 +1398,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .stroke-offset-\$variable{stroke-dashoffset:var(--variable);}
 .stroke-offset-1,
 .stroke-offset-1px{stroke-dashoffset:1px;}
-@property --un-stroke-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .stroke-\[\#123\]{stroke:color-mix(in oklch, #123 var(--un-stroke-opacity), transparent) /* #123 */;}
 .stroke-\[calc\(1rem-1px\)\]{stroke-width:calc(1rem - 1px);}
 .stroke-current{stroke:currentColor;}
@@ -1230,26 +1458,23 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .animate-inherit{animation:inherit;}
 .animate-unset{animation:unset;}
 .bg-linear-\[70deg\,blue\,pink\]{--un-gradient-position:70deg,blue,pink;background-image:linear-gradient(var(--un-gradient-stops));}
-@property --un-from-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .from-\$bg-from{--un-gradient-from:color-mix(in oklab, var(--bg-from) var(--un-from-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
-@property --un-gradient-position {syntax: "*";inherits: false;}
-@property --un-gradient-from {syntax: "<color>";inherits: false;initial-value: #0000;}
-@property --un-gradient-via {syntax: "<color>";inherits: false;initial-value: #0000;}
-@property --un-gradient-to {syntax: "<color>";inherits: false;initial-value: #0000;}
-@property --un-gradient-stops {syntax: "*";inherits: false;}
-@property --un-gradient-via-stops {syntax: "*";inherits: false;}
-@property --un-gradient-from-position {syntax: "<length-percentage>";inherits: false;initial-value: 0%;}
-@property --un-gradient-via-position {syntax: "<length-percentage>";inherits: false;initial-value: 50%;}
-@property --un-gradient-to-position {syntax: "<length-percentage>";inherits: false;initial-value: 100%;}
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
 .from-current{--un-gradient-from:currentColor;--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
 .from-green-500{--un-gradient-from:color-mix(in oklab, var(--colors-green-500) var(--un-from-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
 .from-green-500\/50{--un-from-opacity:50%;--un-gradient-from:color-mix(in oklab, var(--colors-green-500) var(--un-from-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
 .from-green-600{--un-gradient-from:color-mix(in oklab, var(--colors-green-600) var(--un-from-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
 .from-green-600\/60{--un-from-opacity:60%;--un-gradient-from:color-mix(in oklab, var(--colors-green-600) var(--un-from-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
 .from-transparent{--un-gradient-from:transparent;--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
-@property --un-stops-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .stops-\[blue\,pink\]{--un-gradient-stops:color-mix(in oklab, blue,pink var(--un-stops-opacity), transparent);}
-@property --un-to-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .to-\$bg-to{--un-gradient-to:color-mix(in oklab, var(--bg-to) var(--un-to-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
 .to-current{--un-gradient-to:currentColor;--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
 .to-green-500{--un-gradient-to:color-mix(in oklab, var(--colors-green-500) var(--un-to-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
@@ -1257,7 +1482,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .to-green-600{--un-gradient-to:color-mix(in oklab, var(--colors-green-600) var(--un-to-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
 .to-green-600\/60{--un-to-opacity:60%;--un-gradient-to:color-mix(in oklab, var(--colors-green-600) var(--un-to-opacity), transparent);--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
 .to-transparent{--un-gradient-to:transparent;--un-gradient-stops:var(--un-gradient-via-stops, var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-to) var(--un-gradient-to-position));}
-@property --un-via-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .via-\$bg-via{--un-gradient-via:color-mix(in oklab, var(--bg-via) var(--un-via-opacity), transparent);--un-gradient-via-stops:var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-via) var(--un-gradient-via-position), var(--un-gradient-to) var(--un-gradient-to-position);--un-gradient-stops:var(--un-gradient-via-stops);}
 .via-current{--un-gradient-via:currentColor;--un-gradient-via-stops:var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-via) var(--un-gradient-via-position), var(--un-gradient-to) var(--un-gradient-to-position);--un-gradient-stops:var(--un-gradient-via-stops);}
 .via-green-500{--un-gradient-via:color-mix(in oklab, var(--colors-green-500) var(--un-via-opacity), transparent);--un-gradient-via-stops:var(--un-gradient-position), var(--un-gradient-from) var(--un-gradient-from-position), var(--un-gradient-via) var(--un-gradient-via-position), var(--un-gradient-to) var(--un-gradient-to-position);--un-gradient-stops:var(--un-gradient-via-stops);}
@@ -1342,29 +1566,11 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .break-after-column{break-after:column;}
 .break-after-unset{break-after:unset;}
 .backdrop-blur{--un-backdrop-blur:blur(8px);-webkit-backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);}
-@property --un-backdrop-blur {syntax: "*";inherits: false;}
-@property --un-backdrop-brightness {syntax: "*";inherits: false;}
-@property --un-backdrop-contrast {syntax: "*";inherits: false;}
-@property --un-backdrop-grayscale {syntax: "*";inherits: false;}
-@property --un-backdrop-hue-rotate {syntax: "*";inherits: false;}
-@property --un-backdrop-invert {syntax: "*";inherits: false;}
-@property --un-backdrop-opacity {syntax: "*";inherits: false;}
-@property --un-backdrop-saturate {syntax: "*";inherits: false;}
-@property --un-backdrop-sepia {syntax: "*";inherits: false;}
 .backdrop-blur-4{--un-backdrop-blur:blur(4px);-webkit-backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);}
 .backdrop-blur-md{--un-backdrop-blur:blur(12px);-webkit-backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);}
 .backdrop-blur-none{--un-backdrop-blur:blur(0);-webkit-backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);}
 .blur,
 .filter-blur{--un-blur:blur(8px);filter:var(--un-blur,) var(--un-brightness,) var(--un-contrast,) var(--un-grayscale,) var(--un-hue-rotate,) var(--un-invert,) var(--un-saturate,) var(--un-sepia,) var(--un-drop-shadow,);}
-@property --un-blur {syntax: "*";inherits: false;}
-@property --un-brightness {syntax: "*";inherits: false;}
-@property --un-contrast {syntax: "*";inherits: false;}
-@property --un-grayscale {syntax: "*";inherits: false;}
-@property --un-hue-rotate {syntax: "*";inherits: false;}
-@property --un-invert {syntax: "*";inherits: false;}
-@property --un-saturate {syntax: "*";inherits: false;}
-@property --un-sepia {syntax: "*";inherits: false;}
-@property --un-drop-shadow {syntax: "*";inherits: false;}
 .blur-\$variable{--un-blur:blur(var(--variable));filter:var(--un-blur,) var(--un-brightness,) var(--un-contrast,) var(--un-grayscale,) var(--un-hue-rotate,) var(--un-invert,) var(--un-saturate,) var(--un-sepia,) var(--un-drop-shadow,);}
 .blur-4,
 .filter-blur-4{--un-blur:blur(4px);filter:var(--un-blur,) var(--un-brightness,) var(--un-contrast,) var(--un-grayscale,) var(--un-hue-rotate,) var(--un-invert,) var(--un-saturate,) var(--un-sepia,) var(--un-drop-shadow,);}
@@ -1386,7 +1592,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .drop-shadow-none{--un-drop-shadow:;filter:var(--un-blur,) var(--un-brightness,) var(--un-contrast,) var(--un-grayscale,) var(--un-hue-rotate,) var(--un-invert,) var(--un-saturate,) var(--un-sepia,) var(--un-drop-shadow,);}
 .drop-shadow-sm{--un-drop-shadow:drop-shadow(0 1px 2px var(--un-drop-shadow-color, rgb(0 0 0 / 0.15)));filter:var(--un-blur,) var(--un-brightness,) var(--un-contrast,) var(--un-grayscale,) var(--un-hue-rotate,) var(--un-invert,) var(--un-saturate,) var(--un-sepia,) var(--un-drop-shadow,);}
 .drop-shadow-color-red-300{--un-drop-shadow-color:color-mix(in oklch, var(--colors-red-300) var(--un-drop-shadow-opacity), transparent) /* oklch(0.808 0.114 19.571) */;}
-@property --un-drop-shadow-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .drop-shadow-color-op-30{--un-drop-shadow-opacity:30%;}
 .backdrop-grayscale{--un-backdrop-grayscale:grayscale(100%);-webkit-backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);}
 .backdrop-grayscale-90{--un-backdrop-grayscale:grayscale(90%);-webkit-backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);}
@@ -1429,10 +1634,8 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .line-clamp-100{overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:100;}
 .line-clamp-7{overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:7;}
 .line-clamp-none{overflow:visible;display:block;-webkit-box-orient:horizontal;-webkit-line-clamp:unset;}
-@property --un-placeholder-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .placeholder-red-400::placeholder{color:color-mix(in oklch, var(--colors-red-400) var(--un-placeholder-opacity), transparent) /* oklch(0.704 0.191 22.216) */;}
 .placeholder-opacity-60::placeholder{--un-placeholder-opacity:60%;}
-@property --un-scroll-snap-strictness {syntax: "*";inherits: false;initial-value: proximity;}
 .snap-both{scroll-snap-type:both var(--un-scroll-snap-strictness);}
 .snap-y{scroll-snap-type:y var(--un-scroll-snap-strictness);}
 .snap-mandatory{--un-scroll-snap-strictness:mandatory;}
@@ -1463,8 +1666,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .border-collapse{border-collapse:collapse;}
 .border-separate{border-collapse:separate;}
 .border-spacing-\[3px\]{--un-border-spacing-x:3px;--un-border-spacing-y:3px;border-spacing:var(--un-border-spacing-x) var(--un-border-spacing-y);}
-@property --un-border-spacing-x {syntax: "<length>";inherits: false;initial-value: 0;}
-@property --un-border-spacing-y {syntax: "<length>";inherits: false;initial-value: 0;}
 .border-spacing-\$var{--un-border-spacing-x:var(--var);--un-border-spacing-y:var(--var);border-spacing:var(--un-border-spacing-x) var(--un-border-spacing-y);}
 .border-spacing-0{--un-border-spacing-x:calc(var(--spacing) * 0);--un-border-spacing-y:calc(var(--spacing) * 0);border-spacing:var(--un-border-spacing-x) var(--un-border-spacing-y);}
 .border-spacing-x-\[3px\]{--un-border-spacing-x:3px;border-spacing:var(--un-border-spacing-x) var(--un-border-spacing-y);}
@@ -1475,43 +1676,34 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .table-empty-cells-visible{empty-cells:show;}
 .table-empty-cells-hidden{empty-cells:hide;}
 .touch-pan-left{--un-pan-x:pan-left;touch-action:var(--un-pan-x) var(--un-pan-y) var(--un-pinch-zoom);}
-@property --un-pan-x {syntax: "*";inherits: false;}
-@property --un-pan-y {syntax: "*";inherits: false;}
-@property --un-pinch-zoom {syntax: "*";inherits: false;}
 .touch-pan-y{--un-pan-y:pan-y;touch-action:var(--un-pan-x) var(--un-pan-y) var(--un-pinch-zoom);}
 .touch-pinch-zoom{--un-pinch-zoom:pinch-zoom;touch-action:var(--un-pan-x) var(--un-pan-y) var(--un-pinch-zoom);}
 .touch-manipulation{touch-action:manipulation;}
 .touch-none{touch-action:none;}
 .touch-initial{touch-action:initial;}
 .lining-nums{--un-numeric-figure:lining-nums;font-variant-numeric:var(--un-ordinal) var(--un-slashed-zero) var(--un-numeric-figure) var(--un-numeric-spacing) var(--un-numeric-fraction);}
-@property --un-ordinal {syntax: "*";inherits: false;}
-@property --un-slashed-zero {syntax: "*";inherits: false;}
-@property --un-numeric-figure {syntax: "*";inherits: false;}
-@property --un-numeric-spacing {syntax: "*";inherits: false;}
-@property --un-numeric-fraction {syntax: "*";inherits: false;}
+[object Object]
+[object Object]
+[object Object]
+[object Object]
+[object Object]
 .tabular-nums{--un-numeric-spacing:tabular-nums;font-variant-numeric:var(--un-ordinal) var(--un-slashed-zero) var(--un-numeric-figure) var(--un-numeric-spacing) var(--un-numeric-fraction);}
 .normal-nums{font-variant-numeric:normal;}
 .view-transition-foo{view-transition-name:foo;}
 .view-transition-none{view-transition-name:none;}
 .space-x-\[var\(--space\)\]>:not(:last-child),
 .space-x-\$space>:not(:last-child){--un-space-x-reverse:0;margin-inline-start: calc(var(--space) * var(--un-space-x-reverse));margin-inline-end: calc(var(--space) * calc(1 - var(--un-space-x-reverse)));}
-@property --un-space-x-reverse {syntax: "*";inherits: false;initial-value: 0;}
 .space-x-2>:not(:last-child){--un-space-x-reverse:0;margin-inline-start: calc(calc(var(--spacing) * 2) * var(--un-space-x-reverse));margin-inline-end: calc(calc(var(--spacing) * 2) * calc(1 - var(--un-space-x-reverse)));}
 .space-y-4>:not(:last-child){--un-space-y-reverse:0;margin-block-start: calc(calc(var(--spacing) * 4) * var(--un-space-y-reverse));margin-block-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--un-space-y-reverse)));}
-@property --un-space-y-reverse {syntax: "*";inherits: false;initial-value: 0;}
 .space-x-reverse>:not(:last-child){--un-space-x-reverse:1;}
-@property --un-divide-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
 .divide-\$variable>:not(:last-child){border-color:color-mix(in oklch, var(--variable) var(--un-divide-opacity), transparent) /* var(--variable) */;}
 .divide-current>:not(:last-child){border-color:currentColor;}
 .divide-green-500>:not(:last-child){border-color:color-mix(in oklch, var(--colors-green-500) var(--un-divide-opacity), transparent) /* oklch(0.723 0.219 149.579) */;}
 .divide-transparent>:not(:last-child){border-color:transparent;}
 .divide-opacity-50>:not(:last-child){--un-divide-opacity:50%;}
 .divide-x-\$variable>:not(:last-child){--un-divide-x-reverse:0;border-left-width:calc(var(--variable) * var(--un-divide-x-reverse));border-left-style:var(--un-border-style);border-right-width:calc(var(--variable) * calc(1 - var(--un-divide-x-reverse)));border-right-style:var(--un-border-style);}
-@property --un-border-style {syntax: "*";inherits: false;initial-value: solid;}
-@property --un-divide-x-reverse {syntax: "*";inherits: false;initial-value: 0;}
 .divide-x-4>:not(:last-child){--un-divide-x-reverse:0;border-left-width:calc(4px * var(--un-divide-x-reverse));border-left-style:var(--un-border-style);border-right-width:calc(4px * calc(1 - var(--un-divide-x-reverse)));border-right-style:var(--un-border-style);}
 .divide-y-4>:not(:last-child){--un-divide-y-reverse:0;border-top-width:calc(4px * var(--un-divide-y-reverse));border-top-style:var(--un-border-style);border-bottom-width:calc(4px * calc(1 - var(--un-divide-y-reverse)));border-bottom-style:var(--un-border-style);}
-@property --un-divide-y-reverse {syntax: "*";inherits: false;initial-value: 0;}
 .divide-x-reverse>:not(:last-child){--un-divide-x-reverse:1;}
 .divide-dashed>:not(:last-child){border-style:dashed;}
 .divide-dotted>:not(:last-child){border-style:dotted;}

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -162,7 +162,7 @@ describe('preset-wind4', () => {
     const { css } = await uno.generate('c-foo')
     expect(css).toMatchInlineSnapshot(`
       "/* layer: cssvar-property */
-      @property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+      @property --un-text-opacity{syntax:"<percentage>";inherits:false;initial-value:"100%";}
       /* layer: theme */
       :root, :host {
       --colors-foo: var(--colors-bar);

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -161,7 +161,9 @@ describe('preset-wind4', () => {
 
     const { css } = await uno.generate('c-foo')
     expect(css).toMatchInlineSnapshot(`
-      "/* layer: theme */
+      "/* layer: cssvar-property */
+      @property --un-text-opacity{syntax:"<percentage>";inherits:false;initialValue:"100%";}
+      /* layer: theme */
       :root, :host {
       --colors-foo: var(--colors-bar);
       --colors-bar: var(--colors-baz-bcd, #000);
@@ -169,7 +171,6 @@ describe('preset-wind4', () => {
       --colors-test: #fff;
       }
       /* layer: default */
-      @property --un-text-opacity {syntax: "<percentage>";inherits: false;initial-value: 100%;}
       .c-foo{color:color-mix(in oklch, var(--colors-foo) var(--un-text-opacity), transparent) /* var(--colors-bar) */;}"
     `)
   })


### PR DESCRIPTION
WIP, I need to implement a way to make `noMerge` check for exact duplications

This PR introduces `symbols.noMerge`, and converts `defineProperty` from raw rules to CSS object

--- 

Another approach might be that we make it possible to assign layers to raw rules