### PR TITLE
perf(preset-wind4): hoist remRE

### DIFF
--- a/packages-presets/preset-wind4/src/utils/handlers/index.ts
+++ b/packages-presets/preset-wind4/src/utils/handlers/index.ts
@@ -5,5 +5,3 @@ export const handler = createValueHandler(valueHandlers)
 export const h = handler
 
 export { valueHandlers }
-
-export * from './regex'

--- a/packages-presets/preset-wind4/src/utils/handlers/index.ts
+++ b/packages-presets/preset-wind4/src/utils/handlers/index.ts
@@ -5,3 +5,5 @@ export const handler = createValueHandler(valueHandlers)
 export const h = handler
 
 export { valueHandlers }
+
+export * from './regex'

--- a/packages-presets/preset-wind4/src/utils/handlers/regex.ts
+++ b/packages-presets/preset-wind4/src/utils/handlers/regex.ts
@@ -14,3 +14,4 @@ export const unitOnlyMap: Record<string, number> = {
 }
 export const bracketTypeRe = /^\[(color|image|length|size|position|quoted|string):/i
 export const splitComma = /,(?![^()]*\))/g
+export const remRE = /(-?[.\d]+)rem/g

--- a/packages-presets/preset-wind4/src/utils/unit-resolver.ts
+++ b/packages-presets/preset-wind4/src/utils/unit-resolver.ts
@@ -1,5 +1,5 @@
 import type { CSSEntry } from '@unocss/core'
-import { remRE } from './handlers'
+import { remRE } from './handlers/regex'
 
 export function createRemToPxResolver(base: number = 16) {
   return (utility: CSSEntry) => {

--- a/packages-presets/preset-wind4/src/utils/unit-resolver.ts
+++ b/packages-presets/preset-wind4/src/utils/unit-resolver.ts
@@ -1,8 +1,8 @@
 import type { CSSEntry } from '@unocss/core'
+import { remRE } from './handlers'
 
 export function createRemToPxResolver(base: number = 16) {
   return (utility: CSSEntry) => {
-    const remRE = /(-?[.\d]+)rem/g
     if (typeof utility[1] === 'string' && remRE.test(utility[1]))
       utility[1] = utility[1].replace(remRE, (_, p1) => `${p1 * base}px`)
   }


### PR DESCRIPTION
The regular expression object gets recreated every time the resolver function is called, which is less efficient than reusing the imported regex from ./handlers.