### PR TITLE
fix(preset-mini): handle nested named groups containing hyphens

### DIFF
--- a/packages-presets/preset-mini/src/_variants/pseudo.test.ts
+++ b/packages-presets/preset-mini/src/_variants/pseudo.test.ts
@@ -1,6 +1,6 @@
 import { createGenerator } from '@unocss/core'
 import { expect, it } from 'vitest'
-import { variantPseudoClassesAndElements } from './pseudo'
+import { variantPseudoClassesAndElements, variantTaggedPseudoClasses } from './pseudo'
 
 // https://github.com/unocss/unocss/issues/2713
 it('pseudo variant order', async () => {
@@ -79,4 +79,34 @@ it('focus-visible:', async () => {
       .focus\\:foo-2:focus{text:foo-2;}
       .focus-visible\\:foo-1:focus-visible{text:foo-1;}"
     `)
+})
+
+it('nested named groups containing hyphens', async () => {
+  const uno = await createGenerator({
+    variants: [
+      ...variantTaggedPseudoClasses(),
+    ],
+    rules: [
+      [/^foo-(\d)$/, ([_, a]) => ({ text: `foo-${a}` })],
+    ],
+  })
+
+  const result = await uno.generate([
+    'group-hover/named:foo-1',
+    'group-hover/named-group:foo-2',
+  ])
+
+  expect(result.matched)
+    .toMatchInlineSnapshot(`
+      Set {
+        "group-hover/named:foo-1",
+        "group-hover/named-group:foo-2",
+      }
+    `)
+
+  expect(result.css).toMatchInlineSnapshot(`
+    "/* layer: default */
+    .group\\/named-group:hover .group-hover\\/named-group\\:foo-2{text:foo-2;}
+    .group\\/named:hover .group-hover\\/named\\:foo-1{text:foo-1;}"
+  `)
 })

--- a/packages-presets/preset-mini/src/_variants/pseudo.ts
+++ b/packages-presets/preset-mini/src/_variants/pseudo.ts
@@ -170,9 +170,9 @@ function taggedPseudoClassMatcher(tag: string, parent: string, combinator: strin
     match(input, ctx) {
       if (!(splitRE && pseudoRE && pseudoColonRE)) {
         splitRE = new RegExp(`(?:${ctx.generator.config.separators.join('|')})`)
-        pseudoRE = new RegExp(`^${tag}-(?:(?:(${PseudoClassFunctionsStr})-)?(${PseudoClassesStr}))(?:(/\\w+))?(?:${ctx.generator.config.separators.join('|')})`)
-        pseudoColonRE = new RegExp(`^${tag}-(?:(?:(${PseudoClassFunctionsStr})-)?(${PseudoClassesColonStr}))(?:(/\\w+))?(?:${ctx.generator.config.separators.filter(x => x !== '-').join('|')})`)
-        pseudoVarRE = new RegExp(`^${tag}-(?:(${PseudoClassFunctionsStr})-)?\\[(.+)\\](?:(/\\w+))?(?:${ctx.generator.config.separators.filter(x => x !== '-').join('|')})`)
+        pseudoRE = new RegExp(`^${tag}-(?:(?:(${PseudoClassFunctionsStr})-)?(${PseudoClassesStr}))(?:(/[\\w-]+))?(?:${ctx.generator.config.separators.join('|')})`)
+        pseudoColonRE = new RegExp(`^${tag}-(?:(?:(${PseudoClassFunctionsStr})-)?(${PseudoClassesColonStr}))(?:(/[\\w-]+))?(?:${ctx.generator.config.separators.filter(x => x !== '-').join('|')})`)
+        pseudoVarRE = new RegExp(`^${tag}-(?:(${PseudoClassFunctionsStr})-)?\\[(.+)\\](?:(/[\\w-]+))?(?:${ctx.generator.config.separators.filter(x => x !== '-').join('|')})`)
       }
 
       if (!input.startsWith(tag))


### PR DESCRIPTION
handle nested named groups containing hyphens not working

- for example `group-hover/named-group:text-red-500` is not working, beacuse `named-group` containing `-`,
- [playground](https://uno.antfu.me/play/#html=DwEwlgbgBAxgNgQwM5ILwCIDmAnA9gVwAcB6AOwQFsBTEKMUueqgWgCM5cYBrWfbJXNmaFc9AC5Vs6AHwAoKFGAALAIyxEKDDgKFmS3BEllKNAFwSAHmObYazAKwAGR1EvWAbBbhRWgkJKhCC2YADhl9Q2woamBiVTkFYEJpbSI9AyNyahBzKisbOydHWOTZWPAIOTKK9WQ0dEIAT2YVRxlZashazSw8ImNs5lTCOgYmNg5uXn5BYVFSCSkExVVu%2BuH0yIG7Ydz82xAHZ1c8jy8fPwCg0PCMqJi4lWWklL7dCMyTQ923AsOikpycqQaRAA&config=JYWwDg9gTgLgBAbwFBzgEwKYDNgDsMDCEuOA5gDQpxhQYDOGMAgjDFMAEYCuMwWAnpVQ16jAJIBjYnSHVaDGAFk8wSgF84WKBBBwA5F1wQJdOnqRIMAD0ix02AIZcANvEw58REsFIAKZMLyjHQAXHAA2lSBokoqvgCUstEKLGycPHz8CUlyMZLS-lGocHQSDs4YYQCMAHQATDmoEmi4YXoAFqxgoQD0PfQgNXTtPXo5aolUALrq8UhAA&css=PQKgBA6gTglgLgUzAYwK4Gc4HsC2YDCAyoWABYJQIA0YAhgHYAmYcUD6AZllDhWOqgAOg7nAB0YAGLcwCAB60cggDYIAXGBDAAUKDBi0mXGADe2sGC704AWgDuCGAHNScDQFYADJ4Dc5sAACtMLKAJ5gggCMLPK2ABR2pPBIcsoAlH4WAEa0yADWTlBYqEw2yFjK3Bpw5LxxAOTllVDoYpSMYgAs3vUZ2gC%2BmsBAA&options=N4XyA&version=66.0.0)