### PR TITLE
feat(postcss): allow content from node_modules

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -187,7 +187,7 @@ The usage extracted from each source will be **merged** together.
 - **Type:** `string[]`
 - **Default:** `[]`
 
-Glob patterns to extract from the file system, in addition to other content sources.
+Glob patterns to extract from the file system, in addition to other content sources. `node_modules` are ignored by default, but unocss will scan from it when you specify the path includes `node_modules`.
 
 In dev mode, the files will be watched and trigger HMR.
 

--- a/packages-integrations/postcss/src/esm.ts
+++ b/packages-integrations/postcss/src/esm.ts
@@ -103,12 +103,13 @@ export function createPlugin(options: UnoPostcssPluginOptions) {
     }
 
     const globs = uno.config.content?.filesystem ?? defaultFilesystemGlobs
+    const needCheckNodeMoudules = globs.some(i => i.includes('node_modules'))
     const plainContent = uno.config.content?.inline ?? []
 
     const entries = await glob(isScanTarget ? globs : [from], {
       cwd,
       absolute: true,
-      ignore: ['**/node_modules/**'],
+      ignore: needCheckNodeMoudules ? undefined : ['**/node_modules/**'],
       expandDirectories: false,
     })
 


### PR DESCRIPTION
I think the `content.filesystem` options is like `@source` in [tailwindcss](https://tailwindcss.com/docs/detecting-classes-in-source-files#explicitly-registering-sources)

sometimes we may need to include the packages from `node_modules`, like [@llamaindex/chat-ui](https://www.npmjs.com/package/@llamaindex/chat-ui)

so it'd be better to be able access the node_modules