### PR TITLE
docs: fix link to extractor-pug in extractors.md

### DIFF
--- a/docs/config/extractors.md
+++ b/docs/config/extractors.md
@@ -30,4 +30,4 @@ export default defineConfig({
 })
 ```
 
-For example, please check the implementation of [pug extractor](https://github.com/unocss/unocss/tree/main/packages-integrations/extractor-pug) or the [attributify extractor](https://github.com/unocss/unocss/blob/main/packages-presets/preset-attributify/src/extractor.ts).
+For example, please check the implementation of [pug extractor](https://github.com/unocss/unocss/blob/main/packages-presets/extractor-pug/src/index.ts) or the [attributify extractor](https://github.com/unocss/unocss/blob/main/packages-presets/preset-attributify/src/extractor.ts).


### PR DESCRIPTION
```
[pug extractor](https://github.com/unocss/unocss/tree/main/packages-integrations/extractor-pug)
```

is 404.