### PR TITLE
fix(vite): call css plugin transform handlers more properly

### DIFF
--- a/packages-integrations/vite/src/modes/global/build.ts
+++ b/packages-integrations/vite/src/modes/global/build.ts
@@ -26,8 +26,12 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
     } = await getConfig()
     if (!cssPlugins.get(dir) || !postcss)
       return css
+    const cssPlugin = cssPlugins.get(dir)!
+    const cssPluginTransformHandler = 'handler' in cssPlugin.transform!
+      ? cssPlugin.transform.handler
+      : cssPlugin.transform!
     // @ts-expect-error without this context absolute assets will throw an error
-    const result = await cssPlugins.get(dir).transform.call(ctx, css, id)
+    const result = await cssPluginTransformHandler.call(ctx, css, id)
     if (!result)
       return css
     if (typeof result === 'string')
@@ -196,7 +200,7 @@ export function GlobalModeBuildPlugin(ctx: UnocssPluginContext<VitePluginConfig>
           )
 
           // Fool the vite:css-post plugin to replace the CSS content
-          await cssPostTransformHandler.call({} as any, css, mod)
+          await cssPostTransformHandler.call(this as Rollup.TransformPluginContext, css, mod)
         }
       },
       async buildEnd() {


### PR DESCRIPTION
While I added a patch to make it work in 6.3 (https://github.com/vitejs/vite/pull/19878), I'd like to remove them in Vite 7.
This PR changes the `cssPlugin.transform` / `cssPostPlugin.transform` calls to do it more properly.
The points made are

- the handler might exist as a `handler` property
- the context passed should at least satisfy PluginContext

In Vite 7, I might add `filter` property to the css plugins. To do it more properly, you'll need to check that. But in this case, it should be fine as unocss only calls it for the files selected on unocss side.

refs #4597
