### PR TITLE
fix(autocomplete): enhance variant group handling in autocomplete suggestions

### DIFF
--- a/packages-integrations/vscode/src/autocomplete.ts
+++ b/packages-integrations/vscode/src/autocomplete.ts
@@ -72,10 +72,23 @@ export async function registerAutoComplete(
 
       const cursorPosition = doc.offsetAt(position)
       let result: SuggestResult | undefined
-
+      const isTransformVariantGroup = ctx.uno.userConfig?.transformers?.some(item => item.name === '@unocss/transformer-variant-group')
+      const isCursourInVariantGroup = () => {
+        const lineText = doc.lineAt(position.line).text
+        const char = position.character
+        for (const match of lineText.matchAll(/\w+:\(([^)]*)\)/g)) {
+          const start = match.index + match[0].indexOf('(') + 1
+          const end = match.index + match[0].lastIndexOf(')')
+          if (char > start && char <= end)
+            return true
+        }
+        return false
+      }
+      if (!isTransformVariantGroup && isCursourInVariantGroup())
+        return
       // Special treatment for Pug Vue templates
       if (isPug) {
-      // get content from cursorPosition
+        // get content from cursorPosition
         const textBeforeCursor = code.substring(0, cursorPosition)
         // check the dot
         const dotMatch = textBeforeCursor.match(/\.[-\w]*$/)
@@ -96,7 +109,7 @@ export async function registerAutoComplete(
           }
         }
         else {
-        // original logic
+          // original logic
           result = await autoComplete.suggestInFile(code, cursorPosition)
         }
       }


### PR DESCRIPTION
When we do not use transformVariantGroup, we should not get code tips related to transformVariantGroup