### PR TITLE
fix(preset-icons): use node icon loader in deno

### DIFF
--- a/packages-presets/preset-icons/src/core.ts
+++ b/packages-presets/preset-icons/src/core.ts
@@ -191,7 +191,7 @@ export function createCDNFetchLoader(
 
 export function getEnvFlags() {
   // eslint-disable-next-line node/prefer-global/process
-  const isNode = typeof process !== 'undefined' && process.stdout && !process.versions.deno
+  const isNode = typeof process !== 'undefined' && process.stdout
   // eslint-disable-next-line node/prefer-global/process
   const isVSCode = isNode && !!process.env.VSCODE_CWD
   // eslint-disable-next-line node/prefer-global/process


### PR DESCRIPTION
Deno now supports all of the APIs required for the node loader to work, so this removes the hack added in https://github.com/unocss/unocss/pull/759 so that deno uses the node loader as well. This fixes issues with loading icons in frameworks like https://github.com/slidevjs/slidev when running in deno.