### PR TITLE
fix(examples): update outdated vite-plugin-svelte in svelte examples

### DIFF
--- a/examples/sveltekit-preprocess/package.json
+++ b/examples/sveltekit-preprocess/package.json
@@ -28,7 +28,7 @@
     "@sveltejs/adapter-auto": "^3.3.1",
     "@sveltejs/kit": "^2.19.0",
     "@sveltejs/package": "^2.3.10",
-    "@sveltejs/vite-plugin-svelte": "^4.0.4",
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@unocss/core": "link:../../packages-engine/core",
     "@unocss/preset-icons": "link:../../packages-presets/preset-icons",
     "@unocss/svelte-scoped": "link:../../packages-integrations/svelte-scoped",

--- a/examples/sveltekit-scoped/package.json
+++ b/examples/sveltekit-scoped/package.json
@@ -14,7 +14,7 @@
     "@julr/unocss-preset-forms": "^0.1.0",
     "@sveltejs/adapter-auto": "^3.3.1",
     "@sveltejs/kit": "^2.19.0",
-    "@sveltejs/vite-plugin-svelte": "^4.0.4",
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@unocss/core": "link:../../packages-engine/core",
     "@unocss/preset-icons": "link:../../packages-presets/preset-icons",
     "@unocss/svelte-scoped": "link:../../packages-integrations/svelte-scoped",

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -13,7 +13,7 @@
     "@iconify/utils": "^2.3.0",
     "@sveltejs/adapter-auto": "^3.3.1",
     "@sveltejs/kit": "^2.19.0",
-    "@sveltejs/vite-plugin-svelte": "^4.0.4",
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@unocss/core": "link:../../packages-engine/core",
     "@unocss/extractor-svelte": "link:../../packages-presets/extractor-svelte",
     "@unocss/preset-icons": "link:../../packages-presets/preset-icons",

--- a/examples/vite-svelte-postcss/package.json
+++ b/examples/vite-svelte-postcss/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@iconify-json/logos": "^1.2.4",
-    "@sveltejs/vite-plugin-svelte": "^4.0.4",
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@tsconfig/svelte": "^5.0.4",
     "@unocss/extractor-svelte": "link:../../packages-presets/extractor-svelte",
     "@unocss/postcss": "link:../../packages-integrations/postcss",

--- a/examples/vite-svelte/package.json
+++ b/examples/vite-svelte/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@iconify-json/logos": "^1.2.4",
-    "@sveltejs/vite-plugin-svelte": "^4.0.4",
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@tsconfig/svelte": "^5.0.4",
     "@unocss/core": "link:../../packages-engine/core",
     "@unocss/extractor-svelte": "link:../../packages-presets/extractor-svelte",


### PR DESCRIPTION
This PR updates the `vite-plugin-svelte` version to a version that works with Svelte 5/Vite 6.

This should make the Svelte examples here https://unocss.dev/integrations/#examples run properly again.