### PR TITLE
feat(preset-wind4): add noscript variant in Tailwind 4.1

### DIFF
--- a/packages-presets/preset-wind4/src/variants/default.ts
+++ b/packages-presets/preset-wind4/src/variants/default.ts
@@ -10,7 +10,7 @@ import { variantColorsMediaOrClass, variantColorsScheme } from './dark'
 import { variantDataAttribute, variantTaggedDataAttributes } from './data'
 import { variantLanguageDirections } from './directions'
 import { variantImportant } from './important'
-import { variantContrasts, variantCustomMedia, variantForcedColors, variantMotions, variantOrientations, variantPrint } from './media'
+import { variantContrasts, variantCustomMedia, variantForcedColors, variantMotions, variantNoscript, variantOrientations, variantPrint } from './media'
 import { variantCssLayer, variantInternalLayer, variantScope, variantSelector, variantStickyHover, variantTheme, variantVariables } from './misc'
 import { variantNegative } from './negative'
 import { placeholderModifier } from './placeholder'
@@ -30,6 +30,7 @@ export function variants(options: PresetWind4Options): Variant<Theme>[] {
     variantStartingStyle,
     variantImportant(),
     variantSupports,
+    variantNoscript,
     variantPrint,
     variantCustomMedia,
     ...variantContrasts,

--- a/packages-presets/preset-wind4/src/variants/media.ts
+++ b/packages-presets/preset-wind4/src/variants/media.ts
@@ -2,6 +2,8 @@ import type { Variant, VariantObject } from '@unocss/core'
 import type { Theme } from '../theme'
 import { h, variantGetParameter, variantParentMatcher } from '../utils'
 
+export const variantNoscript: VariantObject = variantParentMatcher('noscript', '@media (scripting: none)')
+
 export const variantPrint = variantParentMatcher('print', '@media print') as VariantObject<Theme>
 
 export const variantCustomMedia: VariantObject<Theme> = {

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -1580,6 +1580,9 @@ unocss .scope-\[unocss\]\:block{display:block;}
 @media (prefers-reduced-motion: reduce){
 .motion-reduce\:hover\:translate-0:hover{--un-translate-x:calc(var(--spacing) * 0);--un-translate-y:calc(var(--spacing) * 0);translate:var(--un-translate-x) var(--un-translate-y);}
 }
+@media (scripting: none){
+.noscript\:text-red-500{color:color-mix(in oklch, var(--colors-red-500) var(--un-text-opacity), transparent) /* oklch(0.637 0.237 25.331) */;}
+}
 @media not (prefers-color-scheme: dark){
 .not-dark\:text-xl{font-size:var(--text-xl-fontSize);line-height:var(--un-leading, var(--text-xl-lineHeight));}
 }

--- a/test/assets/preset-wind4-targets.ts
+++ b/test/assets/preset-wind4-targets.ts
@@ -379,6 +379,9 @@ export const presetWind4Targets: string[] = [
   // variants combinators
   'svg:fill-red',
 
+  // variants noscript
+  'noscript:text-red-500',
+
   // variants supports: grid
   'supports-grid:block',
 


### PR DESCRIPTION
https://tailwindcss.com/blog/tailwindcss-v4-1#new-noscript-variant

Not adding it into the mini preset, as there are 3 values of the media feature. Do we need to support all of them?

> The scripting feature is specified as a keyword value chosen from the list below.
>
> [none](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting#none)
Scripting is completely unavailable on the current document.
>
> [initial-only](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting#initial-only)
Scripting is enabled during the initial page load, but not afterwards.
>
> [enabled](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting#enabled)
Scripting is supported and active on the current document.
