### PR TITLE
fix(preset-wind4): add `leading-none` utility

### DIFF
--- a/packages-presets/preset-wind4/src/theme/font.ts
+++ b/packages-presets/preset-wind4/src/theme/font.ts
@@ -75,6 +75,7 @@ export const tracking = {
 } satisfies Theme['tracking']
 
 export const leading = {
+  none: '1',
   tight: '1.25',
   snug: '1.375',
   normal: '1.5',

--- a/test/assets/output/preset-wind4-theme.css
+++ b/test/assets/output/preset-wind4-theme.css
@@ -335,6 +335,7 @@
 --tracking-wide: 0.025em;
 --tracking-wider: 0.05em;
 --tracking-widest: 0.1em;
+--leading-none: 1;
 --leading-tight: 1.25;
 --leading-snug: 1.375;
 --leading-normal: 1.5;


### PR DESCRIPTION
After testing out `presetWind4` on my personal site I noticed that the `leading-none` utility was not working. Appears to just be missing so I added it!

https://tailwindcss.com/docs/line-height