### PR TITLE
fix(vscode-ext): display oklch colors inline

### DIFF
--- a/packages-integrations/vscode/src/utils.ts
+++ b/packages-integrations/vscode/src/utils.ts
@@ -6,7 +6,7 @@ import prettier from 'prettier/standalone'
 
 const remUnitRE = /(-?[\d.]+)rem(\s+!important)?;/
 const matchCssVarNameRE = /var\((?<cssVarName>--[^,|)]+)(?:,(?<fallback>[^)]+))?\)/g
-const cssColorRE = /(?:#|0x)(?:[a-f0-9]{3}|[a-f0-9]{6})\b|(?:rgb|hsl|oklch)a?\(.*\)/g
+const cssColorRE = /(?:#|0x)(?:[a-f0-9]{3}|[a-f0-9]{6})\b|((?:rgb|hsl)a?|oklch)?\(.*\)/g
 const varFnRE = /var\((--[^,|)]+)(?:,([^)]+))?\)/
 
 export function throttle<T extends ((...args: any) => any)>(func: T, timeFrame: number): T {

--- a/packages-integrations/vscode/src/utils.ts
+++ b/packages-integrations/vscode/src/utils.ts
@@ -6,7 +6,7 @@ import prettier from 'prettier/standalone'
 
 const remUnitRE = /(-?[\d.]+)rem(\s+!important)?;/
 const matchCssVarNameRE = /var\((?<cssVarName>--[^,|)]+)(?:,(?<fallback>[^)]+))?\)/g
-const cssColorRE = /(?:#|0x)(?:[a-f0-9]{3}|[a-f0-9]{6})\b|(?:rgb|hsl)a?\(.*\)/g
+const cssColorRE = /(?:#|0x)(?:[a-f0-9]{3}|[a-f0-9]{6})\b|(?:rgb|hsl|oklch)a?\(.*\)/g
 const varFnRE = /var\((--[^,|)]+)(?:,([^)]+))?\)/
 
 export function throttle<T extends ((...args: any) => any)>(func: T, timeFrame: number): T {
@@ -159,9 +159,6 @@ export function getColorString(str: string) {
     // rgb(248 113 113 / var(--no-value)) => rgba(248 113 113)
     colorString = colorString.replaceAll(/,?\s+var\(--.*?\)/g, '')
   }
-
-  // if (!(new TinyColor(colorString).isValid))
-  //   return
 
   if (/\/\)/.test(colorString))
     colorString = colorString.replace(/ \/\)/g, '/ 1)')

--- a/packages-integrations/vscode/src/utils.ts
+++ b/packages-integrations/vscode/src/utils.ts
@@ -6,7 +6,7 @@ import prettier from 'prettier/standalone'
 
 const remUnitRE = /(-?[\d.]+)rem(\s+!important)?;/
 const matchCssVarNameRE = /var\((?<cssVarName>--[^,|)]+)(?:,(?<fallback>[^)]+))?\)/g
-const cssColorRE = /(?:#|0x)(?:[a-f0-9]{3}|[a-f0-9]{6})\b|((?:rgb|hsl)a?|oklch)?\(.*\)/g
+const cssColorRE = /(?:#|0x)(?:[a-f0-9]{3}|[a-f0-9]{6})\b|(?:(?:rgb|hsl)a?|oklch)?\(.*\)/g
 const varFnRE = /var\((--[^,|)]+)(?:,([^)]+))?\)/
 
 export function throttle<T extends ((...args: any) => any)>(func: T, timeFrame: number): T {

--- a/packages-integrations/vscode/test/utils.test.ts
+++ b/packages-integrations/vscode/test/utils.test.ts
@@ -31,10 +31,28 @@ it('getColorString', () => {
   }
   `
 
+  const bgOklch = `
+  /* layer: default */
+  .bg-dark-red {
+    --un-bg-opacity: 1;
+    background-color: oklch(44.4% 0.177 26.899 / var(--un-bg-opacity));
+  }`
+
+  const bgOklchImportant = `
+  /* layer: default */
+  .\!bg-dark-red {
+    --un-bg-opacity: 1 !important;
+    background-color: oklch(44.4% 0.177 26.899 / var(--un-bg-opacity)) !important;
+  }`
+
   expect(getColorString(textAmber)).eql('rgba(251, 191, 36,  1)')
   expect(getColorString(textAmberImportant)).eql('rgba(251, 191, 36,  1 )')
+
   expect(getColorString(bgAmber)).eql('rgba(251, 191, 36,  1)')
   expect(getColorString(bgAmberImportant)).eql('rgba(251, 191, 36,  1 )')
+
+  expect(getColorString(bgOklch)).eql('oklch(44.4% 0.177 26.899 /  1)')
+  expect(getColorString(bgOklchImportant)).eql('oklch(44.4% 0.177 26.899 /  1 )')
 })
 
 it('addRemToPxComment', () => {


### PR DESCRIPTION
This PR is for the VSCode extension, allowing it to display colors inline with the text when they are in oklch.

The only change is to make `cssColorRE` match oklch colors.

Fix #4651 