### PR TITLE
feat(virtual-shared): update defaultPipelineInclude to support vue-vine

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -208,7 +208,7 @@ Set `false` to disable.
 ##### include
 
 - **Type:** `FilterPattern`
-- **Default:** `[/\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/]`
+- **Default:** `[/\.(vue|svelte|[jt]sx|vine.ts|mdx?|astro|elm|php|phtml|html)($|\?)/]`
 
 Patterns that filter the files being extracted. Supports regular expressions and `picomatch` glob patterns.
 

--- a/docs/guide/extracting.md
+++ b/docs/guide/extracting.md
@@ -32,7 +32,7 @@ export default defineConfig({
     pipeline: {
       include: [
         // the default
-        /\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/,
+        /\.(vue|svelte|[jt]sx|vine.ts|mdx?|astro|elm|php|phtml|html)($|\?)/,
         // include js/ts files
         'src/**/*.{js,ts}',
       ],

--- a/packages-engine/core/src/types.ts
+++ b/packages-engine/core/src/types.ts
@@ -805,7 +805,7 @@ export interface ContentOptions {
      * By default, `.ts` and `.js` files are NOT extracted.
      *
      * @see https://www.npmjs.com/package/picomatch
-     * @default [/\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/]
+     * @default [/\.(vue|svelte|[jt]sx|vine.ts|mdx?|astro|elm|php|phtml|html)($|\?)/]
      */
     include?: FilterPattern
 

--- a/virtual-shared/integration/src/defaults.ts
+++ b/virtual-shared/integration/src/defaults.ts
@@ -3,7 +3,7 @@ import { SKIP_COMMENT_RE } from './constants'
 
 // picomatch patterns, used with rollup's createFilter
 export const defaultPipelineExclude = [cssIdRE]
-export const defaultPipelineInclude = [/\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/]
+export const defaultPipelineInclude = [/\.(vue|svelte|[jt]sx|vine.ts|mdx?|astro|elm|php|phtml|html)($|\?)/]
 
 // micromatch patterns, used in postcss plugin
 export const defaultFilesystemGlobs = [


### PR DESCRIPTION
I tried using unocss in vue-vine, but unocss does not support `.ts|js` by default, so I hope unocss can support vine.ts by default

Minimum reproduction path [here](https://stackblitz.com/edit/unocss-unocss-59z5bv85?file=uno.config.ts)