### PR TITLE
feat(preset-mini, preset-wind4): enhance `pseudo` syntax

### DIFF
--- a/packages-presets/preset-mini/src/_variants/pseudo.ts
+++ b/packages-presets/preset-mini/src/_variants/pseudo.ts
@@ -238,7 +238,7 @@ export function variantPseudoClassesAndElements(): VariantObject[] {
         if (match) {
           let pseudo = PseudoClasses[match[1]] || PseudoClassesColon[match[1]] || `:${match[1]}`
           if (match[2]) {
-            const anPlusB = h.bracket(match[2]) ?? match[2]
+            const anPlusB = h.bracket(match[2])
             if (anPlusB) {
               pseudo = pseudo.replace(PseudoPlaceholder, anPlusB)
             }

--- a/packages-presets/preset-mini/src/_variants/pseudo.ts
+++ b/packages-presets/preset-mini/src/_variants/pseudo.ts
@@ -3,6 +3,8 @@ import type { PresetMiniOptions } from '..'
 import { escapeRegExp, escapeSelector } from '@unocss/core'
 import { getBracket, h, variantGetBracket } from '../_utils'
 
+const PseudoPlaceholder = '__pseudo_placeholder__'
+
 /**
  * Note: the order of following pseudo classes will affect the order of generated css.
  *
@@ -57,6 +59,7 @@ const PseudoClasses: Record<string, string> = Object.fromEntries([
   ['even', ':nth-child(even)'],
   ['odd-of-type', ':nth-of-type(odd)'],
   ['odd', ':nth-child(odd)'],
+  ['nth', `:nth-child(${PseudoPlaceholder})`],
   'first-of-type',
   ['first', ':first-child'],
   'last-of-type',
@@ -227,13 +230,19 @@ export function variantPseudoClassesAndElements(): VariantObject[] {
       name: 'pseudo',
       match(input, ctx) {
         if (!(PseudoClassesAndElementsRE && PseudoClassesAndElementsColonRE)) {
-          PseudoClassesAndElementsRE = new RegExp(`^(${PseudoClassesAndElementsStr})(?:${ctx.generator.config.separators.join('|')})`)
+          PseudoClassesAndElementsRE = new RegExp(`^(${PseudoClassesAndElementsStr})(?:-(\\[\\w+\\]))?(?:${ctx.generator.config.separators.join('|')})`)
           PseudoClassesAndElementsColonRE = new RegExp(`^(${PseudoClassesAndElementsColonStr})(?:${ctx.generator.config.separators.filter(x => x !== '-').join('|')})`)
         }
 
         const match = input.match(PseudoClassesAndElementsRE) || input.match(PseudoClassesAndElementsColonRE)
         if (match) {
-          const pseudo = PseudoClasses[match[1]] || PseudoClassesColon[match[1]] || `:${match[1]}`
+          let pseudo = PseudoClasses[match[1]] || PseudoClassesColon[match[1]] || `:${match[1]}`
+          if (match[2]) {
+            const anPlusB = h.bracket(match[2]) ?? match[2]
+            if (anPlusB) {
+              pseudo = pseudo.replace(PseudoPlaceholder, anPlusB)
+            }
+          }
 
           // order of pseudo classes
           let index: number | undefined = PseudoClassesKeys.indexOf(match[1])

--- a/packages-presets/preset-wind4/src/variants/pseudo.ts
+++ b/packages-presets/preset-wind4/src/variants/pseudo.ts
@@ -239,7 +239,7 @@ export function variantPseudoClassesAndElements(): VariantObject<Theme>[] {
         if (match) {
           let pseudo = PseudoClasses[match[1]] || PseudoClassesColon[match[1]] || `:${match[1]}`
           if (match[2]) {
-            const anPlusB = h.bracket(match[2]) ?? match[2]
+            const anPlusB = h.bracket(match[2])
             if (anPlusB) {
               pseudo = pseudo.replace(PseudoPlaceholder, anPlusB)
             }

--- a/packages-presets/preset-wind4/src/variants/pseudo.ts
+++ b/packages-presets/preset-wind4/src/variants/pseudo.ts
@@ -4,6 +4,8 @@ import type { Theme } from '../theme'
 import { escapeRegExp, escapeSelector } from '@unocss/core'
 import { getBracket, h, variantGetBracket } from '../utils'
 
+const PseudoPlaceholder = '__pseudo_placeholder__'
+
 /**
  * Note: the order of following pseudo classes will affect the order of generated css.
  *
@@ -58,6 +60,7 @@ const PseudoClasses: Record<string, string> = Object.fromEntries([
   ['even', ':nth-child(even)'],
   ['odd-of-type', ':nth-of-type(odd)'],
   ['odd', ':nth-child(odd)'],
+  ['nth', `:nth-child(${PseudoPlaceholder})`],
   'first-of-type',
   ['first', ':first-child'],
   'last-of-type',
@@ -228,13 +231,19 @@ export function variantPseudoClassesAndElements(): VariantObject<Theme>[] {
       name: 'pseudo',
       match(input, ctx) {
         if (!(PseudoClassesAndElementsRE && PseudoClassesAndElementsColonRE)) {
-          PseudoClassesAndElementsRE = new RegExp(`^(${PseudoClassesAndElementsStr})(?:${ctx.generator.config.separators.join('|')})`)
+          PseudoClassesAndElementsRE = new RegExp(`^(${PseudoClassesAndElementsStr})(?:-(\\[\\w+\\]))?(?:${ctx.generator.config.separators.join('|')})`)
           PseudoClassesAndElementsColonRE = new RegExp(`^(${PseudoClassesAndElementsColonStr})(?:${ctx.generator.config.separators.filter(x => x !== '-').join('|')})`)
         }
 
         const match = input.match(PseudoClassesAndElementsRE) || input.match(PseudoClassesAndElementsColonRE)
         if (match) {
-          const pseudo = PseudoClasses[match[1]] || PseudoClassesColon[match[1]] || `:${match[1]}`
+          let pseudo = PseudoClasses[match[1]] || PseudoClassesColon[match[1]] || `:${match[1]}`
+          if (match[2]) {
+            const anPlusB = h.bracket(match[2]) ?? match[2]
+            if (anPlusB) {
+              pseudo = pseudo.replace(PseudoPlaceholder, anPlusB)
+            }
+          }
 
           // order of pseudo classes
           let index: number | undefined = PseudoClassesKeys.indexOf(match[1])

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -774,6 +774,7 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .checked\:next\:text-slate-100+*:checked{--un-text-opacity:1;color:rgb(241 245 249 / var(--un-text-opacity));}
 .next\:checked\:children\:text-slate-600>*:checked+*{--un-text-opacity:1;color:rgb(71 85 105 / var(--un-text-opacity));}
 .next\:checked\:text-slate-200:checked+*{--un-text-opacity:1;color:rgb(226 232 240 / var(--un-text-opacity));}
+.nth-\[2\]\:text-yellow:nth-child(2){--un-text-opacity:1;color:rgb(250 204 21 / var(--un-text-opacity));}
 .c-\[\#157\],
 .c-\#157,
 .c-hex-157{--un-text-opacity:1;color:rgb(17 85 119 / var(--un-text-opacity));}

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -147,6 +147,7 @@
 --colors-green-DEFAULT: oklch(0.792 0.209 151.711);
 --colors-violet-50: oklch(0.969 0.016 293.756);
 --colors-pink-100: oklch(0.948 0.028 342.258);
+--colors-yellow-DEFAULT: oklch(0.852 0.199 91.936);
 --colors-violet-200: oklch(0.894 0.057 293.283);
 --text-2xl-fontSize: 1.5rem;
 --text-2xl-lineHeight: 2rem;
@@ -221,6 +222,7 @@
 .next\:checked\:text-slate-200:checked+*{color:color-mix(in oklch, var(--colors-slate-200) var(--un-text-opacity), transparent) /* oklch(0.929 0.013 255.508) */;}
 .checked\:next\:hover\:text-slate-500:hover+*:checked{color:color-mix(in oklch, var(--colors-slate-500) var(--un-text-opacity), transparent) /* oklch(0.554 0.046 257.417) */;}
 .next\:checked\:children\:text-slate-600>*:checked+*{color:color-mix(in oklch, var(--colors-slate-600) var(--un-text-opacity), transparent) /* oklch(0.446 0.043 257.281) */;}
+.nth-\[2\]\:text-yellow:nth-child(2){color:color-mix(in oklch, var(--colors-yellow-DEFAULT) var(--un-text-opacity), transparent) /* oklch(0.852 0.199 91.936) */;}
 .c-\[\#157\],
 .c-\#157,
 .c-hex-157{color:color-mix(in oklch, #157 var(--un-text-opacity), transparent) /* #157 */;}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -1205,6 +1205,7 @@ export const presetMiniTargets: string[] = [
   'group-aria-[.not-parent]/label:font-19',
 
   // variants - variables
+  'nth-[2]:text-yellow',
   '[&:nth-child(2)]:m-10',
   '[&>*]:m-11',
   '[*>&]:m-12',


### PR DESCRIPTION
close #4647

Enhance `pseudo` variants. In order not to affect subsequent rule parsing and cause incorrect capture strings, only the syntax starting with `pseudo-[xxx]` is supported.