### PR TITLE
chore(vite): add ts-ignore to transformIndexHtml old interface

### DIFF
--- a/packages-integrations/vite/src/modes/global/dev.ts
+++ b/packages-integrations/vite/src/modes/global/dev.ts
@@ -147,8 +147,11 @@ export function GlobalModeDevPlugin(ctx: UnocssPluginContext): Plugin[] {
           setWarnTimer()
           tasks.push(extract(code, filename))
         },
-        // Compatibility with Legacy Vite
+        // eslint-disable-next-line ts/ban-ts-comment
+        // @ts-ignore Compatibility with Legacy Vite
         enforce: 'pre',
+        // eslint-disable-next-line ts/ban-ts-comment
+        // @ts-ignore Compatibility with Legacy Vite
         transform(code, { filename }) {
           setWarnTimer()
           tasks.push(extract(code, filename))


### PR DESCRIPTION
This PR fixes this ecosystem-ci failure: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/15061007152/job/42336016816#step:8:2085

This old interface will be removed in the next major (https://github.com/vitejs/vite/pull/19349) and the type error was happening.
