### PR TITLE
fix: retain query string when `resolveId`

### DIFF
--- a/virtual-shared/integration/src/layers.ts
+++ b/virtual-shared/integration/src/layers.ts
@@ -11,6 +11,7 @@ export function resolveId(id: string, importer?: string) {
       let virtual = match[1]
         ? `__uno_${match[1]}.css`
         : '__uno.css'
+      virtual += match[2] || ''
       if (importer)
         virtual = resolve(importer, '..', virtual)
       else


### PR DESCRIPTION
Close https://github.com/unocss/unocss/issues/4137

Related:
https://github.com/unocss/unocss/pull/2570
https://github.com/unocss/unocss/issues/2579
https://github.com/unocss/unocss/issues/2533

Apparently, the `VIRTUAL_ENTRY_ALIAS` regex has already captured the query string but it was not retained in the resolved ID result. This PR just add it back.