### PR TITLE
docs: add example link to Next.js

### DIFF
--- a/docs/integrations/next.md
+++ b/docs/integrations/next.md
@@ -5,9 +5,7 @@ description: Getting started with UnoCSS and Next.js.
 
 # Next.js
 
-// TODO: link to examples
-
-Getting Started with UnoCSS and Next.js.
+Getting Started with UnoCSS and Next.js. Check the [example](https://github.com/unocss/unocss/tree/main/examples/next).
 
 ## Setup
 


### PR DESCRIPTION
I struggled to integrate UnoCSS into my Next.js project, but I discovered the excellent example included in the UnoCSS repository. After comparing it with my own setup, I was able to resolve all the issues. I believe it would be very helpful to include this example in the documentation.

By the way, if you need someone to update this doc for you, I'd be happy to offer my help.