### PR TITLE
fix: inspector url

### DIFF
--- a/packages-integrations/inspector/src/index.ts
+++ b/packages-integrations/inspector/src/index.ts
@@ -115,8 +115,15 @@ export default function UnocssInspector(ctx: UnocssPluginContext): Plugin {
     server.printUrls = () => {
       _printUrls()
       for (const localUrl of server.resolvedUrls?.local ?? []) {
-        const url = server.config.base ? localUrl.replace(server.config.base, '') : localUrl
-        const inspectorUrl = url.endsWith('/') ? `${url}${baseUrl}/` : `${url}/${baseUrl}/`
+        // server.config.base will be normalized with leading and trailing slashes,
+        // but localUrl might not have a trailing slash
+        const appUrl = localUrl.endsWith('/') ? localUrl : `${localUrl}/`
+        // remove the base path from appUrl if possible
+        const serverUrl = server.config.base && appUrl.endsWith(server.config.base)
+          ? appUrl.slice(0, -server.config.base.length)
+          : appUrl
+        // we removed the trailing slash from serverUrl when removing the base, add it back
+        const inspectorUrl = `${serverUrl}/${baseUrl}/`
         // eslint-disable-next-line no-console
         console.log(`  ${green('➜')}  ${bold('UnoCSS Inspector')}: ${colorUrl(`${inspectorUrl}`)}`)
       }

--- a/packages-integrations/inspector/src/index.ts
+++ b/packages-integrations/inspector/src/index.ts
@@ -121,7 +121,7 @@ export default function UnocssInspector(ctx: UnocssPluginContext): Plugin {
         // remove the base path from appUrl if possible
         const serverUrl = server.config.base && appUrl.endsWith(server.config.base)
           ? appUrl.slice(0, -server.config.base.length)
-          : appUrl
+          : appUrl.slice(0, -1) // remove the trailing slash
         // we removed the trailing slash from serverUrl when removing the base, add it back
         const inspectorUrl = `${serverUrl}/${baseUrl}/`
         // eslint-disable-next-line no-console


### PR DESCRIPTION
Hi!

It seems like #4536 was not correct fix for this issue.

```md
# Before this PR

## With base=/

  ➜  Local:   http://localhost:5173/
  ➜  UnoCSS Inspector: http:/localhost:5173/__unocss/
                            ^ notice the broken protocol

## With base=/app (through sveltekit)

  ➜  Local:   http://localhost:5173/app
  ➜  UnoCSS Inspector: http://localhost:5173/app/__unocss/
                       ^ incorrect url, the inspector will be at /__unocss/

# After this PR

## With base=/

  ➜  Local:   http://localhost:5173/
  ➜  UnoCSS Inspector: http://localhost:5173/__unocss/

## With base=/app

  ➜  Local:   http://localhost:5173/app
  ➜  UnoCSS Inspector: http://localhost:5173/__unocss/
```

I think my testing was careful enough, but ping me if I missed anything