### PR TITLE
chore: make ecosystem-ci pass with rolldown-vite

### DIFF
--- a/packages-integrations/vite/src/modes/chunk-build.ts
+++ b/packages-integrations/vite/src/modes/chunk-build.ts
@@ -42,7 +42,11 @@ export function ChunkModeBuildPlugin(ctx: UnocssPluginContext): Plugin {
       await cssPostTransformHandler.call(this as Rollup.TransformPluginContext, css, fakeCssId)
       chunk.modules[fakeCssId] = {
         code: null,
+        // eslint-disable-next-line ts/ban-ts-comment
+        // @ts-ignore does not exist in rolldown
         originalLength: 0,
+        // eslint-disable-next-line ts/ban-ts-comment
+        // @ts-ignore does not exist in rolldown
         removedExports: [],
         renderedExports: [],
         renderedLength: 0,

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -3,9 +3,11 @@ import process from 'node:process'
 import fs from 'fs-extra'
 import { glob } from 'tinyglobby'
 import { build } from 'vite'
+import * as vite from 'vite'
 import { describe, expect, it } from 'vitest'
 
 const isWindows = process.platform === 'win32'
+const isRolldownVite = 'rolldownVersion' in vite
 
 async function getGlobContent(cwd: string, pattern: string) {
   return await glob([pattern], { cwd, absolute: true, expandDirectories: false })
@@ -52,7 +54,7 @@ describe.concurrent('fixtures', () => {
     expect(css).not.contains('.text-teal')
   })
 
-  it.skipIf(isWindows)('vite legacy', async () => {
+  it.skipIf(isWindows || isRolldownVite)('vite legacy', async () => {
     const root = resolve(__dirname, 'fixtures/vite-legacy')
     await fs.emptyDir(join(root, 'dist'))
     await build({
@@ -71,7 +73,7 @@ describe.concurrent('fixtures', () => {
     expect(css).contains('.text-red')
   }, 15000)
 
-  it.skipIf(isWindows)('vite legacy renderModernChunks false', async () => {
+  it.skipIf(isWindows || isRolldownVite)('vite legacy renderModernChunks false', async () => {
     const root = resolve(__dirname, 'fixtures/vite-legacy-chunks')
     await fs.emptyDir(join(root, 'dist'))
     await build({


### PR DESCRIPTION
This PR makes some small changes to make ecosystem-ci pass with rolldown-vite.
