### PR TITLE
feat(vscode): allows overriding of annotation related settings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ export default antfu(
       'packages-presets/reset/**/*.css',
       'packages-presets/preset-icons/src/collections.json',
       'packages-integrations/eslint-plugin/fixtures',
+      'packages-integrations/vscode/src/generated',
 
       // Nested CSS
       'interactive/markdown.css',

--- a/packages-integrations/vscode/package.json
+++ b/packages-integrations/vscode/package.json
@@ -86,11 +86,13 @@
         "unocss.underline": {
           "type": "boolean",
           "default": true,
+          "scope": "language-overridable",
           "description": "Enable/disable underline decoration for class names"
         },
         "unocss.colorPreview": {
           "type": "boolean",
           "default": true,
+          "scope": "language-overridable",
           "description": "Enable/disable color preview decorations"
         },
         "unocss.colorPreviewRadius": {
@@ -101,11 +103,13 @@
         "unocss.remToPxPreview": {
           "type": "boolean",
           "default": true,
+          "scope": "language-overridable",
           "description": "Enable/disable rem to px preview in hover"
         },
         "unocss.remToPxRatio": {
           "type": "number",
           "default": 16,
+          "scope": "language-overridable",
           "description": "Ratio of rem to px"
         },
         "unocss.selectionStyle": {

--- a/packages-integrations/vscode/src/annotation.ts
+++ b/packages-integrations/vscode/src/annotation.ts
@@ -100,12 +100,14 @@ export async function registerAnnotations(
       if (!isTarget)
         return reset(editor)
 
+      const docConfig = getConfig(doc)
+
       const result = await ctx.uno.generate(code, { id, preflights: false, minify: true })
 
       const colorRanges: DecorationOptions[] = []
 
-      const remToPxRatio = config.remToPxPreview
-        ? config.remToPxRatio
+      const remToPxRatio = docConfig.remToPxPreview
+        ? docConfig.remToPxRatio
         : -1
 
       const positions = await getMatchedPositionsFromDoc(ctx.uno, doc)
@@ -116,7 +118,7 @@ export async function registerAnnotations(
           try {
             const md = await getPrettiedMarkdown(ctx!.uno, isAttributify ? [i[2], `[${i[2]}=""]`] : i[2], remToPxRatio)
 
-            if (config.colorPreview) {
+            if (docConfig.colorPreview) {
               const color = getColorString(md)
               if (color && !colorRanges.find(r => r.range.start.isEqual(doc.positionAt(i[0])))) {
                 colorRanges.push({
@@ -143,7 +145,7 @@ export async function registerAnnotations(
 
       editor.setDecorations(colorDecoration, colorRanges)
 
-      if (config.underline) {
+      if (docConfig.underline) {
         editor.setDecorations(NoneDecoration, [])
         editor.setDecorations(UnderlineDecoration, ranges)
       }

--- a/packages-integrations/vscode/src/configs.ts
+++ b/packages-integrations/vscode/src/configs.ts
@@ -1,16 +1,16 @@
-import type { Disposable } from 'vscode'
+import type { ConfigurationScope, Disposable } from 'vscode'
 import type { ConfigShorthandTypeMap } from './generated/meta'
 import { languages, window, workspace } from 'vscode'
 import { defaultLanguageIds } from './constants'
 import { configs } from './generated/meta'
 
-export function getConfig(): ConfigShorthandTypeMap & {
+export function getConfig(scope?: ConfigurationScope): ConfigShorthandTypeMap & {
   watchChanged: (keys: (keyof ConfigShorthandTypeMap)[], callback: () => void) => Disposable
 } {
   function watchChanged(keys: (keyof ConfigShorthandTypeMap)[], callback: () => void) {
     const fullKeys = keys.map(key => configs[key].key)
     return workspace.onDidChangeConfiguration((e) => {
-      if (fullKeys.some(key => e.affectsConfiguration(key))) {
+      if (fullKeys.some(key => e.affectsConfiguration(key, scope))) {
         callback()
       }
     })
@@ -20,7 +20,7 @@ export function getConfig(): ConfigShorthandTypeMap & {
     watchChanged,
   } as any
 
-  const config = workspace.getConfiguration()
+  const config = workspace.getConfiguration(undefined, scope)
 
   for (const [key, value] of Object.entries(configs) as any) {
     Object.defineProperty(object, key, {


### PR DESCRIPTION
Allows to override these four options: `'underline', 'colorPreview', 'remToPxPreview', 'remToPxRatio'` in language specific settings, so that annotations can be disabled in css files.

Before:
![截屏2025-06-17 11 31 57](https://github.com/user-attachments/assets/d6307524-1778-4b1c-ae41-27721f1521ce)

After:
![截屏2025-06-17 11 31 20](https://github.com/user-attachments/assets/2e1578d0-8191-49af-84b7-cd87c25c9051)

