### PR TITLE
fix(nuxt): Dynamically Import Vite/Webpack Plugins When Needed

### DIFF
--- a/packages-integrations/nuxt/src/index.ts
+++ b/packages-integrations/nuxt/src/index.ts
@@ -7,8 +7,6 @@ import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { addComponentsDir, addPluginTemplate, addTemplate, defineNuxtModule, extendViteConfig, extendWebpackConfig, findPath, isNuxt2, isNuxt3 } from '@nuxt/kit'
 import { createRecoveryConfigLoader } from '@unocss/config'
-import VitePlugin from '@unocss/vite'
-import WebpackPlugin from '@unocss/webpack'
 import { resolveOptions } from './options'
 
 export { UnocssNuxtOptions }
@@ -125,6 +123,7 @@ export default mergeConfigs([${configPaths.map((_, index) => `cfg${index}`).join
       await nuxt.callHook('unocss:config', unoConfig)
 
       extendViteConfig(async (config) => {
+        const { default: VitePlugin } = await import('@unocss/vite')
         config.plugins = config.plugins || []
         config.plugins.unshift(...VitePlugin({
           mode: options.mode,
@@ -132,6 +131,7 @@ export default mergeConfigs([${configPaths.map((_, index) => `cfg${index}`).join
       })
 
       extendWebpackConfig(async (config) => {
+        const { default: WebpackPlugin } = await import('@unocss/webpack')
         config.plugins = config.plugins || []
         config.plugins.unshift(WebpackPlugin({}, unoConfig))
       })


### PR DESCRIPTION
In the future, this would also allow moving the packages to optional dependencies or something similar, to stop having to install Webpack when using Nuxt.

For now, this allows removing `@unocss/webpack` from being installed without breaking the plugin.

e.g.

```yml
// pnpm-workspace.yaml
overrides:
  "@unocss/webpack": "-"
```