### PR TITLE
fix(preset-mini, preset-wind4): 🐛 support `has-data-*` variants

### DIFF
--- a/packages-presets/preset-mini/src/_variants/data.ts
+++ b/packages-presets/preset-mini/src/_variants/data.ts
@@ -43,4 +43,5 @@ export const variantTaggedDataAttributes: Variant[] = [
   taggedData('peer'),
   taggedData('parent'),
   taggedData('previous'),
+  taggedData('has'),
 ]

--- a/packages-presets/preset-wind4/src/variants/data.ts
+++ b/packages-presets/preset-wind4/src/variants/data.ts
@@ -43,4 +43,5 @@ export const variantTaggedDataAttributes: Variant<Theme>[] = [
   taggedData('peer'),
   taggedData('parent'),
   taggedData('previous'),
+  taggedData('has'),
 ]

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -484,7 +484,8 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .b-2,
 .border-size-2{border-width:2px;}
 .border{border-width:1px;}
-.border-4{border-width:4px;}
+.border-4,
+.has-data-\[state\=closed\]\:border-4:has([data-state=closed]){border-width:4px;}
 .border-x{border-left-width:1px;border-right-width:1px;}
 .border-b{border-bottom-width:1px;}
 .border-e-4{border-inline-end-width:4px;}

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -547,7 +547,8 @@
 .b-2,
 .border-size-2{border-width:2px;}
 .border{border-width:1px;}
-.border-4{border-width:4px;}
+.border-4,
+.has-data-\[state\=closed\]\:border-4:has([data-state=closed]){border-width:4px;}
 .border-x{border-inline-width:1px;}
 .border-b{border-bottom-width:1px;}
 .border-e-4{border-inline-end-width:4px;}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -1270,6 +1270,7 @@ export const presetMiniTargets: string[] = [
   'group-data-[state=open]:font-bold',
   'group-data-[state=open]/named:font-medium',
   'peer-data-[state=closed]:border-3',
+  'has-data-[state=closed]:border-4',
 
   // variants - container parent
   '@container',


### PR DESCRIPTION
Fix https://github.com/unocss/unocss/issues/4759