### PR TITLE
feat(preset-mini,preset-wind4): support `**` variant & fix `*` variant

### DIFF
--- a/packages-presets/preset-mini/src/_variants/children.ts
+++ b/packages-presets/preset-mini/src/_variants/children.ts
@@ -2,5 +2,5 @@ import type { Variant } from '@unocss/core'
 import { variantMatcher } from '../utils'
 
 export const variantChildren: Variant[] = [
-  variantMatcher('*', input => ({ selector: `${input.selector} > *` })),
+  variantMatcher('*', input => ({ selector: `${input.selector} > *` }), { order: -1 }),
 ]

--- a/packages-presets/preset-wind4/src/variants/children.ts
+++ b/packages-presets/preset-wind4/src/variants/children.ts
@@ -3,5 +3,6 @@ import type { Theme } from '../theme'
 import { variantMatcher } from '../utils'
 
 export const variantChildren: Variant<Theme>[] = [
-  variantMatcher('*', input => ({ selector: `${input.selector} > *` })) as Variant<Theme>,
+  variantMatcher('*', input => ({ selector: `${input.selector} > *` }), { order: -1 }),
+  variantMatcher('**', input => ({ selector: `${input.selector} *` }), { order: -1 }),
 ]

--- a/packages-presets/rule-utils/src/variants.ts
+++ b/packages-presets/rule-utils/src/variants.ts
@@ -2,7 +2,7 @@ import type { Arrayable, VariantHandler, VariantHandlerContext, VariantObject } 
 import { escapeRegExp, toArray } from '@unocss/core'
 import { getBracket } from './utilities'
 
-export function variantMatcher<T extends object = object>(name: string, handler: Arrayable<(input: VariantHandlerContext) => Record<string, any>>): VariantObject<T> {
+export function variantMatcher<T extends object = object>(name: string, handler: Arrayable<(input: VariantHandlerContext) => Record<string, any>>, options: Omit<VariantObject<T>, 'match'> = {}): VariantObject<T> {
   let re: RegExp
   return {
     name,
@@ -19,6 +19,7 @@ export function variantMatcher<T extends object = object>(name: string, handler:
             ...input,
             ...handler(input),
           }),
+          ...options,
         }))
         return handlers.length === 1
           ? handlers[0]

--- a/test/assets/output/preset-mini-targets.css
+++ b/test/assets/output/preset-mini-targets.css
@@ -697,6 +697,7 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .p-none{padding:0;}
 .p-unset{padding:unset;}
 .pa{padding:auto;}
+.\*\:hover\:p-2 > *:hover{padding:0.5rem;}
 .hover\:\!p-1:hover{padding:0.25rem !important;}
 .hover\:p-5:hover{padding:1.25rem;}
 .p-xy,

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -464,7 +464,12 @@
 .mbs-\$height{margin-block-start:var(--height);}
 .mbs-unset{margin-block-start:unset;}
 .\*-p-2 > *,
+.\*\:data-\[inline\]\:p-2 > *[data-inline],
 .\*\:p-2 > *,
+.\*\*-p-2 *,
+.\*\*\:aria-\[id\=avatar\]\:p-2 *[aria-id=avatar],
+.\*\*\:data-\[inline\]\:p-2 *[data-inline],
+.\*\*\:p-2 *,
 .has-hover\:p-2:has(:hover),
 .p-2,
 .p2,
@@ -479,6 +484,11 @@
 .p-unset{padding:unset;}
 .pa{padding:auto;}
 .hover\:\!p-1:hover{padding:calc(var(--spacing) * 1) !important;}
+.\*\:data-\[inline\]\:hover\:p-2 > *:hover[data-inline]{padding:calc(var(--spacing) * 2);}
+.\*\:hover\:p-2 > *:hover{padding:calc(var(--spacing) * 2);}
+.\*\*\:aria-\[id\=avatar\]\:hover\:p-2 *:hover[aria-id=avatar]{padding:calc(var(--spacing) * 2);}
+.\*\*\:data-\[inline\]\:hover\:p-2 *:hover[data-inline]{padding:calc(var(--spacing) * 2);}
+.\*\*\:hover\:data-\[inline\]\:p-2 *[data-inline]:hover{padding:calc(var(--spacing) * 2);}
 .hover\:p-5:hover{padding:calc(var(--spacing) * 5);}
 .group-aria:focus .group-aria-focus\:p-4,
 .group:focus .group-focus\:p-4{padding:calc(var(--spacing) * 4);}

--- a/test/assets/preset-mini-targets.ts
+++ b/test/assets/preset-mini-targets.ts
@@ -1099,6 +1099,7 @@ export const presetMiniTargets: string[] = [
   '-!mb-safe',
   '!-ms-safe',
   '*:p-2',
+  '*:hover:p-2',
   '*-p-2',
 
   // variants class

--- a/test/assets/preset-wind4-targets.ts
+++ b/test/assets/preset-wind4-targets.ts
@@ -441,6 +441,16 @@ export const presetWind4Targets: string[] = [
   '-scroll-p-px',
   '-space-x-4',
 
+  '*:data-[inline]:p-2',
+  '*:data-[inline]:hover:p-2',
+  '**:p-2',
+  '**-p-2',
+  '**:data-[inline]:p-2',
+  '**:data-[inline]:hover:p-2',
+  '**:hover:data-[inline]:p-2',
+  '**:aria-[id=avatar]:p-2',
+  '**:aria-[id=avatar]:hover:p-2',
+
   // variants experimental
   '@hover-text-red',
   '@hover:[[open]_&]:text-blue',


### PR DESCRIPTION
fix #4718 #4726 

another implement is:
```ts
  variantMatcher('*', input => ({ parent: input.selector, selector: ':is(& > *)' }), { order: -1 }),
  variantMatcher('**', input => ({ parent: input.selector, selector: ':is(& *)' }), { order: -1 }),
```

and its output would be:

```css
.\*-p-2{
:is(& > *){padding:calc(var(--spacing) * 2);}
}
.\*\:data-\[inline\]\:hover\:p-2{
:is(& > *):hover[data-inline]{padding:calc(var(--spacing) * 2);}
}
.\*\:data-\[inline\]\:p-2{
:is(& > *)[data-inline]{padding:calc(var(--spacing) * 2);}
}
.\*\:hover\:p-2{
:is(& > *):hover{padding:calc(var(--spacing) * 2);}
}
.\*\:p-2{
:is(& > *){padding:calc(var(--spacing) * 2);}
}
.\*\*-p-2{
:is(& *){padding:calc(var(--spacing) * 2);}
}
.\*\*\:aria-\[id\=avatar\]\:hover\:p-2{
:is(& *):hover[aria-id=avatar]{padding:calc(var(--spacing) * 2);}
}
.\*\*\:aria-\[id\=avatar\]\:p-2{
:is(& *)[aria-id=avatar]{padding:calc(var(--spacing) * 2);}
}
.\*\*\:data-\[inline\]\:hover\:p-2{
:is(& *):hover[data-inline]{padding:calc(var(--spacing) * 2);}
}
.\*\*\:data-\[inline\]\:p-2{
:is(& *)[data-inline]{padding:calc(var(--spacing) * 2);}
}
.\*\*\:hover\:data-\[inline\]\:p-2{
:is(& *)[data-inline]:hover{padding:calc(var(--spacing) * 2);}
}
.\*\*\:p-2{
:is(& *){padding:calc(var(--spacing) * 2);}
}
```

which is more aligned with [tw4](https://play.tailwindcss.com/FM8OpUQRjk)'s output but way more verbose

which one do you prefer?