### PR TITLE
chore: move all pnpm settings to `pnpm-workspace.yaml`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-ignore-workspace-root-check=true
-shamefully-hoist=true
-strict-peer-dependencies=false
-auto-install-peers=true

--- a/package.json
+++ b/package.json
@@ -139,27 +139,6 @@
     "vue": "catalog:",
     "vue-router": "catalog:"
   },
-  "pnpm": {
-    "overrides": {
-      "is-arguments": "npm:@nolyfill/is-arguments@^1.0.44",
-      "is-core-module": "npm:@nolyfill/is-core-module@^1.0.39",
-      "is-generator-function": "npm:@nolyfill/is-generator-function@^1.0.44",
-      "is-regex": "npm:@nolyfill/is-regex@^1.0.44",
-      "is-typed-array": "npm:@nolyfill/is-typed-array@^1.0.44",
-      "object.assign": "npm:@nolyfill/object.assign@^1.0.44",
-      "side-channel": "npm:@nolyfill/side-channel@^1.0.44",
-      "which-typed-array": "npm:@nolyfill/which-typed-array@^1.0.44"
-    },
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "core-js",
-      "esbuild",
-      "msw",
-      "nuxt-tsconfig-stub",
-      "sharp",
-      "simple-git-hooks"
-    ]
-  },
   "resolutions": {
     "@typescript-eslint/utils": "catalog:",
     "magic-string": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,14 +425,6 @@ overrides:
   prettier: ^2.8.8
   rollup: ^4.44.0
   vite: ^7.0.0
-  is-arguments: npm:@nolyfill/is-arguments@^1.0.44
-  is-core-module: npm:@nolyfill/is-core-module@^1.0.39
-  is-generator-function: npm:@nolyfill/is-generator-function@^1.0.44
-  is-regex: npm:@nolyfill/is-regex@^1.0.44
-  is-typed-array: npm:@nolyfill/is-typed-array@^1.0.44
-  object.assign: npm:@nolyfill/object.assign@^1.0.44
-  side-channel: npm:@nolyfill/side-channel@^1.0.44
-  which-typed-array: npm:@nolyfill/which-typed-array@^1.0.44
 
 importers:
 
@@ -1307,13 +1299,13 @@ importers:
     devDependencies:
       '@types/webpack':
         specifier: 'catalog:'
-        version: 5.28.5
+        version: 5.28.5(esbuild@0.25.5)
       '@types/webpack-sources':
         specifier: 'catalog:'
         version: 3.2.3
       webpack:
         specifier: 'catalog:'
-        version: 5.99.9
+        version: 5.99.9(esbuild@0.25.5)
 
   packages-presets/extractor-arbitrary-variants:
     dependencies:
@@ -3328,10 +3320,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@nolyfill/is-core-module@1.0.39':
-    resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
-    engines: {node: '>=12.4.0'}
 
   '@nolyfill/is-regex@1.0.44':
     resolution: {integrity: sha512-mIgQATVdwuzpFssMhJK65UhNDcO76lm3BNZ8Vv+itpdROFiWIjKem4wGUVr/S1iJXbyq27c2sRcSidhKlSNtmQ==}
@@ -6081,6 +6069,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   fuse.js@7.1.0:
     resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
     engines: {node: '>=10'}
@@ -6207,6 +6198,10 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -6363,6 +6358,10 @@ packages:
   is-builtin-module@5.0.0:
     resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
     engines: {node: '>=18.20'}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
 
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
@@ -11510,8 +11509,6 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@nolyfill/is-core-module@1.0.39': {}
-
   '@nolyfill/is-regex@1.0.44': {}
 
   '@nolyfill/side-channel@1.0.44': {}
@@ -12401,11 +12398,11 @@ snapshots:
       '@types/source-list-map': 0.1.6
       source-map: 0.7.4
 
-  '@types/webpack@5.28.5':
+  '@types/webpack@5.28.5(esbuild@0.25.5)':
     dependencies:
       '@types/node': 24.0.1
       tapable: 2.2.1
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -14783,6 +14780,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   fuse.js@7.1.0: {}
 
   fzf@0.5.2: {}
@@ -14913,6 +14912,10 @@ snapshots:
       uncrypto: 0.1.3
 
   has-flag@4.0.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -15119,6 +15122,10 @@ snapshots:
   is-builtin-module@5.0.0:
     dependencies:
       builtin-modules: 5.0.0
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
 
   is-docker@2.2.1: {}
 
@@ -17284,13 +17291,13 @@ snapshots:
 
   resolve@1.22.10:
     dependencies:
-      is-core-module: '@nolyfill/is-core-module@1.0.39'
+      is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
   resolve@2.0.0-next.5:
     dependencies:
-      is-core-module: '@nolyfill/is-core-module@1.0.39'
+      is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -17864,14 +17871,16 @@ snapshots:
       unconfig: 7.3.2
       yaml: 2.8.0
 
-  terser-webpack-plugin@5.3.14(webpack@5.99.9):
+  terser-webpack-plugin@5.3.14(esbuild@0.25.5)(webpack@5.99.9(esbuild@0.25.5)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.42.0
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
+    optionalDependencies:
+      esbuild: 0.25.5
 
   terser@5.42.0:
     dependencies:
@@ -18806,7 +18815,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.99.9:
+  webpack@5.99.9(esbuild@0.25.5):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.7
@@ -18829,7 +18838,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.14(webpack@5.99.9)
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.5)(webpack@5.99.9(esbuild@0.25.5))
       watchpack: 2.4.2
       webpack-sources: 3.3.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -159,3 +159,28 @@ catalog:
   webpack-sources: ^3.3.3
   windicss: ^3.5.6
   zimmerframe: ^1.1.2
+
+autoInstallPeers: true
+ignoreWorkspaceRootCheck: true
+shamefullyHoist: true
+strictPeerDependencies: false
+
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - '@tailwindcss/oxide'
+  - core-js
+  - esbuild
+  - msw
+  - nuxt-tsconfig-stub
+  - sharp
+  - simple-git-hooks
+
+overrides:
+  is-arguments: npm:@nolyfill/is-arguments@^1.0.44
+  is-core-module: npm:@nolyfill/is-core-module@^1.0.39
+  is-generator-function: npm:@nolyfill/is-generator-function@^1.0.44
+  is-regex: npm:@nolyfill/is-regex@^1.0.44
+  is-typed-array: npm:@nolyfill/is-typed-array@^1.0.44
+  object.assign: npm:@nolyfill/object.assign@^1.0.44
+  side-channel: npm:@nolyfill/side-channel@^1.0.44
+  which-typed-array: npm:@nolyfill/which-typed-array@^1.0.44


### PR DESCRIPTION
To ease management and avoid conflicts with npm, pnpm supports moving all configurations to the pnpm-workspace.yaml file. For more https://github.com/orgs/pnpm/discussions/9037