### PR TITLE
fix(preset-wind4): shouldn't clear tracked data when reload config

### DIFF
--- a/packages-presets/preset-wind4/src/index.ts
+++ b/packages-presets/preset-wind4/src/index.ts
@@ -159,10 +159,6 @@ export const presetWind4 = definePreset<PresetWind4Options, Theme>((options = {}
       shorthands,
     },
     options,
-    configResolved() {
-      trackedTheme.clear()
-      trackedProperties.clear()
-    },
     meta: {
       themeDeps: trackedTheme,
       propertyDeps: trackedProperties,


### PR DESCRIPTION
`configResolved` runs in next schedule when we in dev mode(vite hmr), it will cleared, and make the page breaking down that lost the tracked theme css.

So, we can't clear them in `configResolved` hook, and i will continue find a better way to implement it.