### PR TITLE
feat(preset-wind4): support `inert` variant

### DIFF
--- a/packages-presets/preset-wind4/src/variants/default.ts
+++ b/packages-presets/preset-wind4/src/variants/default.ts
@@ -10,6 +10,7 @@ import { variantColorsMediaOrClass, variantColorsScheme } from './dark'
 import { variantDataAttribute, variantTaggedDataAttributes } from './data'
 import { variantLanguageDirections } from './directions'
 import { variantImportant } from './important'
+import { variantInert } from './inert'
 import { variantContrasts, variantCustomMedia, variantForcedColors, variantMotions, variantNoscript, variantOrientations, variantPrint, variantScripting } from './media'
 import {
   variantCssLayer,
@@ -62,6 +63,7 @@ export function variants(options: PresetWind4Options): Variant<Theme>[] {
     ...variantLanguageDirections,
     variantScope,
     ...variantChildren,
+    variantInert,
 
     variantContainerQuery,
     variantVariables,

--- a/packages-presets/preset-wind4/src/variants/inert.ts
+++ b/packages-presets/preset-wind4/src/variants/inert.ts
@@ -1,0 +1,7 @@
+import type { Variant } from '@unocss/core'
+import { variantMatcher } from '@unocss/rule-utils'
+
+export const variantInert: Variant = variantMatcher('inert', input => ({
+  parent: `${input.parent ? `${input.parent} $$ ` : ''}${input.selector}`,
+  selector: '&:is([inert],[inert] *)',
+}))

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -1757,6 +1757,9 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .in-data-\[state\=closed\]\:border-5{
 :where(*[data-state=closed]) &{border-width:5px;}
 }
+.inert\:opacity-25{
+&:is([inert],[inert] *){opacity:25%;}
+}
 .parent-aria-\[level\=\"3\"\]\/named\:font-21{
 :where(*[aria-level="3"] > &){--un-font-weight:21;font-weight:21;}
 }

--- a/test/assets/preset-wind4-targets.ts
+++ b/test/assets/preset-wind4-targets.ts
@@ -627,6 +627,9 @@ export const presetWind4Targets: string[] = [
   'in-[a>button:hover]:font-bold',
   'in-data-[state=closed]:border-5',
   'in-aria-[hidden=false]:font-21',
+
+  // inert
+  'inert:opacity-25',
 ]
 
 export const presetWindNonTargets: string[] = [


### PR DESCRIPTION
[tailwindcss](https://tailwindcss.com/docs/hover-focus-and-other-states#styling-inert-elements)