### PR TITLE
chore(svelte-scoped): resolve deprecation of preprocessing from vite plugins

### DIFF
--- a/packages-integrations/svelte-scoped/package.json
+++ b/packages-integrations/svelte-scoped/package.json
@@ -57,7 +57,13 @@
     "test:attw": "attw --pack --config-path ../../.attw-esm-only.json"
   },
   "peerDependencies": {
+    "@sveltejs/vite-plugin-svelte": "catalog:",
     "svelte": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "@sveltejs/vite-plugin-svelte": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@unocss/config": "workspace:*",

--- a/packages-integrations/svelte-scoped/package.json
+++ b/packages-integrations/svelte-scoped/package.json
@@ -56,6 +56,9 @@
     "test:integration": "pnpm -r --filter=\"./test/fixtures/*\" test",
     "test:attw": "attw --pack --config-path ../../.attw-esm-only.json"
   },
+  "peerDependencies": {
+    "svelte": "catalog:"
+  },
   "dependencies": {
     "@unocss/config": "workspace:*",
     "@unocss/preset-uno": "workspace:*",

--- a/packages-integrations/svelte-scoped/src/_vite/passPreprocessToSveltePlugin.ts
+++ b/packages-integrations/svelte-scoped/src/_vite/passPreprocessToSveltePlugin.ts
@@ -1,24 +1,44 @@
 import type { Plugin } from 'vite'
 import type { SvelteScopedContext } from '../preprocess'
 import type { UnocssSvelteScopedViteOptions } from './types'
+import { preprocess } from 'svelte/compiler'
 import UnocssSveltePreprocess from '../preprocess'
 
 export function PassPreprocessToSveltePlugin(context: SvelteScopedContext, options: UnocssSvelteScopedViteOptions = {}): Plugin {
-  let commandIsBuild = true
-  const isBuild = () => commandIsBuild
+  let preprocessor: ReturnType<typeof UnocssSveltePreprocess>
 
-  return {
+  const plugin = {
     name: 'unocss:svelte-scoped:pass-preprocess',
     enforce: 'pre',
 
-    configResolved({ command }) {
-      commandIsBuild = command === 'build'
+    configResolved({ command, plugins }) {
+      preprocessor = UnocssSveltePreprocess(options, context, () => command === 'build')
+
+      // use the exact same id filter as vite-plugin-svelte itself
+      const svelteIdFilter = plugins.find(p => p.name === 'vite-plugin-svelte:config')?.api.idFilter
+      plugin.transform.filter = svelteIdFilter
     },
 
-    api: {
-      sveltePreprocess: UnocssSveltePreprocess(options, context, isBuild),
+    transform: {
+      filter: {
+        // filled above
+      },
+
+      // after base preprocess, but before compile
+      order: 'pre',
+
+      async handler(source, id) {
+        const { code, map } = await preprocess(source, preprocessor, { filename: id })
+
+        if (typeof map === 'string')
+          return { code, map }
+
+        return { code }
+      },
     },
-  }
+  } satisfies Plugin
+
+  return plugin
 }
 
 // reference: https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#how-do-i-add-a-svelte-preprocessor-from-a-vite-plugin

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ catalogs:
     '@shikijs/vitepress-twoslash':
       specifier: ^3.7.0
       version: 3.7.0
+    '@sveltejs/vite-plugin-svelte':
+      specifier: ^6.0.0-next
+      version: 6.0.0-next.2
     '@types/connect':
       specifier: ^3.4.38
       version: 3.4.38
@@ -1168,6 +1171,9 @@ importers:
 
   packages-integrations/svelte-scoped:
     dependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: 'catalog:'
+        version: 6.0.0-next.2(svelte@5.34.7)(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@unocss/config':
         specifier: workspace:*
         version: link:../../packages-engine/config
@@ -3883,6 +3889,21 @@ packages:
     resolution: {integrity: sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==}
     peerDependencies:
       acorn: ^8.9.0
+
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.0-next.1':
+    resolution: {integrity: sha512-720vO2VFSkRY6WL9NXPpcVc8OxAc6HDIkJlbVqkRgZFPzJca/W1txi3fJKZTQhixaKnu/NAXhpcrEQV8HcEUzw==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^6.0.0-next.0
+      svelte: ^5.0.0
+      vite: ^7.0.0
+
+  '@sveltejs/vite-plugin-svelte@6.0.0-next.2':
+    resolution: {integrity: sha512-xXGRZMwyZofeclbtzjbyoPfQBExeFPb/mpYTf7o0brQAmIKKQa4BItSycWZnIKSQSJg9FO/1SVV+GyuYhoaFxQ==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
+    peerDependencies:
+      svelte: ^5.0.0
+      vite: ^7.0.0
 
   '@tailwindcss/node@4.1.10':
     resolution: {integrity: sha512-2ACf1znY5fpRBwRhMgj9ZXvb2XZW8qs+oTfotJ2C5xR0/WNL7UHZ7zXl6s+rUqedL1mNi+0O+WQr5awGowS3PQ==}
@@ -9270,6 +9291,14 @@ packages:
       vite:
         optional: true
 
+  vitefu@1.1.0:
+    resolution: {integrity: sha512-AiG/L9DVsEYHWQ9jAEnke0nKiASlPw+JYwDl6Z4l6a6/IqT1tKseEl6R5+rVnKJt/K3jCTWiQvgoIh5MuqBJJQ==}
+    peerDependencies:
+      vite: ^7.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   vitepress-plugin-group-icons@1.6.0:
     resolution: {integrity: sha512-+nxuVETpFkOYR5qHdvj3M5otWusJyS3ozEvVf1aQaE5Oz5e6NR0naYKTtH0Zf3Qss4vnhqaYt2Lq4jUTn9JVuA==}
     peerDependencies:
@@ -12176,6 +12205,28 @@ snapshots:
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
+
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.0-next.1(@sveltejs/vite-plugin-svelte@6.0.0-next.2(svelte@5.34.7)(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(svelte@5.34.7)(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 6.0.0-next.2(svelte@5.34.7)(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      debug: 4.4.1
+      svelte: 5.34.7
+      vite: 7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@6.0.0-next.2(svelte@5.34.7)(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.0-next.1(@sveltejs/vite-plugin-svelte@6.0.0-next.2(svelte@5.34.7)(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(svelte@5.34.7)(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      debug: 4.4.1
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.17
+      svelte: 5.34.7
+      vite: 7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vitefu: 1.1.0(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+    transitivePeerDependencies:
+      - supports-color
 
   '@tailwindcss/node@4.1.10':
     dependencies:
@@ -18592,6 +18643,10 @@ snapshots:
       yaml: 2.8.0
 
   vitefu@1.0.5(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)):
+    optionalDependencies:
+      vite: 7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+
+  vitefu@1.1.0(vite@7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)):
     optionalDependencies:
       vite: 7.0.0(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,6 +52,7 @@ catalog:
   '@shikijs/markdown-it': ^3.7.0
   '@shikijs/vitepress-twoslash': ^3.7.0
   '@sveltejs/kit': ^2.22.0
+  '@sveltejs/vite-plugin-svelte': ^6.0.0-next
   '@types/connect': ^3.4.38
   '@types/css-tree': ^2.3.10
   '@types/fs-extra': ^11.0.4


### PR DESCRIPTION
The `vite-plugin-svelte` has deprecated passing preprocessors to itself: https://github.com/sveltejs/vite-plugin-svelte/pull/1145
This will be released in the next major and results in this warning:

> [!WARNING]
> [vite-plugin-svelte] The following plugins use the deprecated 'plugin.api.sveltePreprocess' field. Please contact their maintainers and ask them to use a vite plugin transform instead: unocss:svelte-scoped:pass-preprocess

This PR should probably be postponed after that major release and have the peer dep version adjusted.