### PR TITLE
fix(svelte-scoped): create uno generator uniformly

### DIFF
--- a/packages-integrations/svelte-scoped/build.config.ts
+++ b/packages-integrations/svelte-scoped/build.config.ts
@@ -17,7 +17,7 @@ export default defineBuildConfig({
     '@jridgewell/resolve-uri',
     '@unocss/core',
     '@unocss/config',
-    '@unocss/preset-uno',
+    '@unocss/preset-wind3',
     '@unocss/reset',
     'css-tree',
     'svelte',


### PR DESCRIPTION
Before this PR the generator is created differently for both cases. This fixes it and also uses `preset-wind3` instead of the deprecated `preset-uno`.