### PR TITLE
fix(svelte-scoped): correctly transform rules with only --at-apply

### DIFF
--- a/packages-integrations/svelte-scoped/src/_preprocess/transformApply/index.ts
+++ b/packages-integrations/svelte-scoped/src/_preprocess/transformApply/index.ts
@@ -50,10 +50,17 @@ async function parseApply({ s, uno, applyVariables }: TransformApplyContext, nod
   if (!utils.length)
     return
 
+  let end = childNode.loc!.end.offset
+
+  const maybeSemi = s.slice(end, end + 1)
+  if (maybeSemi === ';') {
+    end += 1
+  }
+
+  s.remove(childNode.loc!.start.offset, end)
+
   for (const util of utils)
     writeUtilStyles(util, s, node, childNode)
-
-  s.remove(childNode!.loc!.start.offset, childNode!.loc!.end.offset)
 }
 
 function getChildNodeValue(childNode: CssNode, applyVariables: string[]): string | undefined {


### PR DESCRIPTION
Right now the svelte-scoped integration results in invalid css (at least from the perspective of `vite-plugin-svelte`) if in a rule in the style block there is only an apply (`@apply` or `--at-apply`) and this line ends with a semicolon.

Notice the double semicolon at the end of line 62:

```
09:43:08 [vite] (ssr) Error when evaluating SSR module /src/routes/+page.svelte: src/routes/+page.svelte:62:149 Declaration cannot be empty
https://svelte.dev/e/css_empty_declaration

- Did you forget to add a lang attribute to your style tag?
  Plugin: vite-plugin-svelte
  File: src/routes/+page.svelte:62:149
   60 |  <style>:global(._mx-auto_17hw2a){m... snip
   61 |    .corner {
   62 |      position:fixed;left:0.5rem;bottom:0.5rem;display:flex;--un-bg-opacity:1;background-color:rgb(255 255 255 / var(--un-bg-opacity));padding:0.25rem;;
           ^
   63 |    }:global(.dark) .corner{--un-bg-opacity:1;background-color:rgb(0 0 0 / var(--un-bg-opacity));}@media (min-width: 768px){.corner{left:1.5rem;bottom:1.5rem;}}
   64 |   *{}</style>
```

This can be workedaround by adding anything that is no whitespace behind the `--at-apply: ` line (I always used `/*/`). But this fixes the problem. I also added a check to not remove anything wrong if the line does not end with a semicolon.