### PR TITLE
docs: replace code focus with code ++ to increase legibility

### DIFF
--- a/docs/presets/wind4.md
+++ b/docs/presets/wind4.md
@@ -136,9 +136,9 @@ import { defineConfig } from 'unocss'
 export default defineConfig({
   presets: [
     presetWind4({
-      preflights: { // [!code focus]
-        reset: true, // [!code focus]
-      } // [!code focus]
+      preflights: { // [!code ++]
+        reset: true, // [!code ++]
+      } // [!code ++]
     }),
   ],
 })
@@ -162,9 +162,9 @@ import { defineConfig, presetWind4 } from 'unocss'
 export default defineConfig({
   presets: [
     presetWind4({
-      preflights: { // [!code focus]
-        theme: true, // [!code focus]
-      }, // [!code focus]
+      preflights: { // [!code ++]
+        theme: true, // [!code ++]
+      }, // [!code ++]
     }),
   ],
 })
@@ -175,18 +175,18 @@ export default defineConfig({
 And you can further control the output of your theme variables. For example, if you want to convert `rem` to `px` for theme variables, we provide the `createRemToPxProcessor` function to process your theme variables.
 
 ```ts twoslash [uno.config.ts]
-import { createRemToPxProcessor } from '@unocss/preset-wind4/utils' // [!code focus]
+import { createRemToPxProcessor } from '@unocss/preset-wind4/utils' // [!code ++]
 import { defineConfig, presetWind4 } from 'unocss'
 
 export default defineConfig({
   presets: [
     presetWind4({
-      preflights: { // [!code focus]
-        theme: { // [!code focus]
-          mode: 'on-demand', // Default by 'on-demand' // [!code focus]
-          process: createRemToPxProcessor(), // [!code focus]
-        } // [!code focus]
-      }, // [!code focus]
+      preflights: { // [!code ++]
+        theme: { // [!code ++]
+          mode: 'on-demand', // Default by 'on-demand' // [!code ++]
+          process: createRemToPxProcessor(), // [!code ++]
+        } // [!code ++]
+      }, // [!code ++]
     }),
   ],
 })
@@ -195,20 +195,20 @@ export default defineConfig({
 By the way, if you want to use the `presetRemToPx` preset to convert `rem` to `px`, you no longer need to import this preset separately as `presetWind4` provides this functionality internally.
 
 ```ts twoslash [uno.config.ts]
-import { createRemToPxProcessor } from '@unocss/preset-wind4/utils' // [!code focus]
+import { createRemToPxProcessor } from '@unocss/preset-wind4/utils' // [!code ++]
 import { defineConfig, presetWind4 } from 'unocss'
 
 export default defineConfig({
   presets: [
     presetWind4({
-      preflights: { // [!code focus]
-        theme: { // [!code focus]
-          process: createRemToPxProcessor(), // [!code focus]
-        } // [!code focus]
-      }, // [!code focus]
+      preflights: { // [!code ++]
+        theme: { // [!code ++]
+          process: createRemToPxProcessor(), // [!code ++]
+        } // [!code ++]
+      }, // [!code ++]
     }),
   ],
-  postprocess: [createRemToPxProcessor()], // [!code focus]
+  postprocess: [createRemToPxProcessor()], // [!code ++]
 })
 ```
 


### PR DESCRIPTION
This PR replaces the `[!code focus]` with `[!code ++]` in the docs to make the text easier to read. The blur of the code focus is imo a bit distracting and I think the green highlight of the diff makes it a bit more clear what you need to copy to make something work.