### PR TITLE
fix(sort-rules): prevent generate extra space

### DIFF
--- a/virtual-shared/integration/src/sort-rules.ts
+++ b/virtual-shared/integration/src/sort-rules.ts
@@ -17,6 +17,8 @@ export async function sortRules(rules: string, uno: UnoGenerator) {
   const result: Array<[number, string] | undefined> = []
   const arr = rules.split(/\s+/g)
   for (const i of arr) {
+    if (!i)
+      continue
     const token = await uno.parseToken(i)
     if (token == null) {
       unknown.push(i)

--- a/virtual-shared/integration/test/sort-rules.test.ts
+++ b/virtual-shared/integration/test/sort-rules.test.ts
@@ -33,4 +33,11 @@ describe('sort rules', async () => {
     expect(await sort('hover:(pt-2 p-4) hover:text-red hover:focus:(m1 mx2) foo'))
       .toMatchInlineSnapshot('"foo hover:(p-4 pt-2 text-red) hover:focus:(m1 mx2)"')
   })
+
+  it('should not add extra space', async () => {
+    expect(await sort('none-uno-class mr-1 ml-1'))
+      .toMatchInlineSnapshot('"none-uno-class ml-1 mr-1"')
+    expect(await sort(' none-uno-class mr-1 ml-1 '))
+      .toMatchInlineSnapshot('"none-uno-class ml-1 mr-1"')
+  })
 })


### PR DESCRIPTION
without this fix

```tsx
expect(await sort(' none-uno-class mr-1 ml-1 '))
      .toMatchInlineSnapshot('"none-uno-class ml-1 mr-1"')
```

will fail with an extra space

<img width="1533" height="297" alt="image" src="https://github.com/user-attachments/assets/cdd82284-f297-418e-bc46-f171cad449e6" />
