### PR TITLE
fix(transformer-compile-class)!: remove not rigorous sort

### DIFF
--- a/packages-presets/transformer-compile-class/src/index.ts
+++ b/packages-presets/transformer-compile-class/src/index.ts
@@ -107,7 +107,6 @@ export default function transformerCompileClass(options: CompileClassOptions = {
         }
 
         if (body) {
-          body = body.split(/\s+/).sort().join(' ')
           let hash: string
           let explicitName = false
 

--- a/test/transformer-compile-class.test.ts
+++ b/test/transformer-compile-class.test.ts
@@ -46,32 +46,24 @@ describe('transformer-compile-class', () => {
 </div>
     `.trim())
     expect(result.code.trim()).toMatchInlineSnapshot(`
-      "<div class="uno-pe1esh">
+      "<div class="uno-qe05lz">
       <div class="foo bar">
 
-      <div class="uno-cbgd7b foo">
-        <div class="uno-s9yxer"/>
+      <div class="uno-qlmcrp foo">
+        <div class="uno-0qw2gr"/>
       </div>"
     `)
     expect(result.css).toMatchInlineSnapshot(`
       "/* layer: shortcuts */
-      .uno-pe1esh{--un-scale-x:0.05;--un-scale-y:0.05;transform:translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z)) rotate(var(--un-rotate)) rotateX(var(--un-rotate-x)) rotateY(var(--un-rotate-y)) rotateZ(var(--un-rotate-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z));border-width:1px;--un-border-opacity:1;border-color:rgb(229 231 235 / var(--un-border-opacity));--un-bg-opacity:1;background-color:rgb(239 68 68 / var(--un-bg-opacity));font-size:1.25rem;line-height:1.75rem;font-weight:700;}
-      .dark .uno-pe1esh:hover{--un-bg-opacity:1;background-color:rgb(34 197 94 / var(--un-bg-opacity));}
-      .uno-cbgd7b{text-align:center;}
-      .uno-s9yxer{font-size:0.875rem;line-height:1.25rem;font-weight:700;}
-      .uno-s9yxer:hover{--un-text-opacity:1;color:rgb(248 113 113 / var(--un-text-opacity));}
+      .uno-qe05lz{--un-scale-x:0.05;--un-scale-y:0.05;transform:translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z)) rotate(var(--un-rotate)) rotateX(var(--un-rotate-x)) rotateY(var(--un-rotate-y)) rotateZ(var(--un-rotate-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z));border-width:1px;--un-border-opacity:1;border-color:rgb(229 231 235 / var(--un-border-opacity));--un-bg-opacity:1;background-color:rgb(239 68 68 / var(--un-bg-opacity));font-size:1.25rem;line-height:1.75rem;font-weight:700;}
+      .dark .uno-qe05lz:hover{--un-bg-opacity:1;background-color:rgb(34 197 94 / var(--un-bg-opacity));}
+      .uno-qlmcrp{text-align:center;}
+      .uno-0qw2gr{font-size:0.875rem;line-height:1.25rem;font-weight:700;}
+      .uno-0qw2gr:hover{--un-text-opacity:1;color:rgb(248 113 113 / var(--un-text-opacity));}
       @media (min-width: 640px){
-      .uno-cbgd7b{text-align:left;}
+      .uno-qlmcrp{text-align:left;}
       }"
     `)
-  })
-
-  it('different sequence of utility classes', async () => {
-    const order1 = await transform('<div class=":uno: flex bg-blue-400 my-awesome-class font-bold"></div>')
-    const order2 = await transform('<div class=":uno: my-awesome-class bg-blue-400  font-bold flex"></div>')
-
-    expect(order1.css).toBe(order2.css)
-    expect(order1.code).toBe(order2.code)
   })
 
   it('custom class name trigger (without class name)', async () => {
@@ -128,23 +120,6 @@ describe('transformer-compile-class', () => {
     }).rejects.toMatchInlineSnapshot(`[Error: Duplicated compile class name "uno-foo". One is "w-2" and the other is "w-1". Please choose different class name or set 'alwaysHash' to 'true'.]`)
   })
 
-  it('custom class name should not conflict when the content is the same', async () => {
-    const result = await transform(`
-<div class=":uno-foo: h-1 w-1"/>
-<div class=":uno-foo: w-1 h-1"/>
-    `.trim())
-
-    expect(result.code.trim()).toMatchInlineSnapshot(`
-      "<div class="uno-foo"/>
-      <div class="uno-foo"/>"
-    `)
-
-    expect(result.css.trim()).toMatchInlineSnapshot(`
-      "/* layer: shortcuts */
-      .uno-foo{height:0.25rem;width:0.25rem;}"
-    `)
-  })
-
   it('normal class name should not conflicts', async () => {
     const result = await transform(`
 <div class=":uno: w-1 h-1"/>
@@ -153,8 +128,8 @@ describe('transformer-compile-class', () => {
     `)
 
     expect(result.code.trim()).toMatchInlineSnapshot(`
-      "<div class="uno-prhvrm"/>
-      <div class="uno-umiu5u"/>
+      "<div class="uno-d5cxre"/>
+      <div class="uno-o9cz6y"/>
       <div class="uno-prhvrm"/>"
     `)
   })


### PR DESCRIPTION
close #4840, related #1416

This PR removes non-strict sorting. Using only `sort()` to sort can cause class priority confusion. Since classes have a clear order of precedence, incorrect sorting can lead to unexpected compilation results.

e.g.

Before:
```html
<div class="bg-red bg-blue" /> 
```

Will be transformed

```html
<div class="bg-blue bg-red" /> 
```

For example, if we consider that there are shortcuts, since we don’t know how the shortcuts are named by users, I think the sorting method is extremely complicated.

Before:
```ts
{
  shourtcuts: {
    btn: 'bg-teal'
  }
}
```

```html
<div class="btn bg-blue" /> 
```

Will be transformed

```html
<div class="bg-blue btn" /> 
```

To sum up, I decided to temporarily give up the support for deduplication after sorting.