### PR TITLE
fix(eslint): enhance `unoFunctions` option with nested object expressions

### DIFF
--- a/packages-integrations/eslint-plugin/src/rules/order.test.ts
+++ b/packages-integrations/eslint-plugin/src/rules/order.test.ts
@@ -215,6 +215,9 @@ run({
     'clsx(String.raw`bg-[var(--some\_variable\_with\_underscore)] pl1 pr1`)',
     { code: `superclass('pl1 pr1', test ? 'ml-1 mr-1' : 'left-1 right-1', 'bottom-1 top-1')`, options: [{ unoFunctions: ['superclass'] }] },
     { code: `abc('pl1 pr1', test ? 'ml-1 mr-1' : 'left-1 right-1', test && 'bottom-1 top-1', { 'bottom-1 top-1': test })`, options: [{ unoFunctions: ['abc'] }] },
+    { code: `cva({ variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })`, options: [{ unoFunctions: ['cva'] }] },
+    { code: `cva('bottom-1 top-1', { variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })`, options: [{ unoFunctions: ['cva'] }] },
+    { code: `tv({ base: 'bottom-1 top-1', variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })`, options: [{ unoFunctions: ['tv'] }] },
     // eslint-disable-next-line no-template-curly-in-string
     'clsx(`pl1 pr1 ${more}`, test ? `ml-1 mr-1 ${more}` : `left-1 right-1 ${more}`, test && `bottom-1 top-1 ${more}`, { [`bottom-1 top-1 ${more}`]: test })',
     `notSorted('mr-1 ml-1')`,
@@ -279,6 +282,41 @@ run({
       errors: [
         { messageId: 'invalid-order' },
         { messageId: 'invalid-order' },
+        { messageId: 'invalid-order' },
+        { messageId: 'invalid-order' },
+        { messageId: 'invalid-order' },
+      ],
+    },
+    {
+      options: [{ unoFunctions: ['cva'] }],
+      code: `cva({ variants: { size: { small: 'px-2 text-sm py-1', medium: 'px-4 text-base py-2' } } })`,
+      output: output => expect(output).toMatchInlineSnapshot(`
+            "cva({ variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })"
+      `),
+      errors: [
+        { messageId: 'invalid-order' },
+        { messageId: 'invalid-order' },
+      ],
+    },
+    {
+      options: [{ unoFunctions: ['cva'] }],
+      code: `cva('top-1 bottom-1', { variants: { size: { small: 'px-2 text-sm py-1', medium: 'px-4 text-base py-2' } } })`,
+      output: output => expect(output).toMatchInlineSnapshot(`
+            "cva('bottom-1 top-1', { variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })"
+      `),
+      errors: [
+        { messageId: 'invalid-order' },
+        { messageId: 'invalid-order' },
+        { messageId: 'invalid-order' },
+      ],
+    },
+    {
+      options: [{ unoFunctions: ['tv'] }],
+      code: `tv({ base: 'top-1 bottom-1', variants: { size: { small: 'px-2 text-sm py-1', medium: 'px-4 text-base py-2' } } })`,
+      output: output => expect(output).toMatchInlineSnapshot(`
+            "tv({ base: 'bottom-1 top-1', variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })"
+      `),
+      errors: [
         { messageId: 'invalid-order' },
         { messageId: 'invalid-order' },
         { messageId: 'invalid-order' },


### PR DESCRIPTION
This PR enhances the `@unocss/order` ESLint rule to properly handle nested object expressions in custom functions like `cva` and `tv`, ensuring UnoCSS class ordering is correctly applied throughout complex component variant structures.

### 🐛 Problem

The `@unocss/order` ESLint rule was not properly traversing and ordering UnoCSS classes within nested object expressions used by popular variant libraries like [class-variance-authority](https://www.npmjs.com/package/class-variance-authority) (`cva`) and [tailwind-variants](https://www.npmjs.com/package/tailwind-variants) (`tv`). The `unoFunctions` option only worked with functions accepting simple string parameters, which worked perfectly with utility functions like `clsx` and `cx`:

```javascript
clsx('text-sm px-2 py-1') // ✅ Correctly processed
cx('text-base px-4 py-2') // ✅ Correctly processed
```

However, it failed to traverse and process functions with nested object expressions like `cva` and `tv`, resulting in inconsistent class ordering in component variant definitions where classes within nested objects remained unprocessed.

### ✨ Changes

This enhancement introduces intelligent object traversal capabilities to the `@unocss/order` rule, enabling it to recursively process nested object expressions within function calls.

#### Before

```javascript
cva('top-1 bottom-1', { // ❌ Not processed
  variants: {
    size: {
      small: 'px-2 text-sm py-1', // ❌ Not processed
      medium: 'px-4 text-base py-2' // ❌ Not processed
    }
  }
})

tv({
  base: 'top-1 bottom-1', // ❌ Not processed
  variants: {
    size: {
      small: 'px-2 text-sm py-1', // ❌ Not processed
      medium: 'px-4 text-base py-2' // ❌ Not processed
    }
  }
})
```

#### After

```javascript
cva('bottom-1 top-1', { // ✅ Correctly processed
  variants: {
    size: {
      small: 'text-sm px-2 py-1', // ✅ Correctly processed
      medium: 'text-base px-4 py-2' // ✅ Correctly processed
    }
  }
})

tv({
  base: 'bottom-1 top-1', // ✅ Correctly processed
  variants: {
    size: {
      small: 'text-sm px-2 py-1', // ✅ Correctly processed
      medium: 'text-base px-4 py-2' // ✅ Correctly processed
    }
  }
})
```