### PR TITLE
perf: use `crypto.hash` when available

### DIFF
--- a/virtual-shared/integration/src/hash.ts
+++ b/virtual-shared/integration/src/hash.ts
@@ -1,8 +1,14 @@
-import { createHash } from 'node:crypto'
+import crypto from 'node:crypto'
+
+const hash
+  // crypto.hash is supported in Node 21.7.0+, 20.12.0+
+  = crypto.hash
+    ?? ((
+      algorithm: string,
+      data: crypto.BinaryLike,
+      outputEncoding: crypto.BinaryToTextEncoding,
+    ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
 
 export function getHash(input: string, length = 8) {
-  return createHash('sha256')
-    .update(input)
-    .digest('hex')
-    .slice(0, length)
+  return hash('sha256', input, 'hex').substring(0, length)
 }


### PR DESCRIPTION
ref: https://github.com/vitejs/vite/pull/18317