### PR TITLE
fix(vscode, autocomplete): pre-sense template errors

### DIFF
--- a/alias.ts
+++ b/alias.ts
@@ -39,6 +39,7 @@ export const aliasVirtual: Record<string, string> = {
   '#integration/content': r('./virtual-shared/integration/src/content.ts'),
   '#integration/context': r('./virtual-shared/integration/src/context.ts'),
   '#integration/defaults': r('./virtual-shared/integration/src/defaults.ts'),
+  '#integration/env': r('./virtual-shared/integration/src/env.ts'),
   '#integration/hash': r('./virtual-shared/integration/src/hash.ts'),
   '#integration/layers': r('./virtual-shared/integration/src/layers.ts'),
   '#integration/match-positions': r('./virtual-shared/integration/src/match-positions.ts'),

--- a/packages-engine/autocomplete/build.config.ts
+++ b/packages-engine/autocomplete/build.config.ts
@@ -1,9 +1,11 @@
 import { defineBuildConfig } from 'unbuild'
+import { aliasVirtual } from '../../alias'
 
 export default defineBuildConfig({
   entries: [
     'src/index',
   ],
+  alias: aliasVirtual,
   clean: true,
   declaration: true,
   externals: [

--- a/packages-engine/autocomplete/src/create.ts
+++ b/packages-engine/autocomplete/src/create.ts
@@ -9,7 +9,7 @@ import { parseAutocomplete } from './parse'
 import { searchAttrKey, searchUsageBoundary } from './utils'
 
 export function createAutocomplete(
-  _uno: UnoGenerator | Promise<UnoGenerator>,
+  uno: UnoGenerator,
   options: AutocompleteOptions = {},
 ): UnocssAutocomplete {
   const templateCache = new Map<string, ParsedAutocompleteTemplate>()
@@ -22,9 +22,7 @@ export function createAutocomplete(
 
   const matchType = options.matchType ?? 'prefix'
 
-  let uno: UnoGenerator
-
-  const ready = reset()
+  reset()
 
   return {
     suggest,
@@ -65,7 +63,6 @@ export function createAutocomplete(
   }
 
   async function suggest(input: string, allowsEmptyInput = false) {
-    await ready
     if (!allowsEmptyInput && input.length < 1)
       return []
     if (cache.has(input))
@@ -115,7 +112,6 @@ export function createAutocomplete(
   }
 
   async function suggestInFile(content: string, cursor: number): Promise<SuggestResult | undefined> {
-    await ready
     const isInsideAttrValue = searchAttrKey(content, cursor) !== undefined
 
     // try resolve by extractors
@@ -183,14 +179,10 @@ export function createAutocomplete(
     return ps.flatMap(i => i.status === 'fulfilled' ? i.value : [])
   }
 
-  async function reset() {
+  function reset() {
     templateCache.clear()
     cache.clear()
     errorCache.clear()
-
-    if (!uno) {
-      uno = await Promise.resolve(_uno)
-    }
 
     staticUtils = [
       ...Object.keys(uno.config.rulesStaticMap),

--- a/packages-engine/autocomplete/src/create.ts
+++ b/packages-engine/autocomplete/src/create.ts
@@ -1,17 +1,13 @@
 import type { AutoCompleteExtractorResult, AutoCompleteFunction, AutoCompleteTemplate, SuggestResult, UnoGenerator } from '@unocss/core'
 import type { AutocompleteParseError } from './parse'
 import type { AutocompleteOptions, ParsedAutocompleteTemplate, UnocssAutocomplete } from './types'
-import { getEnvFlags } from '#integration/env'
 import { escapeRegExp, toArray, uniq } from '@unocss/core'
 import { byLengthAsc, byStartAsc, Fzf } from 'fzf'
 import { LRUCache } from 'lru-cache'
 import { parseAutocomplete } from './parse'
 import { searchAttrKey, searchUsageBoundary } from './utils'
 
-export function createAutocomplete(
-  uno: UnoGenerator,
-  options: AutocompleteOptions = {},
-): UnocssAutocomplete {
+export function createAutocomplete(uno: UnoGenerator, options: AutocompleteOptions = {}): UnocssAutocomplete {
   const templateCache = new Map<string, ParsedAutocompleteTemplate>()
   const cache = new LRUCache<string, string[]>({ max: 5000 })
   const errorCache = new Map<string, AutocompleteParseError[]>()
@@ -20,7 +16,10 @@ export function createAutocomplete(
 
   const templates: (AutoCompleteTemplate | AutoCompleteFunction)[] = []
 
-  const matchType = options.matchType ?? 'prefix'
+  const {
+    matchType = 'prefix',
+    throwErrors = true,
+  } = options
 
   reset()
 
@@ -211,7 +210,7 @@ export function createAutocomplete(
       }
     }
 
-    if (errorCache.size && !getEnvFlags().isVSCode) {
+    if (errorCache.size && throwErrors) {
       const message = Array.from(errorCache.values())
         .flat()
         .map(error => error.toString())

--- a/packages-engine/autocomplete/src/create.ts
+++ b/packages-engine/autocomplete/src/create.ts
@@ -173,7 +173,7 @@ export function createAutocomplete(
 
   async function suggestFromTemplates(input: string) {
     const ps = await Promise.allSettled([
-      Array.from(templateCache.values()).map(({ suggest }) => suggest(input, matchType) ?? []).flat(),
+      Array.from(templateCache.values()).flatMap(({ suggest }) => suggest(input, matchType) ?? []),
       ...templates.filter(fn => typeof fn === 'function').map(fn => fn(input)),
     ])
     return ps.flatMap(i => i.status === 'fulfilled' ? i.value : [])

--- a/packages-engine/autocomplete/src/parse.ts
+++ b/packages-engine/autocomplete/src/parse.ts
@@ -12,7 +12,7 @@ export class AutocompleteParseError extends Error {
   }
 
   toString() {
-    return `⚠️ [${this.name}]: ${this.message}. ${this.template ? `Template: ${this.template}` : ''}`
+    return `⚠️ [${this.name}]: ${this.message}. ${this.template ? `Template: ${this.template}.` : ''}`
   }
 }
 

--- a/packages-engine/autocomplete/src/parse.ts
+++ b/packages-engine/autocomplete/src/parse.ts
@@ -40,9 +40,11 @@ export function parseAutocomplete(template: string, theme: any = {}, extraShorth
     ...extraShorthands,
   }
 
-  template = template.replace(/<(\w+)>/g, (_, key) => {
-    if (!newShorthands[key])
-      throw new Error(`Unknown template shorthand: ${key}`)
+  template = template.replace(/<(\w+)>/g, (match, key, _, raw) => {
+    if (!newShorthands[key]) {
+      console.warn(`⚠️ Unknown template shorthand: <${key}> in ${raw}`)
+      return match
+    }
     return newShorthands[key]
   })
 
@@ -64,8 +66,10 @@ export function parseAutocomplete(template: string, theme: any = {}, extraShorth
           type: 'theme',
           objects: m[1].split('|').map((i) => {
             return i.split('.').reduce((v, k) => {
-              if (!k || !v[k])
-                throw new Error(`Invalid theme key ${k}`)
+              if (!k || !v[k]) {
+                console.warn(`⚠️ Invalid theme key: ${k} in ${m.input}`)
+                return {}
+              }
               return v[k]
             }, theme)
           }),

--- a/packages-engine/autocomplete/src/types.ts
+++ b/packages-engine/autocomplete/src/types.ts
@@ -6,6 +6,7 @@ export type AutoCompleteMatchType = 'prefix' | 'fuzzy'
 
 export interface AutocompleteOptions {
   matchType?: AutoCompleteMatchType
+  throwErrors?: boolean
 }
 
 export type AutocompleteTemplatePart = AutocompleteTemplateStatic | AutocompleteTemplateGroup | AutocompleteTemplateTheme

--- a/packages-engine/autocomplete/src/types.ts
+++ b/packages-engine/autocomplete/src/types.ts
@@ -1,5 +1,6 @@
 import type { AutoCompleteFunction, SuggestResult } from '@unocss/core'
 import type { LRUCache } from 'lru-cache'
+import type { AutocompleteParseError } from './parse'
 
 export type AutoCompleteMatchType = 'prefix' | 'fuzzy'
 
@@ -27,6 +28,7 @@ export interface AutocompleteTemplateTheme {
 export interface ParsedAutocompleteTemplate {
   parts: AutocompleteTemplatePart[]
   suggest: (input: string, matchType?: AutoCompleteMatchType) => string[] | undefined
+  errors: AutocompleteParseError[]
 }
 
 export interface UnocssAutocomplete {
@@ -34,6 +36,7 @@ export interface UnocssAutocomplete {
   suggestInFile: (content: string, cursor: number) => Promise<SuggestResult | undefined>
   templates: (string | AutoCompleteFunction)[]
   cache: LRUCache<string, string[]>
+  errorCache: Map<string, AutocompleteParseError[]>
   reset: () => Promise<void>
   enumerate: () => Promise<Set<string>>
 }

--- a/packages-engine/autocomplete/src/types.ts
+++ b/packages-engine/autocomplete/src/types.ts
@@ -37,6 +37,6 @@ export interface UnocssAutocomplete {
   templates: (string | AutoCompleteFunction)[]
   cache: LRUCache<string, string[]>
   errorCache: Map<string, AutocompleteParseError[]>
-  reset: () => Promise<void>
+  reset: () => void
   enumerate: () => Promise<Set<string>>
 }

--- a/packages-engine/autocomplete/test/__snapshots__/autocomplete.test.ts.snap
+++ b/packages-engine/autocomplete/test/__snapshots__/autocomplete.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`autocomplete > should accept variants 1`] = `
 [
   "dark:md:m-xy",
-  "dark:md:marker:",
   "dark:md:max-block",
   "dark:md:max-block-auto",
   "dark:md:max-block-lg",
@@ -108,8 +107,6 @@ exports[`autocomplete > should accept variants 1`] = `
   "dark:md:min-w-sm",
   "dark:md:min-w-xl",
   "dark:md:min-w-xs",
-  "dark:md:motion-reduce:",
-  "dark:md:motion-safe:",
   "dark:md:m-bs-0",
   "dark:md:m-be-0",
   "dark:md:m-is-0",
@@ -382,14 +379,14 @@ exports[`autocomplete > should provide autocomplete 1`] = `
   "keyframes-": "keyframes-back-in-down keyframes-back-in-left keyframes-back-in-right keyframes-back-in-up keyframes-back-out-down keyframes-back-out-left keyframes-back-out-right keyframes-back-out-up keyframes-bounce keyframes-bounce-alt",
   "leading-": "leading-loose leading-none leading-normal leading-relaxed leading-snug leading-tight",
   "line-clamp-": "line-clamp-inherit line-clamp-initial line-clamp-none line-clamp-revert line-clamp-revert-layer line-clamp-unset line-clamp-0 line-clamp-1 line-clamp-2 line-clamp-3",
-  "m-": "m-xy marker: max-block max-block-auto max-block-lg max-block-md max-block-none max-block-prose max-block-screen max-block-sm",
+  "m-": "m-xy max-block max-block-auto max-block-lg max-block-md max-block-none max-block-prose max-block-screen max-block-sm max-block-xl",
   "max-w-": "max-w-auto max-w-full max-w-lg max-w-md max-w-none max-w-prose max-w-screen max-w-sm max-w-xl max-w-xs",
   "mx-": "m-xy mx-0 mx-1 mx-2 mx-3 mx-4 mx-5 mx-6 mx-8 mx-10",
   "object-": "object-b object-bc object-bl object-bottom object-bottom-center object-bottom-left object-bottom-right object-br object-c object-cb",
   "origin-": "origin-b origin-bc origin-bl origin-bottom origin-bottom-center origin-bottom-left origin-bottom-right origin-br origin-c origin-cb",
   "outline-": "outline-amber outline-auto outline-black outline-blue outline-bluegray outline-blueGray outline-coolgray outline-coolGray outline-current outline-cyan",
   "outline-offset-": "outline-offset-0 outline-offset-1 outline-offset-2 outline-offset-3 outline-offset-4 outline-offset-5 outline-offset-6 outline-offset-8 outline-offset-10 outline-offset-12",
-  "placeholder-": "placeholder-.dark: placeholder-.light: placeholder-@dark: placeholder-@hover: placeholder-@light: placeholder-*: placeholder-accent-amber placeholder-accent-black placeholder-accent-blue placeholder-accent-bluegray",
+  "placeholder-": "placeholder-accent-amber placeholder-accent-black placeholder-accent-blue placeholder-accent-bluegray placeholder-accent-blueGray placeholder-accent-coolgray placeholder-accent-coolGray placeholder-accent-current placeholder-accent-cyan placeholder-accent-dark",
   "rows-": "rows-0 rows-1 rows-2 rows-3 rows-4 rows-5 rows-6 rows-8 rows-10 rows-12",
   "scale-": "scale-0 scale-10 scale-20 scale-30 scale-40 scale-50 scale-60 scale-70 scale-80 scale-90",
   "scale-x-": "scale-x-0 scale-x-10 scale-x-20 scale-x-30 scale-x-40 scale-x-50 scale-x-60 scale-x-70 scale-x-80 scale-x-90",
@@ -443,7 +440,6 @@ exports[`autocomplete > should provide skip DEFAULT 1`] = `
 exports[`autocomplete with attributify prefix > should accept variants 1`] = `
 [
   "u-dark:md:m-xy",
-  "u-dark:md:marker:",
   "u-dark:md:max-block",
   "u-dark:md:max-block-auto",
   "u-dark:md:max-block-lg",
@@ -462,6 +458,7 @@ exports[`autocomplete with attributify prefix > should accept variants 1`] = `
   "u-dark:md:max-h-none",
   "u-dark:md:max-h-prose",
   "u-dark:md:max-h-screen",
+  "u-dark:md:max-h-screen-lg",
 ]
 `;
 
@@ -489,14 +486,14 @@ exports[`autocomplete with attributify prefix > should provide autocomplete 1`] 
   "u-keyframes-": "u-keyframes-back-in-down u-keyframes-back-in-left u-keyframes-back-in-right u-keyframes-back-in-up u-keyframes-back-out-down u-keyframes-back-out-left u-keyframes-back-out-right u-keyframes-back-out-up u-keyframes-bounce u-keyframes-bounce-alt",
   "u-leading-": "u-leading-loose u-leading-none u-leading-normal u-leading-relaxed u-leading-snug u-leading-tight",
   "u-line-clamp-": "u-line-clamp-inherit u-line-clamp-initial u-line-clamp-none u-line-clamp-revert u-line-clamp-revert-layer u-line-clamp-unset u-line-clamp-0 u-line-clamp-1 u-line-clamp-2 u-line-clamp-3",
-  "u-m-": "u-m-xy u-marker: u-max-block u-max-block-auto u-max-block-lg u-max-block-md u-max-block-none u-max-block-prose u-max-block-screen u-max-block-sm",
+  "u-m-": "u-m-xy u-max-block u-max-block-auto u-max-block-lg u-max-block-md u-max-block-none u-max-block-prose u-max-block-screen u-max-block-sm u-max-block-xl",
   "u-max-w-": "u-max-w-auto u-max-w-full u-max-w-lg u-max-w-md u-max-w-none u-max-w-prose u-max-w-screen u-max-w-sm u-max-w-xl u-max-w-xs",
   "u-mx-": "u-m-xy u-mx-0 u-mx-1 u-mx-2 u-mx-3 u-mx-4 u-mx-5 u-mx-6 u-mx-8 u-mx-10",
   "u-object-": "u-object-b u-object-bc u-object-bl u-object-bottom u-object-bottom-center u-object-bottom-left u-object-bottom-right u-object-br u-object-c u-object-cb",
   "u-origin-": "u-origin-b u-origin-bc u-origin-bl u-origin-bottom u-origin-bottom-center u-origin-bottom-left u-origin-bottom-right u-origin-br u-origin-c u-origin-cb",
   "u-outline-": "u-outline-amber u-outline-auto u-outline-black u-outline-blue u-outline-bluegray u-outline-blueGray u-outline-coolgray u-outline-coolGray u-outline-current u-outline-cyan",
   "u-outline-offset-": "u-outline-offset-0 u-outline-offset-1 u-outline-offset-2 u-outline-offset-3 u-outline-offset-4 u-outline-offset-5 u-outline-offset-6 u-outline-offset-8 u-outline-offset-10 u-outline-offset-12",
-  "u-placeholder-": "u-placeholder-.dark: u-placeholder-.light: u-placeholder-@dark: u-placeholder-@hover: u-placeholder-@light: u-placeholder-*: u-placeholder-accent-amber u-placeholder-accent-black u-placeholder-accent-blue u-placeholder-accent-bluegray",
+  "u-placeholder-": "u-placeholder-accent-amber u-placeholder-accent-black u-placeholder-accent-blue u-placeholder-accent-bluegray u-placeholder-accent-blueGray u-placeholder-accent-coolgray u-placeholder-accent-coolGray u-placeholder-accent-current u-placeholder-accent-cyan u-placeholder-accent-dark",
   "u-rows-": "u-rows-0 u-rows-1 u-rows-2 u-rows-3 u-rows-4 u-rows-5 u-rows-6 u-rows-8 u-rows-10 u-rows-12",
   "u-scale-": "u-scale-0 u-scale-10 u-scale-20 u-scale-30 u-scale-40 u-scale-50 u-scale-60 u-scale-70 u-scale-80 u-scale-90",
   "u-scale-x-": "u-scale-x-0 u-scale-x-10 u-scale-x-20 u-scale-x-30 u-scale-x-40 u-scale-x-50 u-scale-x-60 u-scale-x-70 u-scale-x-80 u-scale-x-90",

--- a/packages-engine/autocomplete/test/autocomplete.test.ts
+++ b/packages-engine/autocomplete/test/autocomplete.test.ts
@@ -226,11 +226,19 @@ describe('autocomplete', async () => {
       },
     })
 
-    process.env.VSCODE_CWD = ''
-
     expect(() => createAutocomplete(uno as any)).toThrowErrorMatchingInlineSnapshot(`
       [Error: ⚠️ [@unocss/autocomplete]: Unknown template shorthand: <invalid>. Template: bg-<invalid>.
       ⚠️ [@unocss/autocomplete]: Invalid theme key: error. Template: bg-$error.]
+    `)
+
+    const ac = createAutocomplete(uno as any, { throwErrors: false })
+
+    expect(await ac.suggest('bg-')).toMatchInlineSnapshot(`
+      [
+        "bg-bar",
+        "bg-foo",
+        "bg-red",
+      ]
     `)
   })
 })

--- a/packages-engine/autocomplete/test/autocomplete.test.ts
+++ b/packages-engine/autocomplete/test/autocomplete.test.ts
@@ -141,7 +141,6 @@ describe('autocomplete', async () => {
           "lt-md",
           "lt-sm",
           "lt-xl",
-          "ltr:",
           "lt-2xl",
         ]
       `)
@@ -334,7 +333,6 @@ describe('autocomplete with attributify prefix', async () => {
           "u-lt-md",
           "u-lt-sm",
           "u-lt-xl",
-          "u-ltr:",
           "u-lt-2xl",
         ]
       `)

--- a/packages-engine/autocomplete/test/autocomplete.test.ts
+++ b/packages-engine/autocomplete/test/autocomplete.test.ts
@@ -205,6 +205,34 @@ describe('autocomplete', async () => {
         ]
       `)
   })
+
+  it('error on invalid template', async () => {
+    const uno = await createGenerator({
+      theme: {
+        colors: {
+          red: '#f00',
+        },
+      },
+      autocomplete: {
+        shorthands: {
+          valid: `(foo|bar)`,
+        },
+        templates: [
+          'bg-<invalid>',
+          'bg-<valid>',
+          'bg-$colors',
+          'bg-$error',
+        ],
+      },
+    })
+
+    process.env.VSCODE_CWD = ''
+
+    expect(() => createAutocomplete(uno as any)).toThrowErrorMatchingInlineSnapshot(`
+      [Error: ⚠️ [@unocss/autocomplete]: Unknown template shorthand: <invalid>. Template: bg-<invalid>.
+      ⚠️ [@unocss/autocomplete]: Invalid theme key: error. Template: bg-$error.]
+    `)
+  })
 })
 
 describe('autocomplete with attributify prefix', async () => {

--- a/packages-integrations/nuxt/src/options.ts
+++ b/packages-integrations/nuxt/src/options.ts
@@ -8,7 +8,7 @@ import presetWebFonts from '@unocss/preset-web-fonts'
 import presetWind3 from '@unocss/preset-wind3'
 import presetWind4 from '@unocss/preset-wind4'
 
-export async function resolveOptions(options: UnocssNuxtOptions) {
+export function resolveOptions(options: UnocssNuxtOptions) {
   if (options.wind3 && options.wind4) {
     console.warn('[unocss/nuxt]: wind3 and wind4 presets are mutually exclusive. wind3 will be disabled in favor of wind4.')
     options.wind3 = false

--- a/packages-integrations/vscode/package.json
+++ b/packages-integrations/vscode/package.json
@@ -154,8 +154,9 @@
   },
   "devDependencies": {
     "@types/vscode": "^1.71.0",
-    "@unocss/nuxt": "workspace:*",
-    "@unocss/preset-uno": "workspace:*",
+    "@unocss/autocomplete": "workspace:*",
+    "@unocss/core": "workspace:*",
+    "@unocss/preset-wind3": "workspace:*",
     "esno": "catalog:utils",
     "find-up": "catalog:utils",
     "jiti": "catalog:utils",

--- a/packages-integrations/vscode/src/autocomplete.ts
+++ b/packages-integrations/vscode/src/autocomplete.ts
@@ -45,6 +45,7 @@ export async function registerAutoComplete(
 
     const autocomplete = createAutocomplete(ctx.uno, {
       matchType: config.autocompleteMatchType,
+      throwErrors: false,
     })
     if (autocomplete.errorCache.size > 0) {
       for (const error of Array.from(autocomplete.errorCache.values()).flat()) {

--- a/packages-integrations/vscode/src/autocomplete.ts
+++ b/packages-integrations/vscode/src/autocomplete.ts
@@ -46,6 +46,11 @@ export async function registerAutoComplete(
     const autocomplete = createAutocomplete(ctx.uno, {
       matchType: config.autocompleteMatchType,
     })
+    if (autocomplete.errorCache.size > 0) {
+      for (const error of Array.from(autocomplete.errorCache.values()).flat()) {
+        log.appendLine(error.toString())
+      }
+    }
 
     autoCompletes.set(ctx, autocomplete)
     return autocomplete

--- a/packages-integrations/vscode/src/contextLoader.ts
+++ b/packages-integrations/vscode/src/contextLoader.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import { createContext } from '#integration/context'
 import { isCssId } from '#integration/utils'
 import { createNanoEvents, notNull } from '@unocss/core'
-import presetUno from '@unocss/preset-uno'
+import presetWind3 from '@unocss/preset-wind3'
 import { exists } from 'fs-extra'
 import { sourceObjectFields, sourcePluginFactory } from 'unconfig/presets'
 import { resolveOptions as resolveNuxtOptions } from '../../nuxt/src/options'
@@ -29,7 +29,7 @@ export class ContextLoader {
   private fileContextCache = new Map<string, UnocssPluginContext<UserConfig<any>> | null>()
   private configExistsCache = new Map<string, boolean>()
   private defaultUnocssConfig: UserConfigDefaults = {
-    presets: [presetUno()],
+    presets: [presetWind3()],
   }
 
   public events = createNanoEvents<{

--- a/packages-presets/preset-icons/build.config.ts
+++ b/packages-presets/preset-icons/build.config.ts
@@ -1,4 +1,5 @@
 import { defineBuildConfig } from 'unbuild'
+import { aliasVirtual } from '../../alias'
 
 const externals = [
   'ms',
@@ -15,6 +16,7 @@ export default defineBuildConfig({
     'src/browser',
     'src/core',
   ],
+  alias: aliasVirtual,
   clean: true,
   declaration: true,
   externals,

--- a/packages-presets/preset-icons/src/core.ts
+++ b/packages-presets/preset-icons/src/core.ts
@@ -2,6 +2,7 @@ import type { IconifyJSON } from '@iconify/types'
 import type { IconifyLoaderOptions, UniversalIconLoader } from '@iconify/utils'
 import type { CSSObject } from '@unocss/core'
 import type { IconsOptions } from './types'
+import { getEnvFlags } from '#integration/env'
 import { loadIcon } from '@iconify/utils/lib/loader/loader'
 import { searchForIcon } from '@iconify/utils/lib/loader/modern'
 import { encodeSvgForCss } from '@iconify/utils/lib/svg/encode-svg-for-css'
@@ -186,21 +187,6 @@ export function createCDNFetchLoader(
     }
 
     return result
-  }
-}
-
-export function getEnvFlags() {
-  // eslint-disable-next-line node/prefer-global/process
-  const isNode = typeof process !== 'undefined' && process.stdout
-  // eslint-disable-next-line node/prefer-global/process
-  const isVSCode = isNode && !!process.env.VSCODE_CWD
-  // eslint-disable-next-line node/prefer-global/process
-  const isESLint = isNode && !!process.env.ESLINT
-
-  return {
-    isNode,
-    isVSCode,
-    isESLint,
   }
 }
 

--- a/packages-presets/preset-icons/src/index.ts
+++ b/packages-presets/preset-icons/src/index.ts
@@ -1,9 +1,10 @@
 import type { UniversalIconLoader } from '@iconify/utils'
 import type { IconsAPI, IconsOptions } from './core'
+import { getEnvFlags } from '#integration/env'
 import { loadIcon } from '@iconify/utils'
 import { definePreset } from '@unocss/core'
 import { createCDNLoader } from './cdn'
-import { combineLoaders, createPresetIcons, getEnvFlags } from './core'
+import { combineLoaders, createPresetIcons } from './core'
 
 export * from './core'
 

--- a/packages-presets/transformer-attributify-jsx/build.config.ts
+++ b/packages-presets/transformer-attributify-jsx/build.config.ts
@@ -1,9 +1,11 @@
 import { defineBuildConfig } from 'unbuild'
+import { aliasVirtual } from '../../alias'
 
 export default defineBuildConfig({
   entries: [
     'src/index',
   ],
+  alias: aliasVirtual,
   clean: true,
   declaration: true,
   externals: [

--- a/packages-presets/transformer-attributify-jsx/src/index.ts
+++ b/packages-presets/transformer-attributify-jsx/src/index.ts
@@ -1,4 +1,5 @@
 import type { SourceCodeTransformer } from '@unocss/core'
+import { getEnvFlags } from '#integration/env'
 import { parse } from '@babel/parser'
 import traverse from '@babel/traverse'
 import { toArray } from '@unocss/core'
@@ -70,7 +71,7 @@ export default function transformerAttributifyJsx(options: TransformerAttributif
     async transform(code, _, { uno }) {
       // Skip if running in VSCode extension context
       try {
-        if ((await import('node:process')).env.VSCODE_CWD)
+        if (getEnvFlags().isVSCode)
           return
       }
       catch {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1246,12 +1246,15 @@ importers:
       '@types/vscode':
         specifier: ^1.71.0
         version: 1.97.0
-      '@unocss/nuxt':
+      '@unocss/autocomplete':
         specifier: workspace:*
-        version: link:../nuxt
-      '@unocss/preset-uno':
+        version: link:../../packages-engine/autocomplete
+      '@unocss/core':
         specifier: workspace:*
-        version: link:../../packages-deprecated/preset-uno
+        version: link:../../packages-engine/core
+      '@unocss/preset-wind3':
+        specifier: workspace:*
+        version: link:../../packages-presets/preset-wind3
       esno:
         specifier: catalog:utils
         version: 4.8.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -95,6 +95,9 @@
       "#integration/transformers": [
         "./virtual-shared/integration/src/transformers.ts"
       ],
+      "#integration/env": [
+        "./virtual-shared/integration/src/env.ts"
+      ],
       "#integration/utils": [
         "./virtual-shared/integration/src/utils.ts"
       ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -80,6 +80,9 @@
       "#integration/defaults": [
         "./virtual-shared/integration/src/defaults.ts"
       ],
+      "#integration/env": [
+        "./virtual-shared/integration/src/env.ts"
+      ],
       "#integration/hash": [
         "./virtual-shared/integration/src/hash.ts"
       ],
@@ -94,9 +97,6 @@
       ],
       "#integration/transformers": [
         "./virtual-shared/integration/src/transformers.ts"
-      ],
-      "#integration/env": [
-        "./virtual-shared/integration/src/env.ts"
       ],
       "#integration/utils": [
         "./virtual-shared/integration/src/utils.ts"

--- a/virtual-shared/integration/src/env.ts
+++ b/virtual-shared/integration/src/env.ts
@@ -1,0 +1,14 @@
+export function getEnvFlags() {
+  // eslint-disable-next-line node/prefer-global/process
+  const isNode = typeof process !== 'undefined' && process.stdout
+  // eslint-disable-next-line node/prefer-global/process
+  const isVSCode = isNode && !!process.env.VSCODE_CWD
+  // eslint-disable-next-line node/prefer-global/process
+  const isESLint = isNode && !!process.env.ESLINT
+
+  return {
+    isNode,
+    isVSCode,
+    isESLint,
+  }
+}

--- a/virtual-shared/integration/src/index.ts
+++ b/virtual-shared/integration/src/index.ts
@@ -1,6 +1,7 @@
 export * from './constants'
 export * from './context'
 export * from './defaults'
+export * from './env'
 export * from './hash'
 export * from './layers'
 export * from './utils'


### PR DESCRIPTION
close #3942, close #3946

This PR changes the following:
- [virtual-shared/integration]: Extracts the common env detection mechanism.
- [autocomplete]: When creating an autocomplete instance, all templates are automatically parsed and cached, and errors are collected. Previously, template parsing continued during the suggest phase.

I don't believe there's any performance difference between creating autocomplete and analyzing templates using suggest. The only difference is that suggest filters templates configured with variants as needed, which is negligible given the small number of templates that can be configured with variants.
