### PR TITLE
fix(transformer-attributify-jsx): correct default import for @babel/traverse 

### DIFF
--- a/packages-presets/transformer-attributify-jsx/src/index.ts
+++ b/packages-presets/transformer-attributify-jsx/src/index.ts
@@ -4,7 +4,7 @@ import _traverse from '@babel/traverse'
 import { toArray } from '@unocss/core'
 
 // @ts-expect-error ignore
-const traverse = _traverse.default as typeof _traverse
+const traverse = (_traverse.default || _traverse) as typeof _traverse
 
 export type FilterPattern = Array<string | RegExp> | string | RegExp | null
 


### PR DESCRIPTION
Fix ESM project build error:

```sh
[plugin unocss:transformers:pre] /Users/zmj/Documents/repl/test/main.tsx
TypeError: traverse is not a function
```

Relation issue:
https://github.com/babel/babel/issues/13855#issuecomment-945123514