### PR TITLE
chore(preset-icons): upgrade `@iconify/utils@3.0.0`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ catalogs:
       specifier: ^2.0.0
       version: 2.0.0
     '@iconify/utils':
-      specifier: ^2.3.0
-      version: 2.3.0
+      specifier: ^3.0.0
+      version: 3.0.0
   nuxt:
     '@nuxt/kit':
       specifier: ^4.0.2
@@ -1357,7 +1357,7 @@ importers:
     dependencies:
       '@iconify/utils':
         specifier: catalog:icons
-        version: 2.3.0
+        version: 3.0.0
       '@unocss/core':
         specifier: workspace:*
         version: link:../../packages-engine/core
@@ -3068,6 +3068,9 @@ packages:
 
   '@iconify/utils@2.3.0':
     resolution: {integrity: sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==}
+
+  '@iconify/utils@3.0.0':
+    resolution: {integrity: sha512-Bjf0HTRAB59thKK9QFvyLEXE9S793IqxqJEhNQEboh+IjOXj0nDtOIFh63oz+Y6X/ye4UWpxne5sVQ2W250iSA==}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -11331,6 +11334,19 @@ snapshots:
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@antfu/utils': 8.1.1
+      '@iconify/types': 2.0.0
+      debug: 4.4.1
+      globals: 15.15.0
+      kolorist: 1.8.0
+      local-pkg: 1.1.1
+      mlly: 1.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@iconify/utils@3.0.0':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@antfu/utils': 9.2.0
       '@iconify/types': 2.0.0
       debug: 4.4.1
       globals: 15.15.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -89,7 +89,7 @@ catalogs:
     '@iconify-json/uim': ^1.2.3
     '@iconify-json/vscode-icons': ^1.2.24
     '@iconify/types': ^2.0.0
-    '@iconify/utils': ^2.3.0
+    '@iconify/utils': ^3.0.0
 
   nuxt:
     '@nuxt/kit': ^4.0.2


### PR DESCRIPTION
Related https://github.com/iconify/iconify/issues/388 and https://github.com/iconify/iconify/pull/389

From `2.3.0` to `3.0.0`, only  droped cjs, so there is no impact on the functionality. see:  https://github.com/iconify/iconify/pull/390