### PR TITLE
refactor(autocomplete): uno shouldn't be a promise

### DIFF
--- a/packages-engine/autocomplete/src/create.ts
+++ b/packages-engine/autocomplete/src/create.ts
@@ -9,7 +9,7 @@ import { parseAutocomplete } from './parse'
 import { searchAttrKey, searchUsageBoundary } from './utils'
 
 export function createAutocomplete(
-  _uno: UnoGenerator | Promise<UnoGenerator>,
+  uno: UnoGenerator,
   options: AutocompleteOptions = {},
 ): UnocssAutocomplete {
   const templateCache = new Map<string, ParsedAutocompleteTemplate>()
@@ -22,9 +22,7 @@ export function createAutocomplete(
 
   const matchType = options.matchType ?? 'prefix'
 
-  let uno: UnoGenerator
-
-  const ready = reset()
+  reset()
 
   return {
     suggest,
@@ -65,7 +63,6 @@ export function createAutocomplete(
   }
 
   async function suggest(input: string, allowsEmptyInput = false) {
-    await ready
     if (!allowsEmptyInput && input.length < 1)
       return []
     if (cache.has(input))
@@ -115,7 +112,6 @@ export function createAutocomplete(
   }
 
   async function suggestInFile(content: string, cursor: number): Promise<SuggestResult | undefined> {
-    await ready
     const isInsideAttrValue = searchAttrKey(content, cursor) !== undefined
 
     // try resolve by extractors
@@ -183,14 +179,10 @@ export function createAutocomplete(
     return ps.flatMap(i => i.status === 'fulfilled' ? i.value : [])
   }
 
-  async function reset() {
+  function reset() {
     templateCache.clear()
     cache.clear()
     errorCache.clear()
-
-    if (!uno) {
-      uno = await Promise.resolve(_uno)
-    }
 
     staticUtils = [
       ...Object.keys(uno.config.rulesStaticMap),

--- a/packages-engine/autocomplete/src/types.ts
+++ b/packages-engine/autocomplete/src/types.ts
@@ -37,6 +37,6 @@ export interface UnocssAutocomplete {
   templates: (string | AutoCompleteFunction)[]
   cache: LRUCache<string, string[]>
   errorCache: Map<string, AutocompleteParseError[]>
-  reset: () => Promise<void>
+  reset: () => void
   enumerate: () => Promise<Set<string>>
 }


### PR DESCRIPTION
I checked the references to `createAutocomplete` and they all assumed that uno is an instance, not a promise. If it were a promise, it should be awaited by the parent level, not placed in autocomplete.