### PR TITLE
chore: rename `@ampproject/remapping` to `@jridgewell/remapping`

### DIFF
--- a/packages-engine/cli/package.json
+++ b/packages-engine/cli/package.json
@@ -44,7 +44,7 @@
     "stub": "unbuild --stub"
   },
   "dependencies": {
-    "@ampproject/remapping": "catalog:build",
+    "@jridgewell/remapping": "catalog:build",
     "@unocss/config": "workspace:*",
     "@unocss/core": "workspace:*",
     "@unocss/preset-uno": "workspace:*",

--- a/packages-integrations/svelte-scoped/build.config.ts
+++ b/packages-integrations/svelte-scoped/build.config.ts
@@ -9,7 +9,7 @@ export default defineBuildConfig({
   clean: true,
   declaration: true,
   externals: [
-    '@ampproject/remapping',
+    '@jridgewell/remapping',
     '@jridgewell/trace-mapping',
     '@jridgewell/gen-mapping',
     '@jridgewell/set-array',

--- a/packages-integrations/vite/package.json
+++ b/packages-integrations/vite/package.json
@@ -54,7 +54,7 @@
     "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0"
   },
   "dependencies": {
-    "@ampproject/remapping": "catalog:build",
+    "@jridgewell/remapping": "catalog:build",
     "@unocss/config": "workspace:*",
     "@unocss/core": "workspace:*",
     "@unocss/inspector": "workspace:*",

--- a/packages-integrations/webpack/package.json
+++ b/packages-integrations/webpack/package.json
@@ -65,7 +65,7 @@
     "webpack": "^4 || ^5"
   },
   "dependencies": {
-    "@ampproject/remapping": "catalog:build",
+    "@jridgewell/remapping": "catalog:build",
     "@unocss/config": "workspace:*",
     "@unocss/core": "workspace:*",
     "chokidar": "catalog:utils",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,9 +13,9 @@ catalogs:
       specifier: ^7.28.0
       version: 7.28.0
   build:
-    '@ampproject/remapping':
+    '@jridgewell/remapping':
       specifier: ^2.3.0
-      version: 2.3.0
+      version: 2.3.4
     brotli-size:
       specifier: ^4.0.0
       version: 4.0.0
@@ -958,9 +958,9 @@ importers:
 
   packages-engine/cli:
     dependencies:
-      '@ampproject/remapping':
+      '@jridgewell/remapping':
         specifier: catalog:build
-        version: 2.3.0
+        version: 2.3.4
       '@unocss/config':
         specifier: workspace:*
         version: link:../config
@@ -1209,9 +1209,9 @@ importers:
 
   packages-integrations/vite:
     dependencies:
-      '@ampproject/remapping':
+      '@jridgewell/remapping':
         specifier: catalog:build
-        version: 2.3.0
+        version: 2.3.4
       '@unocss/config':
         specifier: workspace:*
         version: link:../../packages-engine/config
@@ -1279,9 +1279,9 @@ importers:
 
   packages-integrations/webpack:
     dependencies:
-      '@ampproject/remapping':
+      '@jridgewell/remapping':
         specifier: catalog:build
-        version: 2.3.0
+        version: 2.3.4
       '@unocss/config':
         specifier: workspace:*
         version: link:../../packages-engine/config
@@ -3213,6 +3213,9 @@ packages:
 
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
+
+  '@jridgewell/remapping@2.3.4':
+    resolution: {integrity: sha512-aG+WvAz17rhbzhKNkSeMLgbkPPK82ovXdONvmucbGhUqcroRFLLVhoGAk4xEI17gHpXgNX3sr0/B1ybRUsbEWw==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -11478,6 +11481,11 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.29
+
+  '@jridgewell/remapping@2.3.4':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
   '@jridgewell/resolve-uri@3.1.2': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ catalogs:
     '@babel/traverse': ^7.28.0
 
   build:
-    '@ampproject/remapping': ^2.3.0
+    '@jridgewell/remapping': ^2.3.0
     brotli-size: ^4.0.0
     bumpp: ^10.2.2
     gzip-size: ^6.0.0

--- a/virtual-shared/integration/src/transformers.ts
+++ b/virtual-shared/integration/src/transformers.ts
@@ -1,6 +1,6 @@
-import type { EncodedSourceMap } from '@ampproject/remapping'
+import type { EncodedSourceMap } from '@jridgewell/remapping'
 import type { SourceCodeTransformerEnforce, UnocssPluginContext } from '@unocss/core'
-import remapping from '@ampproject/remapping'
+import remapping from '@jridgewell/remapping'
 import MagicString from 'magic-string'
 import { IGNORE_COMMENT, SKIP_COMMENT_RE } from './constants'
 import { restoreSkipCode, transformSkipCode } from './utils'


### PR DESCRIPTION
Repository got archived https://github.com/ampproject/remapping development continues under new handle. Seems that only new handle will receive new updates/fixes as 4 versions are posted diffing from ampproject/remapping