### PR TITLE
fix(eslint): disallow extra properties in rule options

### DIFF
--- a/packages-integrations/eslint-plugin/src/rules/order.ts
+++ b/packages-integrations/eslint-plugin/src/rules/order.ts
@@ -29,6 +29,7 @@ export default createRule({
             items: { type: 'string' },
           },
         },
+        additionalProperties: false,
       },
     ],
   },


### PR DESCRIPTION
This PR disallows extra options properties in `order` rule options of the ESLint plugin.