### PR TITLE
feat(core): enhance raw css utils parse with apply variants

### DIFF
--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -1,8 +1,8 @@
-import type { BlocklistMeta, BlocklistValue, ControlSymbols, ControlSymbolsEntry, CSSEntries, CSSEntriesInput, CSSObject, CSSValueInput, ExtendedTokenInfo, ExtractorContext, GenerateOptions, GenerateResult, ParsedUtil, PreflightContext, PreparedRule, RawUtil, ResolvedConfig, Rule, RuleContext, RuleMeta, SafeListContext, Shortcut, ShortcutInlineValue, ShortcutValue, StringifiedUtil, UserConfig, UserConfigDefaults, UtilObject, Variant, VariantContext, VariantHandlerContext, VariantMatchedResult } from './types'
+import type { BlocklistMeta, BlocklistValue, ControlSymbols, ControlSymbolsEntry, CSSEntries, CSSEntriesInput, CSSEntry, CSSObject, CSSValueInput, ExtendedTokenInfo, ExtractorContext, GenerateOptions, GenerateResult, ParsedUtil, PreflightContext, PreparedRule, RawUtil, ResolvedConfig, Rule, RuleContext, RuleMeta, SafeListContext, Shortcut, ShortcutInlineValue, ShortcutValue, StringifiedUtil, UserConfig, UserConfigDefaults, UtilObject, Variant, VariantContext, VariantHandlerContext, VariantMatchedResult } from './types'
 import { version } from '../package.json'
 import { resolveConfig } from './config'
 import { LAYER_DEFAULT, LAYER_PREFLIGHTS } from './constants'
-import { BetterMap, CountableSet, e, entriesToCss, expandVariantGroup, isCountableSet, isRawUtil, isStaticShortcut, isString, noop, normalizeCSSEntries, normalizeCSSValues, notNull, toArray, TwoKeyMap, uniq, warnOnce } from './utils'
+import { BetterMap, CountableSet, e, entriesToCss, expandVariantGroup, isCountableSet, isRawUtil, isStaticShortcut, isString, noop, normalizeCSSEntries, normalizeCSSValues, notNull, toArray, TwoKeyMap, uniq, VirtualKey, warnOnce } from './utils'
 import { createNanoEvents } from './utils/events'
 
 export const symbols: ControlSymbols = {
@@ -13,6 +13,7 @@ export const symbols: ControlSymbols = {
   selector: '$$symbol-selector' as unknown as ControlSymbols['selector'],
   layer: '$$symbol-layer' as unknown as ControlSymbols['layer'],
   sort: '$$symbol-sort' as unknown as ControlSymbols['sort'],
+  body: '$$symbol-body' as unknown as ControlSymbols['body'],
 }
 
 class UnoGeneratorInternal<Theme extends object = object> {
@@ -722,6 +723,9 @@ class UnoGeneratorInternal<Theme extends object = object> {
               ...entryMeta,
               noMerge: entry[1],
             }
+          }
+          else if (entry[0] === symbols.body) {
+            (entry as unknown as CSSEntry)[0] = VirtualKey
           }
         }
 

--- a/packages-engine/core/src/types.ts
+++ b/packages-engine/core/src/types.ts
@@ -85,6 +85,7 @@ declare const SymbolParent: unique symbol
 declare const SymbolSelector: unique symbol
 declare const SymbolLayer: unique symbol
 declare const SymbolSort: unique symbol
+declare const SymbolBody: unique symbol
 
 export interface ControlSymbols {
   /**
@@ -115,6 +116,10 @@ export interface ControlSymbols {
    * Sort modifier
    */
   sort: typeof SymbolSort
+  /**
+   * Custom css body modifier
+   */
+  body: typeof SymbolBody
 }
 
 export interface ControlSymbolsValue {
@@ -125,6 +130,7 @@ export interface ControlSymbolsValue {
   [SymbolSelector]: (selector: string) => string
   [SymbolLayer]: string
   [SymbolSort]: number
+  [SymbolBody]: string
 }
 
 export type ObjectToEntry<T> = { [K in keyof T]: [K, T[K]] }[keyof T]

--- a/packages-engine/core/src/utils/object.ts
+++ b/packages-engine/core/src/utils/object.ts
@@ -33,11 +33,12 @@ export function clearIdenticalEntries(entry: CSSEntries): CSSEntries {
   })
 }
 
+export const VirtualKey = '__virtual_key__'
 export function entriesToCss(arr?: CSSEntries) {
   if (arr == null)
     return ''
   return clearIdenticalEntries(arr)
-    .map(([key, value]) => (value != null && typeof value !== 'function') ? `${key}:${value};` : undefined)
+    .map(([key, value]) => (value != null && typeof value !== 'function') ? key !== VirtualKey ? `${key}:${value};` : value : undefined)
     .filter(Boolean)
     .join('')
 }

--- a/packages-engine/core/test/__snapshots__/extended-info.test.ts.snap
+++ b/packages-engine/core/test/__snapshots__/extended-info.test.ts.snap
@@ -29,6 +29,7 @@ Map {
             ],
           ],
           "symbols": {
+            "body": "$$symbol-body",
             "layer": "$$symbol-layer",
             "noMerge": "$$symbol-no-merge",
             "parent": "$$symbol-parent",
@@ -78,6 +79,7 @@ Map {
             ],
           ],
           "symbols": {
+            "body": "$$symbol-body",
             "layer": "$$symbol-layer",
             "noMerge": "$$symbol-no-merge",
             "parent": "$$symbol-parent",
@@ -125,6 +127,7 @@ Map {
             ],
           ],
           "symbols": {
+            "body": "$$symbol-body",
             "layer": "$$symbol-layer",
             "noMerge": "$$symbol-no-merge",
             "parent": "$$symbol-parent",

--- a/packages-engine/core/test/rule-symbols.test.ts
+++ b/packages-engine/core/test/rule-symbols.test.ts
@@ -240,3 +240,46 @@ it('hoist static rule', async () => {
     }"
   `)
 })
+
+it('custom css body with apply variants', async () => {
+  const style = `
+    color: blue;
+    .bar {
+      font-size: 1rem;
+    }
+  `
+  const uno = await createGenerator({
+    rules: [
+      ['foo', [
+        { color: 'red' },
+        {
+          [symbols.body]: style,
+        },
+      ]],
+    ],
+    variants: [
+      {
+        name: 'hover',
+        match: (matcher) => {
+          if (matcher.startsWith('hover:')) {
+            return {
+              matcher: matcher.slice(6),
+              selector: s => `${s}:hover`,
+            }
+          }
+        },
+      },
+    ],
+  })
+
+  expect((await uno.generate('hover:foo')).css).toMatchInlineSnapshot(`
+    "/* layer: default */
+    .hover\\:foo:hover{
+        color: blue;
+        .bar {
+          font-size: 1rem;
+        }
+      }
+    .hover\\:foo:hover{color:red;}"
+  `)
+})


### PR DESCRIPTION
UnoCSS will marked it as `RawUtil` in parsing, and it missed variants applied and its raw selectors.
e.g. `hover:foo` -> `custom css body`

```ts
rules: [
  [/^foo$/, ()=> ['custom css body']]
]
```

I wanted to enhance it in some way without affecting the original method, since it's already being used in the `keyframe`. Therefore, I chose to define a new key to customize our CSS, marking it as a normal CSSEntry for the next round of parsing.

