### PR TITLE
feat: add customFetch support to LocalFontProcessor for proxy scenarios

### DIFF
--- a/docs/presets/web-fonts.md
+++ b/docs/presets/web-fonts.md
@@ -236,7 +236,10 @@ export default defineConfig({
         fontAssetsDir: 'public/assets/fonts',
 
         // Base URL to serve the fonts from the client
-        fontServeBaseUrl: '/assets/fonts'
+        fontServeBaseUrl: '/assets/fonts',
+
+        // Custom fetch function to download the fonts
+        customFetch: async url => axios.get(url)
       })
     }),
   ],

--- a/packages-presets/preset-web-fonts/src/local.ts
+++ b/packages-presets/preset-web-fonts/src/local.ts
@@ -40,6 +40,11 @@ export interface LocalFontProcessorOptions {
    * @default '/assets/fonts'
    */
   fontServeBaseUrl?: string
+
+  /**
+   * Custom fetch function to provide the font data.
+   */
+  customFetch?: (url: string) => Promise<any>
 }
 
 export function createLocalFontProcessor(options?: LocalFontProcessorOptions): WebFontProcessor {
@@ -50,7 +55,8 @@ export function createLocalFontProcessor(options?: LocalFontProcessorOptions): W
   const fontServeBaseUrl = options?.fontServeBaseUrl || '/assets/fonts'
 
   async function _downloadFont(url: string, assetPath: string) {
-    const response = await fetch(url)
+    const fetcher = options?.customFetch ?? fetch
+    const response = await fetcher(url)
       .then(r => r.arrayBuffer())
     await fsp.mkdir(fontAssetsDir, { recursive: true })
     await fsp.writeFile(assetPath, Buffer.from(response))


### PR DESCRIPTION
fix: #4886

## Overview
This PR resolves issue #4886 where `_downloadFont` in the LocalFontProcessor was hardcoded to use the default `fetch` instead of respecting the `customFetch` option.
This prevented font downloading when using proxy configurations.

## Scope of Work
- Added `customFetch` property to `LocalFontProcessorOptions` interface
- Now uses `options?.customFetch ?? fetch` to support custom fetch implementations

## Example Usage

```typescript
const processor = createLocalFontProcessor({
  customFetch: (url: string) => 
    axios.get(url, { httpsAgent: new ProxyAgent() })
      .then(response => ({
        arrayBuffer: () => response.data
      })),
  // ... other options
})
```

---
This is my first PR for Unocss. If you have any feedback or suggestions, please let me know.