### PR TITLE
fix(preset-web-fonts): handle errors during web fonts preflight fetch

### DIFF
--- a/packages-presets/preset-web-fonts/src/preset.ts
+++ b/packages-presets/preset-web-fonts/src/preset.ts
@@ -129,7 +129,11 @@ export function createWebFontPreset(fetcher: (url: string) => Promise<any>) {
             preflights.push(await importUrl(url))
         }
 
-        preflights.push(await provider.getPreflight?.(fontsForProvider, fetchWithTimeout))
+        try {
+          preflights.push(await provider.getPreflight?.(fontsForProvider, fetchWithTimeout))
+        } catch (e) {
+          console.warn(`[unocss] Web fonts preflight fetch failed.`, e)
+        }
       }
 
       const css = preflights.filter(Boolean).join('\n')

--- a/packages-presets/preset-web-fonts/src/preset.ts
+++ b/packages-presets/preset-web-fonts/src/preset.ts
@@ -131,7 +131,8 @@ export function createWebFontPreset(fetcher: (url: string) => Promise<any>) {
 
         try {
           preflights.push(await provider.getPreflight?.(fontsForProvider, fetchWithTimeout))
-        } catch (e) {
+        }
+        catch (e) {
           console.warn(`[unocss] Web fonts preflight fetch failed.`, e)
         }
       }


### PR DESCRIPTION
When using an unstable network, the web font preflight will fail, so it's better to handle the error thrown by `getPrelight`.

Which caused `vite` load unocss config fail, and quit unexpectedly.