### PR TITLE
fix(eslint): enhance handling of array expressions

### DIFF
--- a/packages-integrations/eslint-plugin/src/rules/order.test.ts
+++ b/packages-integrations/eslint-plugin/src/rules/order.test.ts
@@ -220,6 +220,8 @@ run({
     { code: `tv({ base: 'bottom-1 top-1', variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })`, options: [{ unoFunctions: ['tv'] }] },
     // eslint-disable-next-line no-template-curly-in-string
     'clsx(`pl1 pr1 ${more}`, test ? `ml-1 mr-1 ${more}` : `left-1 right-1 ${more}`, test && `bottom-1 top-1 ${more}`, { [`bottom-1 top-1 ${more}`]: test })',
+    `clsx(['ml-1 mr-1'])`,
+    `clsx(['flex flex-col'], ['bottom-1 top-1'])`,
     `notSorted('mr-1 ml-1')`,
   ],
   invalid: [
@@ -346,6 +348,34 @@ run({
       ),
       errors: [
         { messageId: 'invalid-order' },
+        { messageId: 'invalid-order' },
+      ],
+    },
+    {
+      code: `clsx(['mr-1 ml-1'])`,
+      output: output => expect(output).toMatchInlineSnapshot(`
+            "clsx(['ml-1 mr-1'])"
+      `),
+      errors: [
+        { messageId: 'invalid-order' },
+      ],
+    },
+    {
+      code: `clsx(['mr-1 ml-1'], ['top-1 bottom-1'])`,
+      output: output => expect(output).toMatchInlineSnapshot(`
+            "clsx(['ml-1 mr-1'], ['bottom-1 top-1'])"
+      `),
+      errors: [
+        { messageId: 'invalid-order' },
+        { messageId: 'invalid-order' },
+      ],
+    },
+    {
+      code: `clsx(['flex-col flex'], className)`,
+      output: output => expect(output).toMatchInlineSnapshot(`
+            "clsx(['flex flex-col'], className)"
+      `),
+      errors: [
         { messageId: 'invalid-order' },
       ],
     },

--- a/packages-integrations/eslint-plugin/src/rules/order.ts
+++ b/packages-integrations/eslint-plugin/src/rules/order.ts
@@ -257,6 +257,14 @@ export default createRule({
           if (arg.type === 'ObjectExpression') {
             return handleObjectExpression(arg)
           }
+
+          if (arg.type === 'ArrayExpression') {
+            return arg.elements.forEach((element) => {
+              if (element && isPossibleLiteral(element)) {
+                return checkPossibleLiteral(element)
+              }
+            })
+          }
         })
       },
 


### PR DESCRIPTION
Closes #4923

This PR enhances the `@unocss/order` ESLint rule to support sorting UnoCSS classes inside arrays passed to functions like `classnames` and custom utilities. Previously, unordered classes in arrays were not detected or auto-fixed, which led to inconsistent styling and missed linting errors.

### 🐛 Problem

The rule only checked class strings passed directly to functions. When classes appeared inside arrays, unordered classes slipped through without any warning or auto-fix, making it easy for styling inconsistencies to creep into the codebase.

### ✨ Changes

Now, the ESLint rule inspects and sorts UnoCSS classes within arrays passed to supported functions, so unordered classes are always detected and auto-fixed, whether they appear in strings or arrays. This ensures a consistent developer experience and styling.

#### Before

```javascript
classnames(['flex-col flex']) // ❌ Not processed
classnames(['flex-col flex'], className) // ❌ Not processed
```

#### After

```javascript
classnames(['flex flex-col']) // ✅ Correctly processed
classnames(['flex flex-col'], className) // ✅ Correctly processed
```