### PR TITLE
feat(runtime): Add preset-wind4 integration to runtime

### DIFF
--- a/packages-integrations/runtime/src/presets/preset-wind4.ts
+++ b/packages-integrations/runtime/src/presets/preset-wind4.ts
@@ -1,0 +1,8 @@
+import type { PresetWind4Options } from '@unocss/preset-wind4'
+import type { RuntimeContext } from '..'
+import presetWind4 from '@unocss/preset-wind4'
+
+window.__unocss_runtime = window.__unocss_runtime ?? {} as RuntimeContext
+window.__unocss_runtime.presets = Object.assign(window.__unocss_runtime?.presets ?? {}, {
+  presetWind4: (options: PresetWind4Options) => presetWind4(options),
+})


### PR DESCRIPTION
Hello @zyyv. This began with https://github.com/unocss/unocss/discussions/4700 where I identified that preset-wind4 was missing for the UnoCSS browser runtime. 

It has been more than 3 months but the PR never came, so: 

- I built it myself and it works (check https://github.com/zauberzeug/nicegui/pull/4832/files#diff-2ed51cbcd03da58d03558d618586935bc33d0146601f266464b6801cad0090aa)
- I guess maybe we can YOLO it since we have GitHub actions on our back. https://github.com/unocss/unocss/actions

NiceGUI, where I am contributing the most, may in-the-end need UnoCSS due to how Quasar works (ref: https://github.com/zauberzeug/nicegui/issues/5156#issuecomment-3324997082), so I am looking to boost the progress. Thanks!