### PR TITLE
feat(runtime): Add preset-wind3 integration to runtime

### DIFF
--- a/packages-integrations/runtime/src/presets/preset-wind3.ts
+++ b/packages-integrations/runtime/src/presets/preset-wind3.ts
@@ -1,0 +1,8 @@
+import type { PresetWind3Options } from '@unocss/preset-wind3'
+import type { RuntimeContext } from '..'
+import presetWind3 from '@unocss/preset-wind3'
+
+window.__unocss_runtime = window.__unocss_runtime ?? {} as RuntimeContext
+window.__unocss_runtime.presets = Object.assign(window.__unocss_runtime?.presets ?? {}, {
+  presetWind3: (options: PresetWind3Options) => presetWind3(options),
+})


### PR DESCRIPTION
This PR mirrors https://github.com/unocss/unocss/pull/4933 but for preset-wind3. 

We already have Tailwind V3 preset in browser side but it is still under the old and deprecated name `preset-wind`. I guess we can also speed up the deprication and removal process with this. 

Note: These two PRs are separated since (1) enable selective merging, (2) GitHub website limitations. 