### PR TITLE
fix(playground): add reset styles for non-preset-wind4 configurations

### DIFF
--- a/playground/__play.html
+++ b/playground/__play.html
@@ -27,8 +27,6 @@
 </body>
 
 <script type="module">
-  import '@unocss/reset/tailwind.css'
-
   const container = document.getElementById('container')
   const style = document.getElementById('style')
   const root = document.body.parentElement

--- a/playground/src/composables/uno.ts
+++ b/playground/src/composables/uno.ts
@@ -4,6 +4,7 @@ import type { HighlightAnnotation, UnocssPluginContext } from '@unocss/core'
 import type { GenerateResult, UserConfig } from 'unocss'
 import { evaluateUserConfig } from '#docs'
 import { unocssBundle } from '#docs/unocss-bundle'
+import reset from '@unocss/reset/tailwind.css?raw'
 import MagicString from 'magic-string'
 import { createGenerator } from 'unocss'
 
@@ -73,6 +74,13 @@ debouncedWatch(
           layer: customCSSLayerName,
           getCSS: () => cleanOutput(transformedCSS.value || ''),
         })
+        // @ts-expect-error ignore
+        if (!result.presets?.some(preset => preset.name === '@unocss/preset-wind4')) {
+          preflights.push({
+            layer: 'base',
+            getCSS: () => reset,
+          })
+        }
 
         result.preflights = preflights
         customConfig = result


### PR DESCRIPTION
Not inject reset styles by default