### PR TITLE
fix(apply): add new selector for each grouping selector

### DIFF
--- a/packages-presets/transformer-directives/src/apply.ts
+++ b/packages-presets/transformer-directives/src/apply.ts
@@ -109,7 +109,9 @@ export async function parseApply({ code, uno, applyVariable }: TransformerDirect
         })
         newSelector = generate(prelude)
       }
-      let css = `${newSelector.replace(/.\\-/g, className)}{${body}}`
+
+      let css = `${newSelector.includes('.\\-') ? className.split(',').map(e => newSelector.replace(/.\\-/g, e.trim())).join(',') : newSelector}{${body}}`
+
       if (parent) {
         if (parent.includes(' $$ ')) {
           // split '&&'


### PR DESCRIPTION
### Problem

After UnoCSS v66.5.2 (#4930), the processor handles *incorrectly* `newSelector` for grouping selector 

For example, I have two custom className
```css
.be, .d {
  @apply b color-red-500 dark:color-green-500;
}
```

The code out:

```css
@supports (color: color-mix(in lab, red, red)) {
  .be,
  .d {
    color: color-mix(
      in oklab,
      var(--colors-red-500) var(--un-text-opacity),
      transparent
    );
  }
}
.dark .be,
.dark .d {
  color: color-mix(
    in srgb,
    var(--colors-green-500) var(--un-text-opacity),
    transparent
  );
}
@supports (color: color-mix(in lab, red, red)) {
  .dark .be, 
  .d { /* ⬅️ ⚠️ ISSUE: `.dark` missing ⚠️*/
    color: color-mix(
      in oklab,
      var(--colors-green-500) var(--un-text-opacity),
      transparent
    );
  }
}
```

**Issue**: The .dark parent class is missing for the .d selector in the final `@supports` block.

### Fixes

Added new selector for each grouping selector

### Linked Issue

vitejs/devtools#100