### PR TITLE
docs: create a note when using React Compiler

### DIFF
--- a/docs/integrations/vite.md
+++ b/docs/integrations/vite.md
@@ -141,7 +141,7 @@ export default {
 
 If you're using `@unocss/preset-attributify` you should remove `tsc` from the `build` script.
 
-If you are using `@vitejs/plugin-react` with `@unocss/preset-attributify`, you must add the plugin before `@vitejs/plugin-react`.
+If you are using `babel-plugin-react-compiler`, or `@vitejs/plugin-react` with `@unocss/preset-attributify`, you must add the plugin before `@vitejs/plugin-react`.
 
 ```ts [vite.config.ts]
 import React from '@vitejs/plugin-react'


### PR DESCRIPTION
When using UnoCSS in a React project which is using React Compiler, if you don't add the plugin before `@vitejs/plugin-react`, UnoCSS won't work correctly (it did generate CSS but somehow, the CSS didn't have applied, not all CSS, just a few special).
For example: CSS which is generated from `[background-size:80px_80px] [background-image:linear-gradient(to_right,#f2f2f2_1px,transparent_1px),linear-gradient(to_bottom,#f2f2f2_1px,transparent_1px)]` doesn't have applied