### PR TITLE
docs: Add fill option to view transition animation

### DIFF
--- a/docs/.vitepress/theme/UnoCSSLayout.vue
+++ b/docs/.vitepress/theme/UnoCSSLayout.vue
@@ -35,6 +35,7 @@ provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
     {
       duration: 300,
       easing: 'ease-in',
+      fill: 'forwards',
       pseudoElement: `::view-transition-${isDark.value ? 'old' : 'new'}(root)`,
     },
   )


### PR DESCRIPTION
Missing `fill: 'forwards',`, adding this entry will prevent the flash when switching between themes:

Check code snippet here https://vitepress.dev/guide/extending-default-theme#using-view-transitions-api 