### PR TITLE
fix(vite): resolve path comparison issue for config HMR

### DIFF
--- a/packages-integrations/vite/src/config-hmr.ts
+++ b/packages-integrations/vite/src/config-hmr.ts
@@ -1,5 +1,6 @@
 import type { UnocssPluginContext } from '@unocss/core'
 import type { Plugin } from 'vite'
+import { resolve } from 'node:path'
 
 export function ConfigHMRPlugin(ctx: UnocssPluginContext): Plugin | undefined {
   const { ready } = ctx
@@ -17,7 +18,8 @@ export function ConfigHMRPlugin(ctx: UnocssPluginContext): Plugin | undefined {
 
       server.watcher.add(sources)
       server.watcher.on('change', async (p) => {
-        if (!sources.includes(p))
+        const resolvedChangedPath = resolve(p)
+        if (!sources.some(source => resolve(source) === resolvedChangedPath))
           return
 
         await ctx.reloadConfig()

--- a/packages-integrations/vite/test/config-hmr.test.ts
+++ b/packages-integrations/vite/test/config-hmr.test.ts
@@ -1,0 +1,96 @@
+import type { UnocssPluginContext } from '@unocss/core'
+import type { ViteDevServer } from 'vite'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the path module
+const mockResolve = vi.fn()
+vi.mock('node:path', () => ({
+  resolve: mockResolve,
+}))
+
+// Import the plugin after mocking
+const { ConfigHMRPlugin } = await import('../src/config-hmr')
+
+describe('configHMRPlugin - uno.config.js HMR Fix', () => {
+  const mockWatcher = {
+    add: vi.fn(),
+    on: vi.fn(),
+  }
+
+  const mockServer: ViteDevServer = {
+    watcher: mockWatcher,
+    ws: {
+      send: vi.fn(),
+    },
+  } as any
+
+  const createMockContext = (sources: string[]): UnocssPluginContext =>
+    ({
+      root: '/test/project',
+      ready: Promise.resolve({
+        sources,
+        config: {},
+        dependencies: [],
+      }),
+      updateRoot: vi.fn(),
+      reloadConfig: vi.fn(),
+      uno: {
+        config: { envMode: 'dev' },
+      },
+    } as any)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockResolve.mockImplementation((path: string) => path)
+  })
+
+  it('should detect config changes when relative paths resolve to same file', async () => {
+    const ctx = createMockContext(['/test/project/uno.config.js'])
+    const plugin = ConfigHMRPlugin(ctx)
+
+    if (plugin?.configureServer) {
+      await (plugin.configureServer as any)(mockServer)
+    }
+
+    const changeHandler = mockWatcher.on.mock.calls.find(
+      call => call[0] === 'change',
+    )?.[1]
+
+    // Mock resolve to normalize paths to same absolute path
+    mockResolve
+      .mockReturnValueOnce('/test/project/uno.config.js') // Changed file
+      .mockReturnValueOnce('/test/project/uno.config.js') // Source comparison
+
+    // Simulate file change with relative path (the bug scenario)
+    await changeHandler!('./uno.config.js')
+
+    expect(ctx.reloadConfig).toHaveBeenCalled()
+    expect(mockServer.ws.send).toHaveBeenCalledWith({
+      type: 'custom',
+      event: 'unocss:config-changed',
+    })
+  })
+
+  it('should not reload when paths resolve to different files', async () => {
+    const ctx = createMockContext(['/test/project/uno.config.js'])
+    const plugin = ConfigHMRPlugin(ctx)
+
+    if (plugin?.configureServer) {
+      await (plugin.configureServer as any)(mockServer)
+    }
+
+    const changeHandler = mockWatcher.on.mock.calls.find(
+      call => call[0] === 'change',
+    )?.[1]
+
+    // Mock resolve to return different paths
+    mockResolve
+      .mockReturnValueOnce('/test/project/other-file.js') // Changed file
+      .mockReturnValueOnce('/test/project/uno.config.js') // Source
+
+    await changeHandler!('/test/project/other-file.js')
+
+    expect(ctx.reloadConfig).not.toHaveBeenCalled()
+    expect(mockServer.ws.send).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Attempts to resolve the issue #4982.


From what I can observe, it appears that changes to `.js` config files aren't being detected automatically. I suspect that the issue occurs because the Vite file watcher reports file paths in different formats (relative vs absolute), but the config change detection uses direct string comparison instead of normalized path comparison. For example: `"./uno.config.js" !== "/project/uno.config.js"` causes the change to be ignored.

> Disclaimer: This bugfix was created with the help of GitHub Copilot. I’m not an expert in JavaScript, Vite, or UnoCSS, but I have a solid understanding of JavaScript and have reviewed the changes carefully. They make sense to me, but I’d really appreciate a detailed review from someone more experienced to ensure everything looks correct.