### PR TITLE
update filter_id  from .vue to .vue||.uvue||.nvue

### DIFF
--- a/packages-integrations/vite/src/modes/shadow-dom.ts
+++ b/packages-integrations/vite/src/modes/shadow-dom.ts
@@ -103,7 +103,7 @@ export function ShadowDomModuleModePlugin(ctx: UnocssPluginContext): Plugin {
 
     // We don't need to escape backslashes here, because, unlike the other
     // shadow-dom targets, style block in Vue SFC is not a string literal.
-    if (id.includes('?vue&type=style') || (id.endsWith('.vue') && vueSFCStyleRE.test(code)))
+    if ((id.includes('?vue&type=style')||id.includes('?uvue&type=style')||id.includes('?nvue&type=style')) || ((id.endsWith('.vue')||id.endsWith('.uvue')||id.endsWith('.nvue')) && vueSFCStyleRE.test(code)))
       return code.replace(new RegExp(`(\\/\\*\\s*)?${CSS_PLACEHOLDER}(\\s*\\*\\/)?`), css || '')
 
     return code.replace(CSS_PLACEHOLDER, css?.replace(/\\/g, '\\\\')?.replace(/`/g, '\\`') ?? '')

--- a/packages-integrations/vite/src/modes/vue-scoped.ts
+++ b/packages-integrations/vite/src/modes/vue-scoped.ts
@@ -4,7 +4,7 @@ import { defaultPipelineExclude } from '#integration/defaults'
 import { createFilter } from 'unplugin-utils'
 
 export function VueScopedPlugin(ctx: UnocssPluginContext): Plugin {
-  let filter = createFilter([/\.vue$/], defaultPipelineExclude)
+  let filter = createFilter([/\.(u|n)?vue$/], defaultPipelineExclude)
 
   async function transformSFC(code: string) {
     await ctx.ready
@@ -27,7 +27,7 @@ export function VueScopedPlugin(ctx: UnocssPluginContext): Plugin {
           )
     },
     async transform(code, id) {
-      if (!filter(id) || !id.endsWith('.vue'))
+      if (!filter(id) || !(id.endsWith('.vue')||id.endsWith('.nvue')||id.endsWith('.uvue')))
         return
       const css = await transformSFC(code)
 

--- a/packages-integrations/vscode/src/utils.ts
+++ b/packages-integrations/vscode/src/utils.ts
@@ -232,5 +232,5 @@ export function shouldProvideAutocomplete(code: string, id: string, offset: numb
 const pugTemplateRe = /<template.*?lang=['"]pug['"][^>]*>/i
 
 export function isVueWithPug(code: string, id: string): boolean {
-  return id.endsWith('.vue') && pugTemplateRe.test(code)
+  return (id.endsWith('.vue')||id.endsWith('.nvue')||id.endsWith('.uvue')) && pugTemplateRe.test(code)
 }

--- a/packages-presets/extractor-pug/src/index.ts
+++ b/packages-presets/extractor-pug/src/index.ts
@@ -25,7 +25,7 @@ export default function extractorPug(options: Options = {}): Extractor {
         }
         catch {}
       }
-      else if (ctx.id.endsWith('.vue') || ctx.id.endsWith('.svelte')) {
+      else if ((ctx.id.endsWith('.vue')||ctx.id.endsWith('.nvue')||ctx.id.endsWith('.uvue')) || ctx.id.endsWith('.svelte')) {
         const matches = Array.from(ctx.code.matchAll(regexVueTemplate))
         let tail = ''
         for (const match of matches) {


### PR DESCRIPTION
To enable the use of unocss in .uvue and .nvue suffix files, I modified filter_id  from .vue to .vue||.uvue||.nvue