### PR TITLE
Fix/eslint flat config prefix

### DIFF
--- a/packages-integrations/eslint-plugin/src/configs/flat.ts
+++ b/packages-integrations/eslint-plugin/src/configs/flat.ts
@@ -2,10 +2,10 @@ import { plugin } from '../plugin'
 
 export default {
   plugins: {
-    unocss: plugin,
+    '@unocss': plugin,
   },
   rules: {
-    'unocss/order': 'warn',
-    'unocss/order-attributify': 'warn',
+    '@unocss/order': 'warn',
+    '@unocss/order-attributify': 'warn',
   } as const,
 }


### PR DESCRIPTION
This PR fixes two issues:

### 1. MDX Parsing Crash (`transformer-attributify-jsx`)
- Excluded `.mdx` files from the default include list because the Babel parser cannot handle MDX syntax (e.g. frontmatter) which was causing a `SyntaxError`.
- Added a `try-catch` block around the parser to gracefully handle invalid syntax in other files without crashing the build.
- Fixes #4807

### 2. ESLint Flat Config Prefix (`eslint-plugin`)
- Renamed the plugin registration from `unocss` to `@unocss` in [flat.ts](cci:7://file:///Users/zhetaowang/Desktop/Jack/unocss/packages-integrations/eslint-plugin/src/configs/flat.ts:0:0-0:0) to be consistent with the package name.
- Updated rule prefixes to match, e.g., `@unocss/order` and `@unocss/order-attributify`.
- Fixes #4412