### PR TITLE
fix(preset-mini): resolve nested theme colors with dashed keys

### DIFF
--- a/packages-presets/preset-mini/src/_utils/utilities.ts
+++ b/packages-presets/preset-mini/src/_utils/utilities.ts
@@ -34,29 +34,31 @@ export function directionSize(propertyPrefix: string): DynamicMatcher {
 type ThemeColorKeys = 'colors' | 'borderColor' | 'backgroundColor' | 'textColor' | 'shadowColor' | 'accentColor'
 
 function getThemeColorForKey(theme: Theme, colors: string[], key: ThemeColorKeys = 'colors') {
-  let obj = theme[key] as Theme['colors'] | string
-  let index = -1
+  const obj = theme[key] as Theme['colors'] | string
 
-  for (const c of colors) {
-    index += 1
-    if (obj && typeof obj !== 'string') {
-      const joined = colors.slice(index).join('-')
-      const camel = joined.replace(/(-[a-z])/g, n => n.slice(1).toUpperCase())
-      if (obj[camel])
-        return obj[camel]
+  function deepGet(current: any, path: string[]): any {
+    if (path.length === 0)
+      return current
+    if (!current || typeof current !== 'object')
+      return undefined
 
-      if (obj[joined])
-        return obj[joined]
+    // Try progressively shorter flat keys (e.g., 'dark-blue-foo', 'dark-blue', 'dark')
+    for (let i = path.length; i > 0; i--) {
+      const flatKey = path.slice(0, i).join('-')
+      const camelKey = flatKey.replace(/(-[a-z])/g, n => n.slice(1).toUpperCase())
 
-      if (obj[c]) {
-        obj = obj[c]
-        continue
+      // Try camelCase first, then dashed
+      const value = current[camelKey] ?? current[flatKey]
+      if (value != null) {
+        if (i === path.length)
+          return value
+        return deepGet(value, path.slice(i))
       }
     }
     return undefined
   }
 
-  return obj
+  return deepGet(obj, colors)
 }
 
 /**

--- a/packages-presets/preset-mini/test/color.test.ts
+++ b/packages-presets/preset-mini/test/color.test.ts
@@ -50,7 +50,12 @@ describe('preset-mini color utils', () => {
           colorMixUnoAlpha: 'color-mix(in hsl, oklch(95% 0.10 var(--hue) / %alpha), oklch(100% 0 360))',
           colorMixDosAlpha: 'color-mix(in srgb, oklch(95% 0.10 var(--hue) / %alpha) 30%, oklch(100% 0 360 / %alpha))',
           brand: {
-            'dark-blue': '#123456',
+            'dark-blue': {
+              'DEFAULT': '#123456',
+              'foo-bar': {
+                baz: '#fedcba',
+              },
+            },
           },
         },
       },
@@ -136,7 +141,7 @@ describe('preset-mini color utils', () => {
       prop: 'color-mix(in srgb, oklch(95% 0.10 var(--hue) / 0.2) 30%, oklch(100% 0 360 / 0.2))',
     })
 
-    // nested color with dash in key name
+    // nested color with dash in key name (with DEFAULT)
     expect(fn('brand-dark-blue')).eql({
       '--un-v-opacity': 1,
       'prop': 'rgb(18 52 86 / var(--un-v-opacity))',
@@ -144,6 +149,16 @@ describe('preset-mini color utils', () => {
 
     expect(fn('brand-dark-blue/50')).eql({
       prop: 'rgb(18 52 86 / 0.5)',
+    })
+
+    // deeply nested color with multiple dashed keys
+    expect(fn('brand-dark-blue-foo-bar-baz')).eql({
+      '--un-v-opacity': 1,
+      'prop': 'rgb(254 220 186 / var(--un-v-opacity))',
+    })
+
+    expect(fn('brand-dark-blue-foo-bar-baz/25')).eql({
+      prop: 'rgb(254 220 186 / 0.25)',
     })
 
     // invalid


### PR DESCRIPTION
Theme colors defined with dashes in nested objects (e.g.,
`{ brand: { 'dark-blue': '#123' } }`) were not resolving at runtime when used as `text-brand-dark-blue`.

The color lookup only tried camelCase conversion (`darkBlue`) but never checked the original dashed form (`dark-blue`).

Closes #4770