### PR TITLE
fix(inspector): prevent blinking after toggling dark

### DIFF
--- a/packages-integrations/inspector/client/components/NarBar.vue
+++ b/packages-integrations/inspector/client/components/NarBar.vue
@@ -38,6 +38,7 @@ function toggleDark(event?: MouseEvent) {
       {
         duration: 400,
         easing: 'ease-in',
+        fill: 'forwards',
         pseudoElement: isDark.value
           ? '::view-transition-old(root)'
           : '::view-transition-new(root)',


### PR DESCRIPTION
Fixed the blinking after toggling dark like the video below


https://github.com/user-attachments/assets/9d48eb5a-e4ed-4393-b23f-8814145eec09

