### PR TITLE
fix(vscode): not use catalog version of `@types/vscode`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@types/prettier": "catalog:types",
     "@types/react": "catalog:types",
     "@types/splitpanes": "catalog:types",
-    "@types/vscode": "catalog:types",
     "@types/ws": "catalog:types",
     "@typescript/native-preview": "catalog:typescript",
     "@unocss/astro": "workspace:*",

--- a/packages-integrations/vscode/package.json
+++ b/packages-integrations/vscode/package.json
@@ -20,7 +20,7 @@
   "preview": true,
   "icon": "res/logo.png",
   "engines": {
-    "vscode": "^1.71.0"
+    "vscode": "^1.96.0"
   },
   "activationEvents": [
     "onStartupFinished"
@@ -153,7 +153,7 @@
     "pack": "vsce package --no-dependencies"
   },
   "devDependencies": {
-    "@types/vscode": "catalog:types",
+    "@types/vscode": "^1.96.0",
     "@unocss/autocomplete": "workspace:*",
     "@unocss/core": "workspace:*",
     "@unocss/preset-wind3": "workspace:*",
@@ -163,6 +163,7 @@
     "prettier": "catalog:utils",
     "tsdown": "catalog:build",
     "unconfig": "catalog:utils",
+    "unplugin-utils": "catalog:utils",
     "vscode-ext-gen": "catalog:utils"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,9 +235,6 @@ catalogs:
     '@types/splitpanes':
       specifier: ^2.2.6
       version: 2.2.6
-    '@types/vscode':
-      specifier: ^1.84.0
-      version: 1.96.0
     '@types/webpack':
       specifier: ^5.28.5
       version: 5.28.5
@@ -537,9 +534,6 @@ importers:
       '@types/splitpanes':
         specifier: catalog:types
         version: 2.2.6
-      '@types/vscode':
-        specifier: catalog:types
-        version: 1.96.0
       '@types/ws':
         specifier: catalog:types
         version: 8.18.1
@@ -1267,7 +1261,7 @@ importers:
   packages-integrations/vscode:
     devDependencies:
       '@types/vscode':
-        specifier: catalog:types
+        specifier: ^1.96.0
         version: 1.96.0
       '@unocss/autocomplete':
         specifier: workspace:*
@@ -1296,6 +1290,9 @@ importers:
       unconfig:
         specifier: catalog:utils
         version: 7.4.2
+      unplugin-utils:
+        specifier: catalog:utils
+        version: 0.3.1
       vscode-ext-gen:
         specifier: catalog:utils
         version: 1.5.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -120,7 +120,6 @@ catalogs:
     '@types/pug': ^2.0.10
     '@types/react': ^18.3.27
     '@types/splitpanes': ^2.2.6
-    '@types/vscode': ^1.84.0
     '@types/webpack': ^5.28.5
     '@types/webpack-sources': ^3.2.3
     '@types/ws': ^8.18.1


### PR DESCRIPTION
Based on https://github.com/microsoft/vscode-vsce/issues/1036, we should keep `@types/vscode` uncatalogued in package.json.

Upgrade `engines.vscode` to [1.96.0](https://code.visualstudio.com/updates/v1_96) which has one year's compatibility.

Add `unplugin-utils` to package.json because `src/index.ts` uses it.