### PR TITLE
feat(vscode): support spacing px comment

### DIFF
--- a/packages-integrations/vscode/src/annotation.ts
+++ b/packages-integrations/vscode/src/annotation.ts
@@ -109,14 +109,15 @@ export async function registerAnnotations(
       const remToPxRatio = docConfig.remToPxPreview
         ? docConfig.remToPxRatio
         : -1
-
       const positions = await getMatchedPositionsFromDoc(ctx.uno, doc)
+      // todo: types?
+      const spacingValue = (ctx.uno.config.theme as any)?.spacing?.DEFAULT as string | undefined
       const isAttributify = ctx.uno.config.presets.some(i => i.name === '@unocss/preset-attributify')
 
       const ranges: DecorationOptions[] = (
         await Promise.all(positions.map(async (i): Promise<DecorationOptions> => {
           try {
-            const md = await getPrettiedMarkdown(ctx!.uno, isAttributify ? [i[2], `[${i[2]}=""]`] : i[2], remToPxRatio)
+            const md = await getPrettiedMarkdown(ctx!.uno, isAttributify ? [i[2], `[${i[2]}=""]`] : i[2], remToPxRatio, spacingValue)
 
             if (docConfig.colorPreview) {
               const color = getColorString(md)

--- a/packages-integrations/vscode/src/selectionStyle.ts
+++ b/packages-integrations/vscode/src/selectionStyle.ts
@@ -7,7 +7,7 @@ import prettier from 'prettier/standalone'
 import { MarkdownString, Position, Range, window } from 'vscode'
 import { getConfig } from './configs'
 import { log } from './log'
-import { addRemToPxComment, throttle } from './utils'
+import { addRemToPxComment, addSpacingToPxComment, throttle } from './utils'
 
 export async function registerSelectionStyle(loader: ContextLoader) {
   const config = getConfig()
@@ -42,6 +42,9 @@ export async function registerSelectionStyle(loader: ContextLoader) {
         ? config.remToPxRatio
         : -1
 
+      // todo: types?
+      const spacingValue = (ctx.uno.config.theme as any)?.spacing?.DEFAULT as string | undefined
+
       const result = await getMatchedPositionsFromCode(ctx.uno, code)
       if (result.length <= 1)
         return reset()
@@ -60,6 +63,7 @@ export async function registerSelectionStyle(loader: ContextLoader) {
           tokens.forEach(([, className, cssText, media]) => {
             if (className && cssText) {
               cssText = addRemToPxComment(cssText, remToPxRatio)
+              cssText = addSpacingToPxComment(cssText, spacingValue, remToPxRatio)
               const selector = className
                 .replace(`.${classNamePlaceholder}`, '&')
                 .replace(regexScopePlaceholder, ' ')

--- a/packages-integrations/vscode/test/utils.test.ts
+++ b/packages-integrations/vscode/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { addRemToPxComment, getColorString, shouldProvideAutocomplete } from '../src/utils'
+import { addRemToPxComment, addSpacingToPxComment, getColorString, parseSpacingValue, shouldProvideAutocomplete } from '../src/utils'
 
 it('getColorString', () => {
   const textAmber = `
@@ -85,6 +85,82 @@ it('addRemToPxComment', () => {
   /* layer: default */
   .\!m-9 {
     margin: 2.25rem !important; /* 36px */
+  }`)
+})
+
+it('parseSpacingValue', () => {
+  expect(parseSpacingValue('1px')).eql(1)
+  expect(parseSpacingValue('4px')).eql(4)
+  expect(parseSpacingValue('0.25rem')).eql(4)
+  expect(parseSpacingValue('0.25rem', 16)).eql(4)
+  expect(parseSpacingValue('0.25rem', 20)).eql(5)
+  expect(parseSpacingValue('1rem')).eql(16)
+  expect(parseSpacingValue('2')).eql(2)
+  expect(parseSpacingValue('-1px')).eql(-1)
+  expect(parseSpacingValue('invalid')).eql(undefined)
+})
+
+it('addSpacingToPxComment', () => {
+  const text = `
+  /* layer: default */
+  .w-16 {
+    width: calc(var(--spacing) * 16);
+  }`
+
+  expect(addSpacingToPxComment(text, '1px')).eql(`
+  /* layer: default */
+  .w-16 {
+    width: calc(var(--spacing) * 16) /* 1px * 16 = 16px */;
+  }`)
+
+  expect(addSpacingToPxComment(text, '4px')).eql(`
+  /* layer: default */
+  .w-16 {
+    width: calc(var(--spacing) * 16) /* 4px * 16 = 64px */;
+  }`)
+
+  expect(addSpacingToPxComment(text, '0.25rem')).eql(`
+  /* layer: default */
+  .w-16 {
+    width: calc(var(--spacing) * 16) /* 0.25rem * 16 = 64px */;
+  }`)
+
+  expect(addSpacingToPxComment(text, '0.25rem', 20)).eql(`
+  /* layer: default */
+  .w-16 {
+    width: calc(var(--spacing) * 16) /* 0.25rem * 16 = 80px */;
+  }`)
+
+  const negativeText = `
+  /* layer: default */
+  .-m-4 {
+    margin: calc(var(--spacing) * -4);
+  }`
+
+  expect(addSpacingToPxComment(negativeText, '1px')).eql(`
+  /* layer: default */
+  .-m-4 {
+    margin: calc(var(--spacing) * -4) /* 1px * -4 = -4px */;
+  }`)
+
+  expect(addSpacingToPxComment(text, undefined)).eql(text)
+  expect(addSpacingToPxComment(text, '')).eql(text)
+  expect(addSpacingToPxComment(undefined, '1px')).eql('')
+
+  const multipleText = `
+  .p-4 {
+    padding-top: calc(var(--spacing) * 4);
+    padding-right: calc(var(--spacing) * 4);
+    padding-bottom: calc(var(--spacing) * 4);
+    padding-left: calc(var(--spacing) * 4);
+  }`
+
+  expect(addSpacingToPxComment(multipleText, '1px')).eql(`
+  .p-4 {
+    padding-top: calc(var(--spacing) * 4) /* 1px * 4 = 4px */;
+    padding-right: calc(var(--spacing) * 4) /* 1px * 4 = 4px */;
+    padding-bottom: calc(var(--spacing) * 4) /* 1px * 4 = 4px */;
+    padding-left: calc(var(--spacing) * 4) /* 1px * 4 = 4px */;
   }`)
 })
 


### PR DESCRIPTION
## Summary

   - Add px value comments for `calc(var(--spacing) * N)` expressions in VSCode hover tooltips
   - When using `preset-wind4`, CSS like `width: calc(var(--spacing) * 16)` will now show helpful comments like `/* 1px * 16 = 16px */`
   - Reads `theme.spacing.DEFAULT` from UnoCSS config to calculate the actual px value
   - Supports both `px` and `rem` units for spacing values (rem values are converted using `remToPxRatio`)

## Background

   `preset-wind4` generates CSS using `calc(var(--spacing) * N)` instead of direct `rem` values. The existing `addRemToPxComment` function only handles `Xrem` format, so users couldn't see the calculated px values when hovering over utility classes.

## Example

   With `theme.spacing.DEFAULT: '1px'`:
   ```css
   .w-16 {
     width: calc(var(--spacing) * 16) /* 1px * 16 = 16px */;
   }
   ```

   With `theme.spacing.DEFAULT: '0.25rem'` (preset-wind4 default):
   ```css
   .w-16 {
     width: calc(var(--spacing) * 16) /* 0.25rem * 16 = 64px */;
   }
   ```
   
### before

<img width="300" height="278" alt="image" src="https://github.com/user-attachments/assets/eed59bab-37e5-4815-bf36-21cf9e6da65e" />

### after
<img width="300" height="289" alt="image" src="https://github.com/user-attachments/assets/c8047175-74fe-446e-91ff-5e1b9b530323" />


## Known Limitations

   - **Type casting**: Currently using `(ctx.uno.config.theme as any)?.spacing?.DEFAULT` because the core `Theme` type is generic (`Theme extends
   object = object`) and doesn't know about preset-specific properties like `spacing`. Left `// todo: types?` comments for future improvement. A better approach would be to define a shared interface or improve core type definitions.

## Test plan

   - [x] Unit tests added for `parseSpacingValue` and `addSpacingToPxComment`
   - [x] Manual testing with preset-wind4 and custom spacing values
       - [x] preset-wind4 
       <img width="200" height="262" alt="image" src="https://github.com/user-attachments/assets/c00cfefd-2b34-4853-a499-32735444834e" />

      - [x] custom spacing values
       <img width="200" height="272" alt="image" src="https://github.com/user-attachments/assets/0bb90d6d-9668-465c-a243-83d881f85a05" />

   - [x] Verify hover tooltips show correct px calculations