### PR TITLE
fix(svelte-scoped): explicit export of types to prevent node error

### DIFF
--- a/packages-integrations/svelte-scoped/src/preprocess.ts
+++ b/packages-integrations/svelte-scoped/src/preprocess.ts
@@ -1,2 +1,2 @@
 export { UnocssSveltePreprocess as default } from './_preprocess/index'
-export * from './_preprocess/types.d.js'
+export type { SvelteScopedContext, TransformApplyOptions, TransformClassesOptions, TransformDirectivesOptions, UnocssSveltePreprocessOptions } from './_preprocess/types.d.js'


### PR DESCRIPTION
This PR changes the sketchy `*` export to the actual types to prevent errors.

Fixes https://github.com/unocss/unocss/issues/5066