### PR TITLE
fix(postcss): remove cjs from exports as it's not build anymore

### DIFF
--- a/packages-integrations/postcss/package.json
+++ b/packages-integrations/postcss/package.json
@@ -19,21 +19,14 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
     },
     "./esm": {
       "types": "./dist/esm.d.mts",
       "default": "./dist/esm.mjs"
     }
   },
-  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.mts",
   "typesVersions": {


### PR DESCRIPTION
Resolves #5070 