### PR TITLE
fix(eslint-plugin): support eslint 10

### DIFF
--- a/packages-integrations/eslint-plugin/src/rules/order-attributify.ts
+++ b/packages-integrations/eslint-plugin/src/rules/order-attributify.ts
@@ -41,9 +41,8 @@ export default createRule({
             node,
             messageId: 'invalid-order',
             fix(fixer) {
-              const codeFull = context.getSourceCode()
               const offset = node.range[0]
-              const code = codeFull.getText().slice(node.range[0], node.range[1])
+              const code = context.sourceCode.getText().slice(node.range[0], node.range[1])
 
               const s = new MagicString(code)
 


### PR DESCRIPTION
`context.getSourceCode` is deprecated in eslint v9, and removed in v10