### PR TITLE
docs: add presetwind4 note in theme breakpoint docs

### DIFF
--- a/docs/config/theme.md
+++ b/docs/config/theme.md
@@ -90,6 +90,12 @@ theme: {
 }
 ```
 
+::: tip
+In `presetWind4` the key was changed changed to `breakpoint`.
+
+For the `presetWind4` theme docs see https://unocss.dev/presets/wind4#theme.
+:::
+
 If you want to inherit the `original` theme breakpoints, you can use the `extendTheme`:
 
 ```ts


### PR DESCRIPTION
This PR adds a note for `presetWind4` in theme breakpoint docs since the key changed.

fixes https://github.com/unocss/unocss/issues/5096