### PR TITLE
fix(preset-wind4): remove leading space from space utility values for negative variant

### DIFF
--- a/packages-presets/preset-wind4/src/rules/spacing.ts
+++ b/packages-presets/preset-wind4/src/rules/spacing.ts
@@ -56,7 +56,7 @@ function* handlerSpace([m, d, s]: string[], { theme, symbols }: RuleContext<Them
   if (v != null) {
     const results = directionMap[d === 'x' ? 'inline' : 'block'].map((item, index): [string, string] => {
       const key = `margin${item}`
-      const value = ` calc(${v} * ${index === 0 ? `var(--un-space-${d}-reverse)` : `calc(1 - var(--un-space-${d}-reverse))`})`
+      const value = `calc(${v} * ${index === 0 ? `var(--un-space-${d}-reverse)` : `calc(1 - var(--un-space-${d}-reverse))`})`
       return [key, value]
     })
 

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -1739,6 +1739,9 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .view-transition-none{view-transition-name:none;}
 .field-sizing-fixed{field-sizing:fixed;}
 .field-sizing-content{field-sizing:content;}
+.-space-x-4{
+:where(&>:not(:last-child)){--un-space-x-reverse:0;margin-inline-start:calc(calc(calc(var(--spacing) * 4) * var(--un-space-x-reverse)) * -1);margin-inline-end:calc(calc(calc(var(--spacing) * 4) * calc(1 - var(--un-space-x-reverse))) * -1);}
+}
 .divide-\$variable{
 :where(&>:not(:last-child)){border-color:color-mix(in oklab, var(--variable) var(--un-divide-opacity), transparent) /* var(--variable) */;}
 }
@@ -1839,19 +1842,19 @@ unocss .scope-\[unocss\]\:block{display:block;}
 :where(*[data-x=y] + &){--un-font-weight:17;font-weight:17;}
 }
 .space-x-\[var\(--space\)\]{
-:where(&>:not(:last-child)){--un-space-x-reverse:0;margin-inline-start: calc(var(--space) * var(--un-space-x-reverse));margin-inline-end: calc(var(--space) * calc(1 - var(--un-space-x-reverse)));}
+:where(&>:not(:last-child)){--un-space-x-reverse:0;margin-inline-start:calc(var(--space) * var(--un-space-x-reverse));margin-inline-end:calc(var(--space) * calc(1 - var(--un-space-x-reverse)));}
 }
 .space-x-\$space{
-:where(&>:not(:last-child)){--un-space-x-reverse:0;margin-inline-start: calc(var(--space) * var(--un-space-x-reverse));margin-inline-end: calc(var(--space) * calc(1 - var(--un-space-x-reverse)));}
+:where(&>:not(:last-child)){--un-space-x-reverse:0;margin-inline-start:calc(var(--space) * var(--un-space-x-reverse));margin-inline-end:calc(var(--space) * calc(1 - var(--un-space-x-reverse)));}
 }
 .space-x-2{
-:where(&>:not(:last-child)){--un-space-x-reverse:0;margin-inline-start: calc(calc(var(--spacing) * 2) * var(--un-space-x-reverse));margin-inline-end: calc(calc(var(--spacing) * 2) * calc(1 - var(--un-space-x-reverse)));}
+:where(&>:not(:last-child)){--un-space-x-reverse:0;margin-inline-start:calc(calc(var(--spacing) * 2) * var(--un-space-x-reverse));margin-inline-end:calc(calc(var(--spacing) * 2) * calc(1 - var(--un-space-x-reverse)));}
 }
 .space-x-reverse{
 :where(&>:not(:last-child)){--un-space-x-reverse:1;}
 }
 .space-y-4{
-:where(&>:not(:last-child)){--un-space-y-reverse:0;margin-block-start: calc(calc(var(--spacing) * 4) * var(--un-space-y-reverse));margin-block-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--un-space-y-reverse)));}
+:where(&>:not(:last-child)){--un-space-y-reverse:0;margin-block-start:calc(calc(var(--spacing) * 4) * var(--un-space-y-reverse));margin-block-end:calc(calc(var(--spacing) * 4) * calc(1 - var(--un-space-y-reverse)));}
 }
 @layer base{
 .layer-base\:translate-0{--un-translate-x:calc(var(--spacing) * 0);--un-translate-y:calc(var(--spacing) * 0);translate:var(--un-translate-x) var(--un-translate-y);}


### PR DESCRIPTION
## Summary

Fixes #4996 - `presetWind4` not supporting `-space-x-2`

## Problem

The space utility handler was outputting margin values with a leading space:
```
margin-inline-start: calc(calc(var(--spacing) * 2) * var(--un-space-x-reverse))
```

The negative variant uses `cssMathFnRE = /^(calc|clamp|min|max)\s*\((.+)\)(.*)/` to match and negate calc expressions, but the regex requires the value to **start with** the function name. The leading space caused the regex to fail, resulting in no CSS output for negative space utilities.

## Fix

Remove the leading space from the margin value template string in `handlerSpace`:

```diff
- const value = ` calc(${v} * ...)`
+ const value = `calc(${v} * ...)`
```

## Before/After

**Before:** `-space-x-2` produces no CSS in the default layer

**After:** `-space-x-2` correctly produces:
```css
.-space-x-2{
  :where(&>:not(:last-child)){
    --un-space-x-reverse:0;
    margin-inline-start:calc(calc(calc(var(--spacing) * 2) * var(--un-space-x-reverse)) * -1);
    margin-inline-end:calc(calc(calc(var(--spacing) * 2) * calc(1 - var(--un-space-x-reverse))) * -1);
  }
}
```

## Testing

- [x] All preset-wind4 tests pass
- [x] Snapshot updated to include the now-working `-space-x-4` test case