### PR TITLE
fix(svelte-scoped): generate in buildEnd() to make presetWind4 on-dem…

### DIFF
--- a/packages-integrations/svelte-scoped/src/_vite/globalStylesPlugin.ts
+++ b/packages-integrations/svelte-scoped/src/_vite/globalStylesPlugin.ts
@@ -53,12 +53,18 @@ export function GlobalStylesPlugin(ctx: SvelteScopedContext, injectReset?: Unocs
     // build
     async buildStart() {
       if (viteConfig.command === 'build') {
-        const css = await generateGlobalCss(ctx.uno, injectReset)
         unoCssFileReferenceId = this.emitFile({
           type: 'asset',
           name: GLOBAL_STYLES_CSS_FILE_NAME,
-          source: css,
         })
+      }
+    },
+
+    // build - runs after all module transforms complete, so on-demand theme tokens are fully tracked
+    async buildEnd() {
+      if (viteConfig.command === 'build') {
+        const css = await generateGlobalCss(ctx.uno, injectReset)
+        this.setAssetSource(unoCssFileReferenceId, css)
       }
     },
 


### PR DESCRIPTION
…and theme work correctly

This PR changes svelte-scoped to run generate in the `buildEnd()` hook instead of `buildStart()` so the `on-demand` theme feature in presetWind4 works correctly when built. Before it only worked in dev, now it should work in dev and build.

fixes https://github.com/unocss/unocss/issues/5073