### PR TITLE
chore: exclude examples and test folders from npm scripts view

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,5 +43,7 @@
     "json",
     "jsonc",
     "yaml"
-  ]
+  ],
+
+  "npm.exclude": "**/{examples,test}/**"
 }


### PR DESCRIPTION
There are too many packages in this repository, which makes managing the npm scripts view quite difficult. This PR excludes `examples` and `fixtures` in tests. This might offer a slightly better DX.