### PR TITLE
fix(svelte-scoped): replace build hook with buildEnd to remove setAss…

### DIFF
--- a/packages-integrations/svelte-scoped/src/_vite/globalStylesPlugin.ts
+++ b/packages-integrations/svelte-scoped/src/_vite/globalStylesPlugin.ts
@@ -50,21 +50,15 @@ export function GlobalStylesPlugin(ctx: SvelteScopedContext, injectReset?: Unocs
       }
     },
 
-    // build
-    async buildStart() {
-      if (viteConfig.command === 'build') {
-        unoCssFileReferenceId = this.emitFile({
-          type: 'asset',
-          name: GLOBAL_STYLES_CSS_FILE_NAME,
-        })
-      }
-    },
-
-    // build - runs after all module transforms complete, so on-demand theme tokens are fully tracked
+    // build end - runs after all module transforms complete, so on-demand theme tokens are fully tracked
     async buildEnd() {
       if (viteConfig.command === 'build') {
         const css = await generateGlobalCss(ctx.uno, injectReset)
-        this.setAssetSource(unoCssFileReferenceId, css)
+        unoCssFileReferenceId = this.emitFile({
+          type: 'asset',
+          name: GLOBAL_STYLES_CSS_FILE_NAME,
+          source: css,
+        })
       }
     },
 


### PR DESCRIPTION
…etSource causing failed builds in vite 8

`setAssetSource` was removed (well, not implemented) in Rolldown which caused failed builds in Svelte-scoped when upgrading to Vite 8. It is unclear how willing they are to reimplement it since Vite 8 was released anyway, but in this case there was no real need for it in the first place. 

This PR moves everything into `buildEnd` so the on-demand theme functionality in `presetWind4` continues working without problems.

fixes https://github.com/unocss/unocss/issues/5158