### PR TITLE
fix(inspector): add background colors

### DIFF
--- a/packages-integrations/inspector/client/App.vue
+++ b/packages-integrations/inspector/client/App.vue
@@ -3,7 +3,7 @@ import { Pane, Splitpanes } from 'splitpanes'
 </script>
 
 <template>
-  <div h-full w-full of-hidden>
+  <div h-full w-full of-hidden bg-white dark:bg-black>
     <Splitpanes>
       <Pane size="20" :push-other-panes="false">
         <Sidebar />


### PR DESCRIPTION
The UnoCSS inspector can be loaded in [vitejs/devtools](https://github.com/nuxt/devtools) and [nuxt/devtools](https://github.com/nuxt/devtools) with `<iframe>` tag, which makes website that has no background transparent

This causes the inspector to display weird, as well as dark-light switch animation like the video below

https://github.com/user-attachments/assets/8b0aab69-3d54-491f-bc10-b12870844473

This PR added a global background color to fix that