### PR TITLE
feat(preset-web-fonts): add ZeoSeven Chinese fonts provider

### DIFF
--- a/packages-presets/preset-web-fonts/src/index.ts
+++ b/packages-presets/preset-web-fonts/src/index.ts
@@ -2,6 +2,7 @@ import { definePreset } from '@unocss/core'
 import { createWebFontPreset, normalizedFontMeta } from './preset'
 
 export { createGoogleCompatibleProvider as createGoogleProvider } from './providers/google'
+export { ZeoSevenFontsProvider } from './providers/zeoseven'
 export { normalizedFontMeta }
 export * from './types'
 

--- a/packages-presets/preset-web-fonts/src/preset.ts
+++ b/packages-presets/preset-web-fonts/src/preset.ts
@@ -7,6 +7,7 @@ import { FontshareProvider } from './providers/fontshare'
 import { FontSourceProvider } from './providers/fontsource'
 import { GoogleFontsProvider } from './providers/google'
 import { NoneProvider } from './providers/none'
+import { ZeoSevenFontsProvider } from './providers/zeoseven'
 
 const builtinProviders = {
   google: GoogleFontsProvider,
@@ -15,6 +16,7 @@ const builtinProviders = {
   fontsource: FontSourceProvider,
   coollabs: CoolLabsFontsProvider,
   none: NoneProvider,
+  zeoseven: ZeoSevenFontsProvider,
 }
 
 function resolveProvider(provider: WebFontsProviders): Provider {

--- a/packages-presets/preset-web-fonts/src/providers/zeoseven.ts
+++ b/packages-presets/preset-web-fonts/src/providers/zeoseven.ts
@@ -1,0 +1,52 @@
+import type { Provider, WebFontsProviders } from '../types'
+
+function parseFontName(name: string): { family: string, id: string } {
+  const atIndex = name.lastIndexOf('@')
+  if (atIndex === -1) {
+    throw new Error(
+      `[unocss] ZeoSeven provider requires font ID in format "FontFamily@id", e.g. "LXGW WenKai@292". Got: "${name}"`,
+    )
+  }
+  return {
+    family: name.slice(0, atIndex).trim(),
+    id: name.slice(atIndex + 1).trim(),
+  }
+}
+
+export function createZeoSevenProvider(name: WebFontsProviders, host: string): Provider {
+  return {
+    name,
+    getFontName(font) {
+      const { family } = parseFontName(font.name)
+      return `"${family}"`
+    },
+    async getPreflight(fonts, fetcher) {
+      const cssParts: string[] = []
+
+      for (const font of fonts) {
+        const { id } = parseFontName(font.name)
+        const baseUrl = `${host}/${id}/main/`
+        const url = `${baseUrl}result.css`
+
+        try {
+          const result = await fetcher(url) as string
+          const processed = result.replace(
+            /url\("\.\/([^"]+)"\)/g,
+            `url("${baseUrl}$1")`,
+          )
+          cssParts.push(processed)
+        }
+        catch {
+          throw new Error(`[unocss] Failed to fetch ZeoSeven font CSS for ID "${id}"`)
+        }
+      }
+
+      return cssParts.join('\n')
+    },
+  }
+}
+
+export const ZeoSevenFontsProvider: Provider = createZeoSevenProvider(
+  'zeoseven',
+  'https://fontsapi.zeoseven.com',
+)

--- a/packages-presets/preset-web-fonts/src/types.ts
+++ b/packages-presets/preset-web-fonts/src/types.ts
@@ -1,6 +1,6 @@
 import type { Arrayable, Awaitable } from '@unocss/core'
 
-export type WebFontsProviders = 'google' | 'bunny' | 'fontshare' | 'fontsource' | 'coollabs' | 'none' | Provider
+export type WebFontsProviders = 'google' | 'bunny' | 'fontshare' | 'fontsource' | 'coollabs' | 'zeoseven' | 'none' | Provider
 
 export interface WebFontMeta {
   /**


### PR DESCRIPTION
Closes #3060

Add a new `zeoseven` provider for `preset-web-fonts` that integrates with [ZeoSeven Fonts](https://fonts.zeoseven.com/) — a free CDN hosting 1000+ CJK fonts with unicode-range subsetting.

## Usage

```ts
presetWebFonts({

  provider: 'zeoseven',

  fonts: {

    // Format: "FontFamilyName@zeosevenId"

    wenkai: 'LXGW WenKai@292',

    song: 'Source Han Serif CN@285',

  },

})