### PR TITLE
fix(eslint-plugin): preserve unknown token positions in sortRules

### DIFF
--- a/packages-presets/preset-web-fonts/src/index.ts
+++ b/packages-presets/preset-web-fonts/src/index.ts
@@ -2,6 +2,7 @@ import { definePreset } from '@unocss/core'
 import { createWebFontPreset, normalizedFontMeta } from './preset'
 
 export { createGoogleCompatibleProvider as createGoogleProvider } from './providers/google'
+export { ZeoSevenFontsProvider } from './providers/zeoseven'
 export { normalizedFontMeta }
 export * from './types'
 

--- a/packages-presets/preset-web-fonts/src/preset.ts
+++ b/packages-presets/preset-web-fonts/src/preset.ts
@@ -7,6 +7,7 @@ import { FontshareProvider } from './providers/fontshare'
 import { FontSourceProvider } from './providers/fontsource'
 import { GoogleFontsProvider } from './providers/google'
 import { NoneProvider } from './providers/none'
+import { ZeoSevenFontsProvider } from './providers/zeoseven'
 
 const builtinProviders = {
   google: GoogleFontsProvider,
@@ -15,6 +16,7 @@ const builtinProviders = {
   fontsource: FontSourceProvider,
   coollabs: CoolLabsFontsProvider,
   none: NoneProvider,
+  zeoseven: ZeoSevenFontsProvider,
 }
 
 function resolveProvider(provider: WebFontsProviders): Provider {

--- a/packages-presets/preset-web-fonts/src/providers/zeoseven.ts
+++ b/packages-presets/preset-web-fonts/src/providers/zeoseven.ts
@@ -1,0 +1,52 @@
+import type { Provider, WebFontsProviders } from '../types'
+
+function parseFontName(name: string): { family: string, id: string } {
+  const atIndex = name.lastIndexOf('@')
+  if (atIndex === -1) {
+    throw new Error(
+      `[unocss] ZeoSeven provider requires font ID in format "FontFamily@id", e.g. "LXGW WenKai@292". Got: "${name}"`,
+    )
+  }
+  return {
+    family: name.slice(0, atIndex).trim(),
+    id: name.slice(atIndex + 1).trim(),
+  }
+}
+
+export function createZeoSevenProvider(name: WebFontsProviders, host: string): Provider {
+  return {
+    name,
+    getFontName(font) {
+      const { family } = parseFontName(font.name)
+      return `"${family}"`
+    },
+    async getPreflight(fonts, fetcher) {
+      const cssParts: string[] = []
+
+      for (const font of fonts) {
+        const { id } = parseFontName(font.name)
+        const baseUrl = `${host}/${id}/main/`
+        const url = `${baseUrl}result.css`
+
+        try {
+          const result = await fetcher(url) as string
+          const processed = result.replace(
+            /url\("\.\/([^"]+)"\)/g,
+            `url("${baseUrl}$1")`,
+          )
+          cssParts.push(processed)
+        }
+        catch {
+          throw new Error(`[unocss] Failed to fetch ZeoSeven font CSS for ID "${id}"`)
+        }
+      }
+
+      return cssParts.join('\n')
+    },
+  }
+}
+
+export const ZeoSevenFontsProvider: Provider = createZeoSevenProvider(
+  'zeoseven',
+  'https://fontsapi.zeoseven.com',
+)

--- a/packages-presets/preset-web-fonts/src/types.ts
+++ b/packages-presets/preset-web-fonts/src/types.ts
@@ -1,6 +1,6 @@
 import type { Arrayable, Awaitable } from '@unocss/core'
 
-export type WebFontsProviders = 'google' | 'bunny' | 'fontshare' | 'fontsource' | 'coollabs' | 'none' | Provider
+export type WebFontsProviders = 'google' | 'bunny' | 'fontshare' | 'fontsource' | 'coollabs' | 'zeoseven' | 'none' | Provider
 
 export interface WebFontMeta {
   /**

--- a/virtual-shared/integration/src/sort-rules.ts
+++ b/virtual-shared/integration/src/sort-rules.ts
@@ -30,7 +30,7 @@ export async function sortRules(rules: string, uno: UnoGenerator) {
     result.push([order, i])
   }
 
-  let sorted = result
+  const sortedRecognized = result
     .filter(notNull)
     .sort((a, b) => {
       let result = a[0] - b[0]
@@ -38,11 +38,19 @@ export async function sortRules(rules: string, uno: UnoGenerator) {
         result = a[1].localeCompare(b[1])
       return result
     })
-    .map(i => i[1])
+
+  let sortedIdx = 0
+  let unknownIdx = 0
+  let sorted = result
+    .map((item) => {
+      if (item == null)
+        return unknown[unknownIdx++]
+      return sortedRecognized[sortedIdx++][1]
+    })
     .join(' ')
 
   if (expandedResult?.prefixes.length)
     sorted = collapseVariantGroup(sorted, expandedResult.prefixes)
 
-  return [...unknown, sorted].join(' ').trim()
+  return sorted.trim()
 }


### PR DESCRIPTION
Closes #2780

## Problem

`sortRules()` prepends all unrecognized tokens before sorted ones (`[...unknown, sorted]`). When `order-attributify` passes mixed HTML attributes (e.g. `disable-resize-watcher`, `permanent`, `rail`) alongside UnoCSS utilities, any partial match causes token positions to shift, producing `sorted !== input` → false positive.

Example: input `a b c d` where `a`,`c` are unknown and `b`,`d` are recognized:
- Before: `a c d b` (unknowns grouped at front)
- After: `a d c b` (unknowns stay in place, only recognized tokens reorder)

## Fix

One logic change in `sortRules()`: rebuild the result array by filling unknown tokens back into their original positions instead of prepending them all.