### PR TITLE
fix(variant-group): support data-attributes in variant group prefix

### DIFF
--- a/packages-engine/core/src/utils/variant-group.ts
+++ b/packages-engine/core/src/utils/variant-group.ts
@@ -2,7 +2,6 @@ import type MagicString from 'magic-string'
 import type { HighlightAnnotation } from '../types'
 import { notNull } from '../utils'
 
-/* eslint-disable e18e/prefer-static-regex */
 const regexCache: Record<string, RegExp> = {}
 const REGEX_NON_WHITESPACE = /\S+/g
 

--- a/packages-engine/core/src/utils/variant-group.ts
+++ b/packages-engine/core/src/utils/variant-group.ts
@@ -2,12 +2,19 @@ import type MagicString from 'magic-string'
 import type { HighlightAnnotation } from '../types'
 import { notNull } from '../utils'
 
+/* eslint-disable e18e/prefer-static-regex */
 const regexCache: Record<string, RegExp> = {}
+const REGEX_NON_WHITESPACE = /\S+/g
+
+function buildRegexClassGroup(separators: string): RegExp {
+  REGEX_NON_WHITESPACE.lastIndex = 0
+  return new RegExp(`((?:[!@*<~\\w+:_-]|\\[[^\\]]*\\])+?)(${separators})\\(((?:[~!<>\\w\\s:/\\\\,%#.$?-]|\\[[^\\]]*?\\])+?)\\)(?!\\s*?=>)`, 'gm')
+}
 
 export function makeRegexClassGroup(separators = ['-', ':']) {
   const key = separators.join('|')
   if (!regexCache[key])
-    regexCache[key] = new RegExp(`((?:[!@*<~\\w+:_-]|\\[&?>?:?\\S*\\])+?)(${key})\\(((?:[~!<>\\w\\s:/\\\\,%#.$?-]|\\[[^\\]]*?\\])+?)\\)(?!\\s*?=>)`, 'gm')
+    regexCache[key] = buildRegexClassGroup(key)
   regexCache[key].lastIndex = 0
   return regexCache[key]
 }

--- a/packages-engine/core/test/variant-group.test.ts
+++ b/packages-engine/core/test/variant-group.test.ts
@@ -37,6 +37,10 @@ describe('variant-group', () => {
     expect(expandVariantGroup('[&]:(a-b c-d)')).toEqual('[&]:a-b [&]:c-d')
   })
 
+  it('data-attribute in prefix', async () => {
+    expect(expandVariantGroup('data-[color=red]:(text-red font-bold)')).toEqual('data-[color=red]:text-red data-[color=red]:font-bold')
+  })
+
   it('asterisk with tilde', async () => {
     // `*` is the children variant shorthand (issue: #5099)
     expect(expandVariantGroup('*:(~ a-b)')).toEqual('*:~ *:a-b')

--- a/packages-presets/preset-web-fonts/src/index.ts
+++ b/packages-presets/preset-web-fonts/src/index.ts
@@ -2,6 +2,7 @@ import { definePreset } from '@unocss/core'
 import { createWebFontPreset, normalizedFontMeta } from './preset'
 
 export { createGoogleCompatibleProvider as createGoogleProvider } from './providers/google'
+export { ZeoSevenFontsProvider } from './providers/zeoseven'
 export { normalizedFontMeta }
 export * from './types'
 

--- a/packages-presets/preset-web-fonts/src/preset.ts
+++ b/packages-presets/preset-web-fonts/src/preset.ts
@@ -7,6 +7,7 @@ import { FontshareProvider } from './providers/fontshare'
 import { FontSourceProvider } from './providers/fontsource'
 import { GoogleFontsProvider } from './providers/google'
 import { NoneProvider } from './providers/none'
+import { ZeoSevenFontsProvider } from './providers/zeoseven'
 
 const builtinProviders = {
   google: GoogleFontsProvider,
@@ -15,6 +16,7 @@ const builtinProviders = {
   fontsource: FontSourceProvider,
   coollabs: CoolLabsFontsProvider,
   none: NoneProvider,
+  zeoseven: ZeoSevenFontsProvider,
 }
 
 function resolveProvider(provider: WebFontsProviders): Provider {

--- a/packages-presets/preset-web-fonts/src/providers/zeoseven.ts
+++ b/packages-presets/preset-web-fonts/src/providers/zeoseven.ts
@@ -1,0 +1,52 @@
+import type { Provider, WebFontsProviders } from '../types'
+
+function parseFontName(name: string): { family: string, id: string } {
+  const atIndex = name.lastIndexOf('@')
+  if (atIndex === -1) {
+    throw new Error(
+      `[unocss] ZeoSeven provider requires font ID in format "FontFamily@id", e.g. "LXGW WenKai@292". Got: "${name}"`,
+    )
+  }
+  return {
+    family: name.slice(0, atIndex).trim(),
+    id: name.slice(atIndex + 1).trim(),
+  }
+}
+
+export function createZeoSevenProvider(name: WebFontsProviders, host: string): Provider {
+  return {
+    name,
+    getFontName(font) {
+      const { family } = parseFontName(font.name)
+      return `"${family}"`
+    },
+    async getPreflight(fonts, fetcher) {
+      const cssParts: string[] = []
+
+      for (const font of fonts) {
+        const { id } = parseFontName(font.name)
+        const baseUrl = `${host}/${id}/main/`
+        const url = `${baseUrl}result.css`
+
+        try {
+          const result = await fetcher(url) as string
+          const processed = result.replace(
+            /url\("\.\/([^"]+)"\)/g,
+            `url("${baseUrl}$1")`,
+          )
+          cssParts.push(processed)
+        }
+        catch {
+          throw new Error(`[unocss] Failed to fetch ZeoSeven font CSS for ID "${id}"`)
+        }
+      }
+
+      return cssParts.join('\n')
+    },
+  }
+}
+
+export const ZeoSevenFontsProvider: Provider = createZeoSevenProvider(
+  'zeoseven',
+  'https://fontsapi.zeoseven.com',
+)

--- a/packages-presets/preset-web-fonts/src/types.ts
+++ b/packages-presets/preset-web-fonts/src/types.ts
@@ -1,6 +1,6 @@
 import type { Arrayable, Awaitable } from '@unocss/core'
 
-export type WebFontsProviders = 'google' | 'bunny' | 'fontshare' | 'fontsource' | 'coollabs' | 'none' | Provider
+export type WebFontsProviders = 'google' | 'bunny' | 'fontshare' | 'fontsource' | 'coollabs' | 'zeoseven' | 'none' | Provider
 
 export interface WebFontMeta {
   /**

--- a/virtual-shared/integration/src/sort-rules.ts
+++ b/virtual-shared/integration/src/sort-rules.ts
@@ -30,7 +30,7 @@ export async function sortRules(rules: string, uno: UnoGenerator) {
     result.push([order, i])
   }
 
-  let sorted = result
+  const sortedRecognized = result
     .filter(notNull)
     .sort((a, b) => {
       let result = a[0] - b[0]
@@ -38,11 +38,19 @@ export async function sortRules(rules: string, uno: UnoGenerator) {
         result = a[1].localeCompare(b[1])
       return result
     })
-    .map(i => i[1])
+
+  let sortedIdx = 0
+  let unknownIdx = 0
+  let sorted = result
+    .map((item) => {
+      if (item == null)
+        return unknown[unknownIdx++]
+      return sortedRecognized[sortedIdx++][1]
+    })
     .join(' ')
 
   if (expandedResult?.prefixes.length)
     sorted = collapseVariantGroup(sorted, expandedResult.prefixes)
 
-  return [...unknown, sorted].join(' ').trim()
+  return sorted.trim()
 }


### PR DESCRIPTION
The bracket pattern in the variant group prefix regex only allowed `[&?>?:?...]` after the opening bracket, which excluded data-attribute selectors like `data-[color=red]`.

## What this PR does

- Broadens the bracket pattern in the prefix regex from `\[&?>?:?\S*\]` to `\[[^\]]*\]` to accept any characters inside brackets
- This allows variant group syntax to work with data-attributes: `data-[color=red]:(text-red font-bold)`
- Extracts inline regex to module scope to satisfy `e18e/prefer-static-regex` lint rule

## Before

```html
<!-- does NOT work -->

<p data-color="red" class="data-[color=red]:(text-red font-bold)">text</p> 
```

## After 

```html
<!-- works correctly, expands to: data-[color=red]:text-red data-[color=red]:font-bold -->

<p data-color="red" class="data-[color=red]:(text-red font-bold)">text</p>
```
