### PR TITLE
fix(example/astro): add @unocss/astro dependency

### DIFF
--- a/examples/astro-vue/package.json
+++ b/examples/astro-vue/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@astrojs/vue": "^4.5.3",
     "@iconify-json/logos": "^1.2.4",
+    "@unocss/astro": "link:../../packages-integrations/astro",
     "@unocss/reset": "link:../../packages-presets/reset",
     "astro": "^4.16.18",
     "unocss": "link:../../packages-presets/unocss"

--- a/examples/astro-vue/package.json
+++ b/examples/astro-vue/package.json
@@ -16,7 +16,7 @@
     "@iconify-json/logos": "^1.2.4",
     "@unocss/astro": "link:../../packages-integrations/astro",
     "@unocss/reset": "link:../../packages-presets/reset",
-    "astro": "^4.16.18",
+    "astro": "^6.1.5",
     "unocss": "link:../../packages-presets/unocss"
   },
   "stackblitz": {

--- a/examples/astro-vue/src/env.d.ts
+++ b/examples/astro-vue/src/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="astro/client" />

--- a/examples/astro-vue/tsconfig.json
+++ b/examples/astro-vue/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "compilerOptions": {
+    "extends": "astro/tsconfigs/strict",
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "include": [".astro/types.d.ts", "**/*"],
+    "exclude": ["dist"]
   }
 }

--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -12,7 +12,7 @@
     "@iconify-json/logos": "^1.2.4",
     "@unocss/astro": "link:../../packages-integrations/astro",
     "@unocss/reset": "link:../../packages-presets/reset",
-    "astro": "^4.16.18",
+    "astro": "^6.1.5",
     "canvas-confetti": "^1.9.3",
     "unocss": "link:../../packages-presets/unocss"
   },

--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@iconify-json/logos": "^1.2.4",
+    "@unocss/astro": "link:../../packages-integrations/astro",
     "@unocss/reset": "link:../../packages-presets/reset",
     "astro": "^4.16.18",
     "canvas-confetti": "^1.9.3",

--- a/examples/astro/src/env.d.ts
+++ b/examples/astro/src/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="astro/client" />

--- a/examples/astro/tsconfig.json
+++ b/examples/astro/tsconfig.json
@@ -1,10 +1,17 @@
 {
   "compilerOptions": {
+    "extends": "astro/tsconfigs/strict",
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "include": [".astro/types.d.ts", "**/*"],
+    "exclude": ["dist"],
+    "compilerOptions": {
+      // Needed for TypeScript intellisense in the template inside Vue files
+      "jsx": "preserve"
+    }
   }
 }


### PR DESCRIPTION
A supplement of #5060 and https://github.com/unocss/unocss/commit/557484b743939369145c83397a922644e598595b . The example of Astro should also be updated as well.