### PR TITLE
fix(preset-wind4): keep media outside child selectors

### DIFF
--- a/packages-presets/preset-wind4/src/rules/spacing.ts
+++ b/packages-presets/preset-wind4/src/rules/spacing.ts
@@ -34,6 +34,7 @@ export const spaces: Rule<Theme>[] = [
 export function notLastChildSelectorVariant(s: string): VariantHandler {
   return {
     matcher: s,
+    order: 1,
     handle: (input, next) => next({
       ...input,
       parent: `${input.parent ? `${input.parent} $$ ` : ''}${input.selector}`,

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -490,6 +490,23 @@ describe('preset-wind4', () => {
     }"
   `)
   })
+
+  it('keeps media parents outside divide and space child selectors', async () => {
+    const uno = await createGenerator({
+      presets: [
+        presetWind4({
+          dark: 'media',
+        }),
+      ],
+    })
+
+    const { css } = await uno.generate('dark:divide-gray-700 dark:space-y-4', { preflights: false })
+
+    expect(css).toContain('@media (prefers-color-scheme: dark){.dark\\:divide-gray-700{\n:where(&>:not(:last-child)){border-color:')
+    expect(css).toContain('@media (prefers-color-scheme: dark){.dark\\:space-y-4{\n:where(&>:not(:last-child)){--un-space-y-reverse:0;')
+    expect(css).not.toContain('.dark\\:divide-gray-700{@media')
+    expect(css).not.toContain('.dark\\:space-y-4{@media')
+  })
 })
 
 describe('important', () => {


### PR DESCRIPTION
Fixes #4936

## Summary
- Keep the internal divide/space child selector variant after parent variants so `dark: 'media'` wraps generated rules with `@media`.
- Add regression coverage for `dark:divide-*` and `dark:space-*` in media dark mode.

## Before
`dark:divide-gray-700` generated `.dark\:divide-gray-700{@media ...}`, putting the media query under the class selector.

## After
The media query wraps the `.dark\:*` rule, matching other media dark utilities.

## Tests
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`