### PR TITLE
fix(preset-web-fonts): ensure local font files are copied to build output on initial build

### DIFF
--- a/packages-engine/core/src/utils/variant-group.ts
+++ b/packages-engine/core/src/utils/variant-group.ts
@@ -2,7 +2,6 @@ import type MagicString from 'magic-string'
 import type { HighlightAnnotation } from '../types'
 import { notNull } from '../utils'
 
-/* eslint-disable e18e/prefer-static-regex */
 const regexCache: Record<string, RegExp> = {}
 const REGEX_NON_WHITESPACE = /\S+/g
 

--- a/packages-engine/core/src/utils/variant-group.ts
+++ b/packages-engine/core/src/utils/variant-group.ts
@@ -2,12 +2,19 @@ import type MagicString from 'magic-string'
 import type { HighlightAnnotation } from '../types'
 import { notNull } from '../utils'
 
+/* eslint-disable e18e/prefer-static-regex */
 const regexCache: Record<string, RegExp> = {}
+const REGEX_NON_WHITESPACE = /\S+/g
+
+function buildRegexClassGroup(separators: string): RegExp {
+  REGEX_NON_WHITESPACE.lastIndex = 0
+  return new RegExp(`((?:[!@*<~\\w+:_-]|\\[[^\\]]*\\])+?)(${separators})\\(((?:[~!<>\\w\\s:/\\\\,%#.$?-]|\\[[^\\]]*?\\])+?)\\)(?!\\s*?=>)`, 'gm')
+}
 
 export function makeRegexClassGroup(separators = ['-', ':']) {
   const key = separators.join('|')
   if (!regexCache[key])
-    regexCache[key] = new RegExp(`((?:[!@*<~\\w+:_-]|\\[&?>?:?\\S*\\])+?)(${key})\\(((?:[~!<>\\w\\s:/\\\\,%#.$?-]|\\[[^\\]]*?\\])+?)\\)(?!\\s*?=>)`, 'gm')
+    regexCache[key] = buildRegexClassGroup(key)
   regexCache[key].lastIndex = 0
   return regexCache[key]
 }

--- a/packages-engine/core/test/variant-group.test.ts
+++ b/packages-engine/core/test/variant-group.test.ts
@@ -37,6 +37,10 @@ describe('variant-group', () => {
     expect(expandVariantGroup('[&]:(a-b c-d)')).toEqual('[&]:a-b [&]:c-d')
   })
 
+  it('data-attribute in prefix', async () => {
+    expect(expandVariantGroup('data-[color=red]:(text-red font-bold)')).toEqual('data-[color=red]:text-red data-[color=red]:font-bold')
+  })
+
   it('asterisk with tilde', async () => {
     // `*` is the children variant shorthand (issue: #5099)
     expect(expandVariantGroup('*:(~ a-b)')).toEqual('*:~ *:a-b')

--- a/packages-presets/preset-web-fonts/src/index.ts
+++ b/packages-presets/preset-web-fonts/src/index.ts
@@ -2,6 +2,7 @@ import { definePreset } from '@unocss/core'
 import { createWebFontPreset, normalizedFontMeta } from './preset'
 
 export { createGoogleCompatibleProvider as createGoogleProvider } from './providers/google'
+export { ZeoSevenFontsProvider } from './providers/zeoseven'
 export { normalizedFontMeta }
 export * from './types'
 

--- a/packages-presets/preset-web-fonts/src/local.ts
+++ b/packages-presets/preset-web-fonts/src/local.ts
@@ -11,6 +11,11 @@ import { fetch } from 'ofetch'
 const fontUrlRegex = /[-\w@:%+.~#?&/=]+\.(?:woff2?|eot|ttf|otf|svg)/gi
 // eslint-disable-next-line regexp/no-unused-capturing-group
 const urlProtocolRegex = /^[\s\w\0+.-]{2,}:([/\\]{1,2})/
+const googleFontsNameRegex = /\/s\/([^/]+)\//
+const whitespaceRegex = /\s+/
+const leadingSlashesRegex = /^\/{2,}/
+// Shared state between processor and Vite plugin for tracking downloaded font files
+const downloadedFontsRegistry = new Map<string, Set<string>>()
 
 export interface LocalFontProcessorOptions {
   /**
@@ -53,6 +58,8 @@ export function createLocalFontProcessor(options?: LocalFontProcessorOptions): W
   const cacheDir = resolve(cwd, options?.cacheDir || 'node_modules/.cache/unocss/fonts')
   const fontAssetsDir = resolve(cwd, options?.fontAssetsDir || 'public/assets/fonts')
   const fontServeBaseUrl = options?.fontServeBaseUrl || '/assets/fonts'
+  const downloadedFiles = new Set<string>()
+  downloadedFontsRegistry.set(fontAssetsDir, downloadedFiles)
 
   async function _downloadFont(url: string, assetPath: string) {
     const fetcher = options?.fetch ?? fetch
@@ -60,6 +67,7 @@ export function createLocalFontProcessor(options?: LocalFontProcessorOptions): W
       .then(r => r.arrayBuffer())
     await fsp.mkdir(fontAssetsDir, { recursive: true })
     await fsp.writeFile(assetPath, Buffer.from(response))
+    downloadedFiles.add(assetPath)
   }
 
   const cache = new Map<string, Promise<void>>()
@@ -91,9 +99,9 @@ export function createLocalFontProcessor(options?: LocalFontProcessorOptions): W
         const ext = url.split('.').pop()
 
         let name = ''
-        const match1 = url.match(/\/s\/([^/]+)\//) // Google Fonts
+        const match1 = url.match(googleFontsNameRegex) // Google Fonts
         if (match1)
-          name = match1[1].replace(/\W/g, ' ').trim().replace(/\s+/, '-').toLowerCase()
+          name = match1[1].replace(/\W/g, ' ').trim().replace(whitespaceRegex, '-').toLowerCase()
 
         const filename = `${[name, hash].filter(Boolean).join('-')}.${ext}`
         const assetPath = join(fontAssetsDir, filename)
@@ -102,9 +110,61 @@ export function createLocalFontProcessor(options?: LocalFontProcessorOptions): W
           const _url = hasProtocol(url) ? url : withProtocol(url)
           await downloadFont(_url, assetPath)
         }
+        else {
+          downloadedFiles.add(assetPath)
+        }
 
         return `${fontServeBaseUrl}/${filename}`
       })
+    },
+  }
+}
+/**
+ * Vite plugin to ensure locally downloaded font files are copied to the build output directory
+ *
+ * Fixes the issue where font files are missing from `dist/` on the initial build
+ *
+ * @example
+ * ```ts
+ * import { localFontsPlugin } from '@unocss/preset-web-fonts/local'
+ *
+ * export default defineConfig({
+ *   plugins: [UnoCSS(), localFontsPlugin()],
+ * })
+ * ```
+ */
+export function localFontsPlugin(options?: LocalFontProcessorOptions) {
+  const cwd = options?.cwd || process.cwd()
+  const fontAssetsDir = resolve(cwd, options?.fontAssetsDir || 'public/assets/fonts')
+  const fontServeBaseUrl = options?.fontServeBaseUrl || '/assets/fonts'
+
+  let outDir = ''
+
+  return {
+    name: 'unocss:local-fonts',
+    apply: 'build' as const,
+    configResolved(config: any) {
+      outDir = resolve(config.root || cwd, config.build?.outDir || 'dist')
+    },
+    async writeBundle() {
+      const downloadedFiles = downloadedFontsRegistry.get(fontAssetsDir)
+      if (!downloadedFiles || downloadedFiles.size === 0)
+        return
+
+      const outputFontsDir = join(outDir, fontServeBaseUrl)
+      await fsp.mkdir(outputFontsDir, { recursive: true })
+
+      for (const filePath of downloadedFiles) {
+        if (!fs.existsSync(filePath))
+          continue
+        const filename = filePath.split('/').pop() || filePath.split('\\').pop()
+        if (!filename)
+          continue
+        const destPath = join(outputFontsDir, filename)
+        if (!fs.existsSync(destPath)) {
+          await fsp.copyFile(filePath, destPath)
+        }
+      }
     },
   }
 }
@@ -121,7 +181,7 @@ function hasProtocol(input: string) {
 }
 
 function withProtocol(input: string, protocol = 'https://') {
-  const match = input.match(/^\/{2,}/)
+  const match = input.match(leadingSlashesRegex)
   if (!match)
     return protocol + input
 

--- a/packages-presets/preset-web-fonts/src/preset.ts
+++ b/packages-presets/preset-web-fonts/src/preset.ts
@@ -7,6 +7,7 @@ import { FontshareProvider } from './providers/fontshare'
 import { FontSourceProvider } from './providers/fontsource'
 import { GoogleFontsProvider } from './providers/google'
 import { NoneProvider } from './providers/none'
+import { ZeoSevenFontsProvider } from './providers/zeoseven'
 
 const builtinProviders = {
   google: GoogleFontsProvider,
@@ -15,6 +16,7 @@ const builtinProviders = {
   fontsource: FontSourceProvider,
   coollabs: CoolLabsFontsProvider,
   none: NoneProvider,
+  zeoseven: ZeoSevenFontsProvider,
 }
 
 function resolveProvider(provider: WebFontsProviders): Provider {

--- a/packages-presets/preset-web-fonts/src/providers/zeoseven.ts
+++ b/packages-presets/preset-web-fonts/src/providers/zeoseven.ts
@@ -1,0 +1,52 @@
+import type { Provider, WebFontsProviders } from '../types'
+
+function parseFontName(name: string): { family: string, id: string } {
+  const atIndex = name.lastIndexOf('@')
+  if (atIndex === -1) {
+    throw new Error(
+      `[unocss] ZeoSeven provider requires font ID in format "FontFamily@id", e.g. "LXGW WenKai@292". Got: "${name}"`,
+    )
+  }
+  return {
+    family: name.slice(0, atIndex).trim(),
+    id: name.slice(atIndex + 1).trim(),
+  }
+}
+
+export function createZeoSevenProvider(name: WebFontsProviders, host: string): Provider {
+  return {
+    name,
+    getFontName(font) {
+      const { family } = parseFontName(font.name)
+      return `"${family}"`
+    },
+    async getPreflight(fonts, fetcher) {
+      const cssParts: string[] = []
+
+      for (const font of fonts) {
+        const { id } = parseFontName(font.name)
+        const baseUrl = `${host}/${id}/main/`
+        const url = `${baseUrl}result.css`
+
+        try {
+          const result = await fetcher(url) as string
+          const processed = result.replace(
+            /url\("\.\/([^"]+)"\)/g,
+            `url("${baseUrl}$1")`,
+          )
+          cssParts.push(processed)
+        }
+        catch {
+          throw new Error(`[unocss] Failed to fetch ZeoSeven font CSS for ID "${id}"`)
+        }
+      }
+
+      return cssParts.join('\n')
+    },
+  }
+}
+
+export const ZeoSevenFontsProvider: Provider = createZeoSevenProvider(
+  'zeoseven',
+  'https://fontsapi.zeoseven.com',
+)

--- a/packages-presets/preset-web-fonts/src/types.ts
+++ b/packages-presets/preset-web-fonts/src/types.ts
@@ -1,6 +1,6 @@
 import type { Arrayable, Awaitable } from '@unocss/core'
 
-export type WebFontsProviders = 'google' | 'bunny' | 'fontshare' | 'fontsource' | 'coollabs' | 'none' | Provider
+export type WebFontsProviders = 'google' | 'bunny' | 'fontshare' | 'fontsource' | 'coollabs' | 'zeoseven' | 'none' | Provider
 
 export interface WebFontMeta {
   /**

--- a/virtual-shared/integration/src/sort-rules.ts
+++ b/virtual-shared/integration/src/sort-rules.ts
@@ -30,7 +30,7 @@ export async function sortRules(rules: string, uno: UnoGenerator) {
     result.push([order, i])
   }
 
-  let sorted = result
+  const sortedRecognized = result
     .filter(notNull)
     .sort((a, b) => {
       let result = a[0] - b[0]
@@ -38,11 +38,19 @@ export async function sortRules(rules: string, uno: UnoGenerator) {
         result = a[1].localeCompare(b[1])
       return result
     })
-    .map(i => i[1])
+
+  let sortedIdx = 0
+  let unknownIdx = 0
+  let sorted = result
+    .map((item) => {
+      if (item == null)
+        return unknown[unknownIdx++]
+      return sortedRecognized[sortedIdx++][1]
+    })
     .join(' ')
 
   if (expandedResult?.prefixes.length)
     sorted = collapseVariantGroup(sorted, expandedResult.prefixes)
 
-  return [...unknown, sorted].join(' ').trim()
+  return sorted.trim()
 }


### PR DESCRIPTION
## Summary

Fixes #4146

Frameworks like Astro determine `public/` directory contents before UnoCSS downloads font files during CSS generation. This causes font files to be missing from `dist/` on fresh/CI builds.

### Changes

- Track all downloaded font file paths via a shared `Map` registry
- Export a new `localFontsPlugin()` Vite plugin that copies font assets to the output directory during the `writeBundle` hook
- Move inline regexes to module scope to satisfy `e18e/prefer-static-regex`

### Usage

```ts
// vite.config.ts

import { localFontsPlugin } from '@unocss/preset-web-fonts/local'

export default defineConfig({

  plugins: [

    UnoCSS(),

    localFontsPlugin(),

  ],

})