### PR TITLE
fix(preset-wind4): correctly parse border-[color:*] arbitrary values

### DIFF
--- a/packages-presets/preset-wind4/src/rules/border.ts
+++ b/packages-presets/preset-wind4/src/rules/border.ts
@@ -70,6 +70,10 @@ function borderColorResolver(direction: string) {
 }
 
 function handlerBorderSize([, a = '', b = '1']: string[]): CSSEntries | undefined {
+  // Explicitly typed color arbitrary values (e.g., [color:red]) should be handled by the color handler
+  if (b.startsWith('[color:') || b.startsWith('[c:'))
+    return
+
   const v = h.bracket.cssvar.global.px(b)
   if (a in directionMap && v != null)
     return directionMap[a].map(i => [`border${i}-width`, v])


### PR DESCRIPTION
## Description

This PR fixes an issue where explicit color arbitrary values in borders (e.g., `border-[color:red]`) were incorrectly matched by the border width handler instead of the color handler.

### The Bug
When using typed arbitrary values like `border-[color:red]`, UnoCSS mistakenly treated `[color:red]` as a size value because `handlerBorderSize` did not explicitly ignore color-typed inputs.

### The Fix
Added a check in `handlerBorderSize` to return early if the input value starts with `[color:` or `[c:`. This ensures that these values are correctly passed to and handled by `handlerBorderColorOrSize`.

Fixes #5188