### PR TITLE
fix(preset-wind4): border-[color:*] mapped to border-width instead of border-color

### DIFF
--- a/packages-presets/preset-wind4/src/rules/border.ts
+++ b/packages-presets/preset-wind4/src/rules/border.ts
@@ -2,6 +2,7 @@ import type { CSSEntries, CSSObject, CSSValueInput, Rule, RuleContext } from '@u
 import type { Theme } from '../theme'
 import { notNull } from '@unocss/core'
 import { colorCSSGenerator, cornerMap, directionMap, generateThemeVariable, globalKeywords, h, hasParseableColor, isCSSMathFn, parseColor, SpecialColorKey, themeTracking } from '../utils'
+import { bracketTypeRe } from '../utils/handlers/regex'
 
 export const borderStyles = ['solid', 'dashed', 'dotted', 'double', 'hidden', 'none', 'groove', 'ridge', 'inset', 'outset', ...globalKeywords]
 
@@ -70,6 +71,30 @@ function borderColorResolver(direction: string) {
 }
 
 function handlerBorderSize([, a = '', b = '1']: string[], { theme }: RuleContext<Theme>): CSSEntries | undefined {
+  // Handle typed arbitrary values - respect the type hint
+  const typeMatch = b.match(bracketTypeRe)
+  if (typeMatch) {
+    const type = typeMatch[1].toLowerCase()
+    // color/image should be handled by handlerBorderColorOrSize
+    if (type === 'color' || type === 'image')
+      return
+    // length/size are valid border-width values
+    if (type === 'length' || type === 'size') {
+      const inner = b.slice(typeMatch[0].length, -1)
+      const v = h.bracket.cssvar.global.px(inner, theme)
+      if (a in directionMap && v != null)
+        return directionMap[a].map(i => [`border${i}-width`, v])
+      return
+    }
+  }
+  // Handle [width:*] prefix (not in bracketTypeRe but valid Tailwind v4 syntax)
+  if (b.startsWith('[width:') && b.endsWith(']')) {
+    const inner = b.slice(7, -1)
+    const v = h.bracket.cssvar.global.px(inner, theme)
+    if (a in directionMap && v != null)
+      return directionMap[a].map(i => [`border${i}-width`, v])
+    return
+  }
   const v = h.bracket.cssvar.global.px(b, theme)
   if (a in directionMap && v != null)
     return directionMap[a].map(i => [`border${i}-width`, v])


### PR DESCRIPTION
## Description

Fixes #5188

When using Tailwind v4's typed arbitrary value syntax (e.g., `border-[color:red]`), `preset-wind4` ignores the type hint and generates `border-width` instead of `border-color`. Additionally, `border-[width:2px]` produces invalid CSS (`border-width: width:2px`) because the prefix leaks into the value.

### The Bug

The compound rule `border-(.+)` matches first and delegates to `handlerBorderSize`, which passes the value through `h.bracket()`. The type prefix is silently stripped, so `border-[color:red]` is treated as `border-width: red`.

### The Fix

Added type-aware handling in `handlerBorderSize`:

- `[color:*]` / `[image:*]` → return early, let `handlerBorderColorOrSize` handle it
- `[length:*]` / `[size:*]` → strip type prefix, parse as border-width
- `[width:*]` → strip prefix (not in `bracketTypeRe`), parse as border-width
- Untyped brackets → existing behavior, unchanged

### Result

| Input | Before | After |
|---|---|---|
| `border-[color:red]` | `border-width: red` | `border-color: red` |
| `border-[color:var(--my-color)]` | `border-width: var(--my-color)` | `border-color: var(--my-color)` |
| `border-[length:2px]` | `border-width: 2px` | `border-width: 2px` (unchanged) |
| `border-[width:2px]` | `border-width: width:2px` | `border-width: 2px` |

### Checklist

- [x] Forked from latest `main`
- [ ] Tests added/updated