### PR TITLE
feat(language-server): add autocomplete support for theme() function

### DIFF
--- a/packages-integrations/language-server/src/capabilities/themeCompletion.ts
+++ b/packages-integrations/language-server/src/capabilities/themeCompletion.ts
@@ -1,0 +1,98 @@
+import type { CompletionItem, CompletionParams, Connection, TextDocuments } from 'vscode-languageserver'
+import type { TextDocument } from 'vscode-languageserver-textdocument'
+import type { ContextManager } from '../core/context'
+import { fileURLToPath } from 'node:url'
+import { CompletionItemKind, InsertTextFormat } from 'vscode-languageserver'
+
+const themeCallRegex = /theme\s*\(\s*(['"])([^'"]*)$/
+
+export function registerThemeCompletion(
+  connection: Connection,
+  documents: TextDocuments<TextDocument>,
+  getContextManager: () => ContextManager | undefined,
+) {
+  connection.onCompletion(async (params: CompletionParams): Promise<CompletionItem[] | null> => {
+    const contextManager = getContextManager()
+    if (!contextManager)
+      return null
+
+    const doc = documents.get(params.textDocument.uri)
+    if (!doc)
+      return null
+
+    const code = doc.getText()
+    if (!code)
+      return null
+
+    const line = doc.getText({
+      start: { line: params.position.line, character: 0 },
+      end: { line: params.position.line, character: params.position.character },
+    })
+
+    const match = line.match(themeCallRegex)
+    if (!match)
+      return null
+
+    const quoteChar = match[1]
+    const prefix = match[2]
+
+    const id = fileURLToPath(params.textDocument.uri)
+    const ctx = await contextManager.resolveClosestContext(code, id)
+    if (!ctx?.uno?.config?.theme)
+      return null
+
+    const theme = ctx.uno.config.theme as Record<string, unknown>
+    const suggestions = getThemeSuggestions(theme, prefix)
+
+    if (!suggestions.length)
+      return null
+
+    const items: CompletionItem[] = suggestions.map(({ key, value }) => {
+      const insertText = `${key + quoteChar})`
+      const item: CompletionItem = {
+        label: key,
+        kind: typeof value === 'string' ? CompletionItemKind.Color : CompletionItemKind.Field,
+        insertText,
+        insertTextFormat: InsertTextFormat.Snippet,
+        filterText: key,
+      }
+
+      if (typeof value === 'string') {
+        item.detail = value
+      }
+      else if (typeof value === 'object' && value !== null) {
+        item.detail = `[${Object.keys(value as object).join(', ')}]`
+      }
+
+      return item
+    })
+
+    return items
+  })
+}
+
+function getThemeSuggestions(
+  theme: Record<string, unknown>,
+  prefix: string,
+): { key: string, value: unknown }[] {
+  const parts = prefix ? prefix.split('.') : []
+  let current: unknown = theme
+
+  for (const part of parts) {
+    if (current && typeof current === 'object' && !Array.isArray(current) && part in current) {
+      current = (current as Record<string, unknown>)[part]
+    }
+    else {
+      return []
+    }
+  }
+
+  if (!current || typeof current !== 'object' || Array.isArray(current)) {
+    return []
+  }
+
+  return Object.entries(current as Record<string, unknown>).map(([key, value]) => ({
+    key: prefix ? `${prefix}.${key}` : key,
+    value,
+  }))
+}

--- a/packages-integrations/language-server/src/server.ts
+++ b/packages-integrations/language-server/src/server.ts
@@ -18,6 +18,7 @@ import { registerColorProvider } from './capabilities/colorProvider'
 import { registerCompletion, resetAutoCompleteCache } from './capabilities/completion'
 import { registerHover } from './capabilities/hover'
 import { registerReferences } from './capabilities/references'
+import { registerThemeCompletion } from './capabilities/themeCompletion'
 import { clearAllCache, clearDocumentCache, getMatchedPositionsFromDoc } from './core/cache'
 import { ContextManager } from './core/context'
 import { defaultSettings } from './types'
@@ -177,6 +178,7 @@ connection.onInitialize((params) => {
   registerHover(connection, documents, getContextManager, getSettings)
   registerColorProvider(connection, documents, getContextManager, getSettings)
   registerReferences(connection, documents, getContextManager, getSettings)
+  registerThemeCompletion(connection, documents, getContextManager)
 
   return {
     capabilities: {


### PR DESCRIPTION
## Description
Resolves #5111

This PR adds intelligent autocomplete support for the `theme()` function in CSS, SCSS, and other style blocks within the VS Code extension.

### Features
- **Auto-trigger:** Suggestions appear automatically when the user types `theme('` or `theme("`.
- **Deep Traversal:** Correctly parses the `theme` configuration object, supporting nested keys (e.g., typing `colors.` will suggest `red`, `blue`, `green`, etc.).
- **Value Preview:** Shows the actual value (e.g., the hex code) in the suggestion details.

### How it works
- Added a new `registerThemeCompletion` provider in `language-server/src/capabilities/themeCompletion.ts`.
- Registered the provider in `language-server/src/server.ts`.
- Uses regex detection to intercept the `theme(...)` function call context and traverses the UnoCSS `theme` object to generate `CompletionItems`.

### Testing
To test this PR:
1. Open a CSS or Vue file.
2. Type `color: theme('` inside a `<style>` block.
3. Observe the autocomplete dropdown appearing with keys from the project's `uno.config.ts` theme.