### PR TITLE
fix: improve robustness in core engine and interactive app

### DIFF
--- a/interactive/app/composables/shiki.ts
+++ b/interactive/app/composables/shiki.ts
@@ -21,17 +21,18 @@ export const shiki = computedAsync<HighlighterCore>(async () => {
 })
 
 export function highlight(code: string, lang: 'css' | 'javascript') {
-  if (!shiki.value)
+  if (!shiki.value) {
     return code.replace(/[&<>"']/g, (m) => {
       switch (m) {
         case '&': return '&amp;'
         case '<': return '&lt;'
         case '>': return '&gt;'
         case '"': return '&quot;'
-        case "'": return '&#39;'
+        case '\'': return '&#39;'
         default: return m
       }
     })
+  }
   return shiki.value.codeToHtml(code, {
     lang,
     defaultColor: false,

--- a/interactive/app/composables/shiki.ts
+++ b/interactive/app/composables/shiki.ts
@@ -22,7 +22,16 @@ export const shiki = computedAsync<HighlighterCore>(async () => {
 
 export function highlight(code: string, lang: 'css' | 'javascript') {
   if (!shiki.value)
-    return code
+    return code.replace(/[&<>"']/g, (m) => {
+      switch (m) {
+        case '&': return '&amp;'
+        case '<': return '&lt;'
+        case '>': return '&gt;'
+        case '"': return '&quot;'
+        case "'": return '&#39;'
+        default: return m
+      }
+    })
   return shiki.value.codeToHtml(code, {
     lang,
     defaultColor: false,

--- a/packages-engine/core/src/utils/variant-group.ts
+++ b/packages-engine/core/src/utils/variant-group.ts
@@ -1,11 +1,13 @@
 import type MagicString from 'magic-string'
 import type { HighlightAnnotation } from '../types'
 import { notNull } from '../utils'
+import { escapeRegExp } from './escape'
 
 const regexCache: Record<string, RegExp> = {}
 
 export function makeRegexClassGroup(separators = ['-', ':']) {
-  const key = separators.join('|')
+  const escaped = separators.map(s => escapeRegExp(s))
+  const key = escaped.join('|')
   if (!regexCache[key])
     regexCache[key] = new RegExp(`((?:[!@*<~\\w+:_-]|\\[&?>?:?\\S*\\])+?)(${key})\\(((?:[~!<>\\w\\s:/\\\\,%#.$?-]|\\[[^\\]]*?\\])+?)\\)(?!\\s*?=>)`, 'gm')
   regexCache[key].lastIndex = 0

--- a/packages-integrations/svelte-scoped/src/_common/transformTheme.ts
+++ b/packages-integrations/svelte-scoped/src/_common/transformTheme.ts
@@ -17,6 +17,9 @@ export function getThemeValue(rawArguments: string, theme: Theme): string {
   let current = theme
 
   for (const key of keys) {
+    if (key === '__proto__' || key === 'constructor')
+      throw new Error(`"${rawArguments}" contains invalid key "${key}"`)
+
     if (current[key] === undefined)
       throw new Error(`"${rawArguments}" is not found in your theme`)
 


### PR DESCRIPTION
Rendering raw regex and JavaScript source directly via `v-html` in `Rule.vue` poses a security risk, especially when displaying user-defined or third-party presets. While this is primarily a developer tool, unsanitized output can lead to XSS if a malicious playground link is shared. 

Replacing `v-html` with standard interpolation or adding a proper escaping layer ensures the interactive app remains robust. Specifically, the highlight functions for CSS and JS are now wrapped with a fallback escape mechanism.

Additionally, variant group parsing in `@unocss/core` has been improved by escaping separators before regex construction. This prevents potential ReDoS or unintended regex behavior when using custom separators. Theme lookup in Svelte scoped integration also now includes checks for `__proto__` and `constructor` to ensure safe property access.