### PR TITLE
feat(preset-wind4): add scrollbar gutter utilities

### DIFF
--- a/packages-presets/preset-wind4/src/rules/scrolls.ts
+++ b/packages-presets/preset-wind4/src/rules/scrolls.ts
@@ -3,6 +3,10 @@ import type { Theme } from '../theme'
 import { defineProperty, directionSize } from '../utils'
 
 export const scrolls: Rule<Theme>[] = [
+  ['scrollbar-gutter-auto', { 'scrollbar-gutter': 'auto' }],
+  ['scrollbar-gutter-stable', { 'scrollbar-gutter': 'stable' }],
+  ['scrollbar-gutter-both', { 'scrollbar-gutter': 'stable both-edges' }],
+
   ...['x', 'y', 'both'].map<StaticRule>(d => [
     `snap-${d}`,
     [

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -128,6 +128,27 @@ describe('preset-wind4', () => {
     await expect(css).toMatchFileSnapshot('./assets/output/preset-wind4-reset.css')
   })
 
+  it('scrollbar gutter utilities', async () => {
+    const uno = await createGenerator({
+      envMode: 'dev',
+      presets: [
+        presetWind4({ preflights: { reset: false } }),
+      ],
+    })
+
+    const { css } = await uno.generate('scrollbar-gutter-auto scrollbar-gutter-stable scrollbar-gutter-both md:scrollbar-gutter-stable', { preflights: false })
+
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .scrollbar-gutter-auto{scrollbar-gutter:auto;}
+      .scrollbar-gutter-stable{scrollbar-gutter:stable;}
+      .scrollbar-gutter-both{scrollbar-gutter:stable both-edges;}
+      @media (min-width: 48rem){
+      .md\\:scrollbar-gutter-stable{scrollbar-gutter:stable;}
+      }"
+    `)
+  })
+
   it('fully theme prefight', async () => {
     const uno = await createGenerator({
       envMode: 'dev',


### PR DESCRIPTION
## Summary

- add Wind4 scrollbar-gutter utilities matching Tailwind CSS v4.3 (`scrollbar-gutter-auto`, `scrollbar-gutter-stable`, `scrollbar-gutter-both`)
- cover the generated CSS and responsive variant behavior in preset-wind4 tests

Fixes #5223.

## Tests

- `pnpm --filter @unocss/preset-wind4... run build`
- `pnpm exec vitest run test/preset-wind4.test.ts`
- `pnpm exec eslint packages-presets/preset-wind4/src/rules/scrolls.ts test/preset-wind4.test.ts`