### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/integrations/vite.md
+++ b/docs/integrations/vite.md
@@ -39,6 +39,10 @@ npm install -D unocss
 bun add -D unocss
 ```
 
+```bash [deno]
+deno add -D unocss
+```
+
 :::
 
 Install the plugin:


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The Vite-integration install `code-group` lists pnpm / yarn / npm / bun. Since Deno is a drop-in replacement for npm these days, this adds a Deno tab in parity:

```sh
deno add -D unocss
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
