### PR TITLE
feat(language-server): semantic tokens for matched utilities

### DIFF
--- a/docs/integrations/zed.md
+++ b/docs/integrations/zed.md
@@ -4,7 +4,7 @@ title: Zed Extension for UnoCSS
 
 # Zed Extension
 
-The official [UnoCSS extension for Zed](https://github.com/unocss/unocss/tree/main/packages-integrations/zed), maintained in the UnoCSS monorepo. It runs the official [`@unocss/language-server`](https://www.npmjs.com/package/@unocss/language-server) for completion, hover, color previews and matched-utility underlining.
+The official [UnoCSS extension for Zed](https://github.com/unocss/zed). It runs the official [`@unocss/language-server`](https://www.npmjs.com/package/@unocss/language-server) for completion, hover, color previews and matched-utility underlining.
 
 ## Installation
 
@@ -12,8 +12,9 @@ The official [UnoCSS extension for Zed](https://github.com/unocss/unocss/tree/ma
 The extension is not yet published to the Zed extension registry. The `unocss` entry currently in the registry is a separate [community extension](https://github.com/bajrangCoder/zed-unocss). Until publishing is finalized, install the official extension as a dev extension.
 :::
 
-1. Run `zed: install dev extension` from the command palette.
-2. Point it at the `packages-integrations/zed/` directory of a UnoCSS checkout.
+1. Clone [`unocss/zed`](https://github.com/unocss/zed).
+2. Run `zed: install dev extension` from the command palette.
+3. Point it at the cloned repository's directory.
 
 Zed compiles the extension to wasm; the language server itself is fetched from npm on first use.
 
@@ -82,4 +83,4 @@ Because `unocss` is a custom token type, themes have no dedicated entry for it â
 
 ## Bug Reports / Feature Requests
 
-Report issues at the [UnoCSS issue tracker](https://github.com/unocss/unocss/issues).
+Report issues at the [extension's issue tracker](https://github.com/unocss/zed/issues).

--- a/docs/integrations/zed.md
+++ b/docs/integrations/zed.md
@@ -1,19 +1,85 @@
 ---
-title: Community Zed Extension for UnoCSS
+title: Zed Extension for UnoCSS
 ---
 
 # Zed Extension
 
-A community [extension](https://github.com/bajrangCoder/zed-unocss) that provides support for UnoCSS in Zed.
-
-:::info
-Note: This is a **community-maintained extension, not reviewed or maintained by the UnoCSS team**. Please do your own research before using. If you have any issues with this extension, please report it to [bajrangCoder/zed-unocss](https://github.com/bajrangCoder/zed-unocss).
-:::
+The official [UnoCSS extension for Zed](https://github.com/unocss/unocss/tree/main/packages-integrations/zed), maintained in the UnoCSS monorepo. It runs the official [`@unocss/language-server`](https://www.npmjs.com/package/@unocss/language-server) for completion, hover, color previews and matched-utility underlining.
 
 ## Installation
 
-From zed extension manager install the unocss extension, https://zed.dev/extensions/unocss
+::: info
+The extension is not yet published to the Zed extension registry. The `unocss` entry currently in the registry is a separate [community extension](https://github.com/bajrangCoder/zed-unocss). Until publishing is finalized, install the official extension as a dev extension.
+:::
+
+1. Run `zed: install dev extension` from the command palette.
+2. Point it at the `packages-integrations/zed/` directory of a UnoCSS checkout.
+
+Zed compiles the extension to wasm; the language server itself is fetched from npm on first use.
+
+Once installed, the language server attaches automatically to the supported languages (HTML, CSS, JavaScript, TypeScript, TSX, Vue, Svelte, Astro, Markdown, PHP, ERB) — open a project that has a `uno.config.*` and completion, hover and color previews start working. No manual activation is needed.
+
+## Configuration
+
+Configure the server under `lsp.unocss.settings` in your Zed `settings.json`. Keys are forwarded under the `unocss` namespace the server expects:
+
+```json
+{
+  "lsp": {
+    "unocss": {
+      "settings": {
+        "root": "./",
+        "remToPxRatio": 16,
+        "autocomplete": { "matchType": "fuzzy" }
+      }
+    }
+  }
+}
+```
+
+## Underlining matched utilities
+
+Unlike the VSCode extension (which draws its own underline), the underline in Zed is delivered via semantic tokens, so you opt in with three pieces of config.
+
+1. Turn the feature on in the server and enable semantic tokens for the languages you use (a per-project `.zed/settings.json` is fine):
+
+   ```json
+   {
+     "lsp": { "unocss": { "settings": { "semanticTokens": true } } },
+     "languages": {
+       "HTML": { "semantic_tokens": "combined" },
+       "TypeScript": { "semantic_tokens": "combined" }
+     }
+   }
+   ```
+
+2. Add the styling rule. The per-language `semantic_tokens` settings in step 1 work in a project `.zed/settings.json`, but the rule below uses `global_lsp_settings`, which Zed reads only from your **user** settings (`~/.config/zed/settings.json`) — that key is not available in a worktree-local `.zed/settings.json`:
+
+   ```json
+   { "global_lsp_settings": { "semantic_token_rules": [{ "token_type": "unocss", "underline": "#888888" }] } }
+   ```
+
+`underline` accepts `true` (use the text color) or a hex string. Other supported fields include `foreground_color`, `background_color`, `font_weight`, `font_style` and `strikethrough`.
+
+### Using theme styles
+
+Instead of hardcoding a color, you can borrow a style from the current theme with the `style` field. It takes a list of theme style names and uses the first one found, so you can list fallbacks:
+
+```json
+{
+  "global_lsp_settings": {
+    "semantic_token_rules": [
+      {
+        "token_type": "unocss",
+        "style": ["comment.doc", "comment"]
+      }
+    ]
+  }
+}
+```
+
+Because `unocss` is a custom token type, themes have no dedicated entry for it — reference an existing theme style (e.g. `comment`) to reuse its color. The first match in the active theme wins, so the styling adapts as you switch themes.
 
 ## Bug Reports / Feature Requests
 
-Report it at [Issue Tracker](https://github.com/bajrangCoder/zed-unocss/issues)
+Report issues at the [UnoCSS issue tracker](https://github.com/unocss/unocss/issues).

--- a/docs/integrations/zed.md
+++ b/docs/integrations/zed.md
@@ -40,13 +40,12 @@ Configure the server under `lsp.unocss.settings` in your Zed `settings.json`. Ke
 
 ## Underlining matched utilities
 
-Unlike the VSCode extension (which draws its own underline), the underline in Zed is delivered via semantic tokens, so you opt in with three pieces of config.
+Unlike the VSCode extension (which draws its own underline), the underline in Zed is delivered via semantic tokens, so you opt in with two pieces of config.
 
-1. Turn the feature on in the server and enable semantic tokens for the languages you use (a per-project `.zed/settings.json` is fine):
+1. Enable semantic tokens in Zed for the languages you use (the server emits the `unocss` token by default — a per-project `.zed/settings.json` is fine):
 
    ```json
    {
-     "lsp": { "unocss": { "settings": { "semanticTokens": true } } },
      "languages": {
        "HTML": { "semantic_tokens": "combined" },
        "TypeScript": { "semantic_tokens": "combined" }
@@ -54,32 +53,37 @@ Unlike the VSCode extension (which draws its own underline), the underline in Ze
    }
    ```
 
+   You can turn the server tokens off with:
+
+   ```json
+   { "lsp": { "unocss": { "settings": { "semanticTokens": false } } } }
+   ```
+
 2. Add the styling rule. The per-language `semantic_tokens` settings in step 1 work in a project `.zed/settings.json`, but the rule below uses `global_lsp_settings`, which Zed reads only from your **user** settings (`~/.config/zed/settings.json`) — that key is not available in a worktree-local `.zed/settings.json`:
 
    ```json
-   { "global_lsp_settings": { "semantic_token_rules": [{ "token_type": "unocss", "underline": "#888888" }] } }
+   {
+     "global_lsp_settings": {
+       "semantic_token_rules": [{ "token_type": "unocss", "underline": true }]
+     }
+   }
    ```
 
-`underline` accepts `true` (use the text color) or a hex string. Other supported fields include `foreground_color`, `background_color`, `font_weight`, `font_style` and `strikethrough`.
+`underline: true` uses the current text color. For the other fields (`foreground_color`, `background_color`, `font_weight`, `font_style`, `strikethrough`, `style`) see Zed's [semantic token rules](https://zed.dev/docs/semantic-tokens) docs.
 
 ### Using theme styles
 
-Instead of hardcoding a color, you can borrow a style from the current theme with the `style` field. It takes a list of theme style names and uses the first one found, so you can list fallbacks:
+Instead of a fixed underline you can borrow a color from the active theme with the `style` field — a list of theme style names, first match wins (list fallbacks). `unocss` is a custom token type with no dedicated theme entry, so point it at an existing style; the look then adapts as you switch themes:
 
 ```json
 {
   "global_lsp_settings": {
     "semantic_token_rules": [
-      {
-        "token_type": "unocss",
-        "style": ["comment.doc", "comment"]
-      }
+      { "token_type": "unocss", "style": ["link_text", "function"] }
     ]
   }
 }
 ```
-
-Because `unocss` is a custom token type, themes have no dedicated entry for it — reference an existing theme style (e.g. `comment`) to reuse its color. The first match in the active theme wins, so the styling adapts as you switch themes.
 
 ## Bug Reports / Feature Requests
 

--- a/packages-integrations/language-server/src/capabilities/completion.ts
+++ b/packages-integrations/language-server/src/capabilities/completion.ts
@@ -159,10 +159,6 @@ export function registerCompletion(
         }
 
         if (colorString) {
-          // Normalize to comma-separated `rgba()` so editors whose color
-          // extractors only accept hex/comma syntax (e.g. Zed) still render a
-          // swatch. UnoCSS may emit modern space/slash or `oklch()` forms that
-          // those extractors reject. VS Code parses this form too.
           const rgba = parseColorToRGBA(colorString)
           item.documentation = rgba
             ? `rgba(${Math.round(rgba.red * 255)}, ${Math.round(rgba.green * 255)}, ${Math.round(rgba.blue * 255)}, ${rgba.alpha})`

--- a/packages-integrations/language-server/src/capabilities/completion.ts
+++ b/packages-integrations/language-server/src/capabilities/completion.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url'
 import { createAutocomplete } from '@unocss/autocomplete'
 import { CompletionItemKind } from 'vscode-languageserver'
 import { isCssId } from '#integration/utils'
-import { getColorString } from '../utils/color'
+import { getColorString, parseColorToRGBA } from '../utils/color'
 import { getCSS, getPrettiedCSS, getPrettiedMarkdown } from '../utils/css'
 import { isVueWithPug, shouldProvideAutocomplete } from '../utils/position'
 
@@ -159,7 +159,14 @@ export function registerCompletion(
         }
 
         if (colorString) {
-          item.documentation = colorString
+          // Normalize to comma-separated `rgba()` so editors whose color
+          // extractors only accept hex/comma syntax (e.g. Zed) still render a
+          // swatch. UnoCSS may emit modern space/slash or `oklch()` forms that
+          // those extractors reject. VS Code parses this form too.
+          const rgba = parseColorToRGBA(colorString)
+          item.documentation = rgba
+            ? `rgba(${Math.round(rgba.red * 255)}, ${Math.round(rgba.green * 255)}, ${Math.round(rgba.blue * 255)}, ${rgba.alpha})`
+            : colorString
         }
 
         items.push(item)

--- a/packages-integrations/language-server/src/capabilities/semanticTokens.ts
+++ b/packages-integrations/language-server/src/capabilities/semanticTokens.ts
@@ -1,0 +1,105 @@
+import type { Connection, SemanticTokens, TextDocuments } from 'vscode-languageserver'
+import type { TextDocument } from 'vscode-languageserver-textdocument'
+import type { ContextManager } from '../core/context'
+import type { ServerSettings } from '../types'
+import { fileURLToPath } from 'node:url'
+import { SemanticTokensBuilder } from 'vscode-languageserver'
+import { INCLUDE_COMMENT_IDE } from '#integration/constants'
+import { isCssId } from '#integration/utils'
+import { getMatchedPositionsFromDoc } from '../core/cache'
+
+// Single custom token type for every matched utility; clients style it via
+// their own semantic-token rules (editor-agnostic vs. VSCode's underline).
+// NOTE: some clients only style standard legend types — if so, use 'type'.
+export const semanticTokensLegend = {
+  tokenTypes: ['unocss'],
+  tokenModifiers: [] as string[],
+}
+
+interface TokenRange {
+  start: { line: number, character: number }
+  end: { line: number, character: number }
+}
+
+// Encode matched ranges into LSP semantic-token data. Tokens must be single-line
+// and pushed in non-overlapping, increasing order, so drop multi-line/empty
+// ranges, sort, then skip any range that starts inside the previous one.
+export function buildSemanticTokensData(ranges: TokenRange[]): number[] {
+  const tokens = ranges
+    .filter(({ start, end }) => start.line === end.line && end.character > start.character)
+    .sort((a, b) => a.start.line - b.start.line || a.start.character - b.start.character)
+
+  const builder = new SemanticTokensBuilder()
+  let prevLine = -1
+  let prevEnd = -1
+  for (const { start, end } of tokens) {
+    // Skip tokens starting inside the previous one (overlapping variants).
+    if (start.line === prevLine && start.character < prevEnd)
+      continue
+    builder.push(start.line, start.character, end.character - start.character, 0, 0)
+    prevLine = start.line
+    prevEnd = end.character
+  }
+  return builder.build().data
+}
+
+export function registerSemanticTokens(
+  connection: Connection,
+  documents: TextDocuments<TextDocument>,
+  getContextManager: () => ContextManager | undefined,
+  getSettings: () => ServerSettings,
+) {
+  connection.languages.semanticTokens.on(async (params): Promise<SemanticTokens> => {
+    const empty: SemanticTokens = { data: [] }
+
+    const settings = getSettings()
+    if (!settings.semanticTokens)
+      return empty
+
+    const contextManager = getContextManager()
+    if (!contextManager)
+      return empty
+
+    const doc = documents.get(params.textDocument.uri)
+    if (!doc)
+      return empty
+
+    const id = fileURLToPath(params.textDocument.uri)
+    if (!contextManager.isTarget(id))
+      return empty
+
+    const code = doc.getText()
+    if (!code)
+      return empty
+
+    const ctx = await contextManager.resolveClosestContext(code, id)
+    if (!ctx)
+      return empty
+
+    const isTarget = ctx.filter(code, id)
+      || code.includes(INCLUDE_COMMENT_IDE)
+      || contextManager.configSources.includes(id)
+      || isCssId(id)
+    if (!isTarget)
+      return empty
+
+    try {
+      const positions = await getMatchedPositionsFromDoc(
+        ctx.uno,
+        code,
+        id,
+        settings.strictAnnotationMatch,
+      )
+
+      const ranges = positions.map(([start, end]) => ({
+        start: doc.positionAt(start),
+        end: doc.positionAt(end),
+      }))
+      return { data: buildSemanticTokensData(ranges) }
+    }
+    catch (err) {
+      connection.console.error(`[unocss] semantic tokens failed: ${err instanceof Error ? err.message : String(err)}`)
+      return empty
+    }
+  })
+}

--- a/packages-integrations/language-server/src/core/context.ts
+++ b/packages-integrations/language-server/src/core/context.ts
@@ -215,7 +215,23 @@ export class ContextManager {
     catch (e: any) {
       this.warn(`⚠️ Error on loading config. Config directory: ${dir}`)
       this.warn(String(e.stack ?? e))
-      return this.finishLoading(dir, null)
+      // The config file exists but failed to load (e.g. an uninstalled plugin
+      // imported by vite.config.ts). Degrade to a default context so standard
+      // utilities still resolve, instead of dropping all UnoCSS support for the
+      // document. `configFile: false` keeps this context off the filesystem.
+      this.warn('↩️ Falling back to the default UnoCSS config.')
+      try {
+        const fallback = createContext<UserConfig<any>>({
+          ...this.defaultUnocssConfig,
+          configFile: false,
+        })
+        await fallback.ready
+        this.configSources = []
+        return this.finishLoading(dir, fallback)
+      }
+      catch {
+        return this.finishLoading(dir, null)
+      }
     }
 
     this.configSources = sources

--- a/packages-integrations/language-server/src/server.ts
+++ b/packages-integrations/language-server/src/server.ts
@@ -18,6 +18,7 @@ import { registerColorProvider } from './capabilities/colorProvider'
 import { registerCompletion, resetAutoCompleteCache } from './capabilities/completion'
 import { registerHover } from './capabilities/hover'
 import { registerReferences } from './capabilities/references'
+import { registerSemanticTokens, semanticTokensLegend } from './capabilities/semanticTokens'
 import { clearAllCache, clearDocumentCache, getMatchedPositionsFromDoc } from './core/cache'
 import { ContextManager } from './core/context'
 import { defaultSettings } from './types'
@@ -160,6 +161,17 @@ function getContextManager() {
   return contextManager
 }
 
+// Re-request semantic tokens for open documents after settings/config change.
+// Guarded because not every client supports the refresh request.
+function refreshSemanticTokens() {
+  if (!settings.semanticTokens)
+    return
+  try {
+    connection.languages.semanticTokens.refresh()
+  }
+  catch {}
+}
+
 connection.onInitialize((params) => {
   hasWatchedFilesCapability = !!params.capabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration
   const initializationOptions = params.initializationOptions as WorkspaceInitializationOptions | undefined
@@ -177,6 +189,7 @@ connection.onInitialize((params) => {
   registerHover(connection, documents, getContextManager, getSettings)
   registerColorProvider(connection, documents, getContextManager, getSettings)
   registerReferences(connection, documents, getContextManager, getSettings)
+  registerSemanticTokens(connection, documents, getContextManager, getSettings)
 
   return {
     capabilities: {
@@ -188,6 +201,11 @@ connection.onInitialize((params) => {
       hoverProvider: true,
       referencesProvider: true,
       colorProvider: true,
+      semanticTokensProvider: {
+        legend: semanticTokensLegend,
+        full: true,
+        range: false,
+      },
     },
   }
 })
@@ -219,6 +237,7 @@ connection.onDidChangeWatchedFiles((_change) => {
     await contextManager.reload()
     connection.console.log('🔵 Reloaded.')
     await updateConfigWatchers()
+    refreshSemanticTokens()
   }, 500)
 })
 
@@ -229,6 +248,7 @@ connection.onDidChangeConfiguration(async (change) => {
     await applyConfiguredRoots()
     await updateConfigWatchers()
     resetAutoCompleteCache()
+    refreshSemanticTokens()
   }
 })
 

--- a/packages-integrations/language-server/src/types.ts
+++ b/packages-integrations/language-server/src/types.ts
@@ -6,6 +6,7 @@ export interface ServerSettings {
   include: string | string[] | undefined
   exclude: string | string[] | undefined
   underline: boolean
+  semanticTokens: boolean
   colorPreview: boolean
   colorPreviewRadius: string
   remToPxPreview: boolean
@@ -23,6 +24,9 @@ export const defaultSettings: ServerSettings = {
   include: undefined,
   exclude: undefined,
   underline: true,
+  // Off by default: VSCode renders its own underline; other LSP clients
+  // (e.g. Zed) opt in via `unocss.semanticTokens: true`.
+  semanticTokens: false,
   colorPreview: true,
   colorPreviewRadius: '50%',
   remToPxPreview: true,

--- a/packages-integrations/language-server/src/types.ts
+++ b/packages-integrations/language-server/src/types.ts
@@ -24,9 +24,7 @@ export const defaultSettings: ServerSettings = {
   include: undefined,
   exclude: undefined,
   underline: true,
-  // Off by default: VSCode renders its own underline; other LSP clients
-  // (e.g. Zed) opt in via `unocss.semanticTokens: true`.
-  semanticTokens: false,
+  semanticTokens: true,
   colorPreview: true,
   colorPreviewRadius: '50%',
   remToPxPreview: true,

--- a/packages-integrations/language-server/test/context.test.ts
+++ b/packages-integrations/language-server/test/context.test.ts
@@ -74,6 +74,36 @@ it('discovers nested config within a configured root set after initialization', 
   await expect(manager.resolveClosestContext(sourceCode, sourceFile)).resolves.toBeTruthy()
 })
 
+it('falls back to a default context when the config file fails to load', async () => {
+  const tempDir = await createTempWorkspace()
+
+  const workspaceRoot = path.join(tempDir, 'workspace-a')
+  const configuredRoot = path.join(tempDir, 'workspace-b')
+  const sourceFile = path.join(configuredRoot, 'src', 'App.tsx')
+  const sourceCode = await writeSourceFile(sourceFile)
+
+  await mkdir(workspaceRoot, { recursive: true })
+  // A config that throws on load — it imports a package that isn't installed,
+  // mirroring an example whose UnoCSS config lives in a vite.config.ts with
+  // uninstalled plugin imports.
+  await writeFile(
+    path.join(configuredRoot, 'uno.config.ts'),
+    'import \'this-package-does-not-exist-xyz\'\nexport default {}\n',
+  )
+
+  const manager = new ContextManager(workspaceRoot, connection)
+  await manager.ready
+  await manager.setRoots([configuredRoot])
+
+  // Instead of dropping all support, we degrade to a working fallback context...
+  const context = await manager.resolveClosestContext(sourceCode, sourceFile)
+  expect(context).toBeTruthy()
+
+  // ...that still resolves standard utilities via the default preset.
+  const { css } = await context!.uno.generate('text-red-500', { preflights: false })
+  expect(css).toContain('text-red-500')
+})
+
 it('discovers nested config inside a secondary workspace folder by default', async () => {
   const tempDir = await createTempWorkspace()
 

--- a/packages-integrations/language-server/test/semanticTokens.test.ts
+++ b/packages-integrations/language-server/test/semanticTokens.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { buildSemanticTokensData } from '../src/capabilities/semanticTokens'
+
+// Data is delta-encoded in groups of 5:
+//   [deltaLine, deltaStartChar, length, tokenType, tokenModifiers]
+function range(line: number, start: number, end: number, endLine = line) {
+  return { start: { line, character: start }, end: { line: endLine, character: end } }
+}
+
+describe('buildSemanticTokensData', () => {
+  it('encodes single-line tokens on the same line as char deltas', () => {
+    // second token's deltaStart is relative to the previous start (12 - 5 = 7)
+    expect(buildSemanticTokensData([range(0, 5, 10), range(0, 12, 15)]))
+      .toEqual([0, 5, 5, 0, 0, 0, 7, 3, 0, 0])
+  })
+
+  it('sorts unordered ranges before encoding', () => {
+    // a new line resets to an absolute start char
+    expect(buildSemanticTokensData([range(1, 0, 3), range(0, 2, 5)]))
+      .toEqual([0, 2, 3, 0, 0, 1, 0, 3, 0, 0])
+  })
+
+  it('drops tokens that overlap the previous one (variant matches)', () => {
+    // range(0, 8, 12) starts inside range(0, 5, 10) → dropped
+    expect(buildSemanticTokensData([range(0, 5, 10), range(0, 8, 12)]))
+      .toEqual([0, 5, 5, 0, 0])
+  })
+
+  it('keeps adjacent, non-overlapping tokens', () => {
+    // range(0, 10, 14) starts exactly where the previous ends → kept
+    expect(buildSemanticTokensData([range(0, 5, 10), range(0, 10, 14)]))
+      .toEqual([0, 5, 5, 0, 0, 0, 5, 4, 0, 0])
+  })
+
+  it('drops multi-line and empty ranges', () => {
+    // line-spanning and zero-width ranges are filtered out, leaving only range(2, 4, 7)
+    expect(buildSemanticTokensData([range(0, 5, 2, 1), range(2, 3, 3), range(2, 4, 7)]))
+      .toEqual([2, 4, 3, 0, 0])
+  })
+
+  it('returns an empty array for no ranges', () => {
+    expect(buildSemanticTokensData([])).toEqual([])
+  })
+})


### PR DESCRIPTION
Hey! 👋 This is the language-server side of the new [UnoCSS Zed extension](https://github.com/unocss/zed/pull/1). It started life in #5227 alongside the extension
Now the extension has its own repo, and this PR brings the `@unocss/language-server` changes it relies on.

### What's in here

- **Semantic tokens** — the server now emits each matched utility as a custom `unocss` token, so any LSP client can style them (an editor-agnostic take on VSCode's underline). The encoding lives in a pure, unit-tested `buildSemanticTokensData()` that handles the single-line / non-overlapping rules LSP expects, and tokens refresh on config/settings changes.
- **On by default** — `semanticTokens` defaults to `true` (set `unocss.semanticTokens: false` to opt out). This flips the off-by-default from #5227; emitting by default is the nicer baseline, and VSCode is unaffected since it draws its own underline.
- **Graceful config fallback** — if a config file exists but fails to load (e.g. `vite.config.ts` imports a plugin you haven't installed), the server falls back to a default context so basic utilities still work, instead of going dark.
- **Color completion fix** — color docs now show comma-form `rgba(r, g, b, a)` for consistent previews.
- **Docs** — the Zed integration page now points at the standalone extension and covers the opt-in underline setup.

### Testing

See the the counterpart PR in the Zed extension repo 😄 

<img width="946" height="539" alt=" 2026-06-23 um 19 16 16" src="https://github.com/user-attachments/assets/1b373e79-aba8-4104-9baa-2ee960eb361e" />
<img width="931" height="310" alt="grafik" src="https://github.com/user-attachments/assets/d55d14f1-01b7-459c-8608-eb82fc6990c0" />
