### PR TITLE
perf(core): prefilter dynamic rules

### DIFF
--- a/packages-engine/core/src/config.ts
+++ b/packages-engine/core/src/config.ts
@@ -11,6 +11,39 @@ export function resolveShortcuts<Theme extends object = object>(shortcuts: UserS
   })
 }
 
+function createDynamicRuleFilters<Theme extends object>(rules: readonly DynamicRule<Theme>[]) {
+  const filterSources = new Map<string, string[]>()
+  const fallback: DynamicRule<Theme>[] = []
+
+  for (const rule of rules) {
+    const [matcher, , meta] = rule
+    // These patterns cannot be safely embedded into a larger alternation.
+    if (meta?.prefix || matcher.global || matcher.sticky || /\\(?:[1-9]|k<)|\(\?</.test(matcher.source)) {
+      fallback.push(rule)
+      continue
+    }
+    const sources = filterSources.get(matcher.flags) ?? []
+    sources.push(`(?:${matcher.source})`)
+    filterSources.set(matcher.flags, sources)
+  }
+
+  try {
+    return {
+      fallback,
+      filters: Array.from(
+        filterSources,
+        ([flags, sources]) => new RegExp(sources.join('|'), flags),
+      ),
+    }
+  }
+  catch {
+    return {
+      fallback: [...rules],
+      filters: [],
+    }
+  }
+}
+
 const __RESOLVED = '_uno_resolved'
 
 /**
@@ -226,6 +259,8 @@ export async function resolveConfig<Theme extends object = object>(
 
   for (const p of sources)
     p?.configResolved?.(resolved)
+
+  resolved.rulesDynamicFilter = createDynamicRuleFilters(resolved.rulesDynamic)
 
   return resolved
 }

--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -618,8 +618,14 @@ class UnoGeneratorInternal<Theme extends object = object> {
         }
       }
 
+      const dynamicRuleFilter = this.config.rulesDynamicFilter
+      const dynamicRules = dynamicRuleFilter?.filters.length
+        && !dynamicRuleFilter.filters.some(filter => filter.test(processed))
+        ? dynamicRuleFilter.fallback
+        : this.config.rulesDynamic
+
       // match rules
-      for (const rule of this.config.rulesDynamic) {
+      for (const rule of dynamicRules) {
         const [matcher, handler, meta] = rule
         // ignore internal rules
         if (meta?.internal && !internal)

--- a/packages-engine/core/src/types.ts
+++ b/packages-engine/core/src/types.ts
@@ -916,6 +916,14 @@ export interface ResolvedConfig<Theme extends object = object> extends Omit<
   rulesSize: number
   rules: readonly Rule<Theme>[]
   rulesDynamic: readonly DynamicRule<Theme>[]
+  /**
+   * Prefilter for dynamic rules.
+   * @internal
+   */
+  rulesDynamicFilter?: {
+    fallback: readonly DynamicRule<Theme>[]
+    filters: readonly RegExp[]
+  }
   rulesStaticMap: Record<string, StaticRule | undefined>
   autocomplete: {
     templates: (AutoCompleteFunction | AutoCompleteTemplate)[]

--- a/packages-engine/core/test/rule-regexp.test.ts
+++ b/packages-engine/core/test/rule-regexp.test.ts
@@ -1,0 +1,34 @@
+import { createGenerator } from '@unocss/core'
+import { expect, it } from 'vitest'
+
+it('supports dynamic rules that cannot be combined into a filter', async () => {
+  const uno = await createGenerator({
+    rules: [
+      [/^(foo)-\1$/, () => ({ color: 'red' })],
+      [/(?<=lookbehind-)value$/, () => ({ color: 'green' })],
+      [/^(?<name>baz)$/, () => ({ color: 'blue' })],
+      [/^global-.+$/g, () => ({ color: 'orange' })],
+      [/^qux$/i, () => ({ color: 'purple' })],
+      [/^plain-.+$/, () => ({ color: 'black' })],
+    ],
+  })
+
+  const { matched } = await uno.generate(new Set([
+    'foo-foo',
+    'lookbehind-value',
+    'baz',
+    'global-value',
+    'QUX',
+    'plain-value',
+    'unmatched',
+  ]), { preflights: false })
+
+  expect([...matched]).toEqual([
+    'foo-foo',
+    'lookbehind-value',
+    'baz',
+    'global-value',
+    'QUX',
+    'plain-value',
+  ])
+})


### PR DESCRIPTION
This PR builds a (conservative) regex prefilter for dynamic rules, allowing tokens that cannot match any compatible rule to skip the full dynamic-rule scan while safely falling back for prefixes, backreferences, lookarounds, and stateful regexes. 

On the real npmx corpus, median UnoCSS generation improved from 782.3ms to 536.3ms (31.5% faster), while the full Nuxt client build improved from 6.124s to 5.908s on average (3.53% faster). 