### PR TITLE
perf(core): skip redundant shortcut variant matching

### DIFF
--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -153,7 +153,7 @@ class UnoGeneratorInternal<Theme extends object = object> {
         context.variants = [...matched[3]]
 
       // expand shortcuts
-      const expanded = await this.expandShortcut(context.currentSelector, context)
+      const expanded = await this.expandShortcut(context.currentSelector, context, 5, true)
       const utils = expanded
         ? await this.stringifyShortcuts(context.variantMatch, context, expanded[0], expanded[1])
         // no shortcuts
@@ -793,6 +793,7 @@ class UnoGeneratorInternal<Theme extends object = object> {
     input: string,
     context: RuleContext<Theme>,
     depth = 5,
+    skipVariantMatch = false,
   ): Promise<[(string | ShortcutInlineValue)[], RuleMeta | undefined] | undefined> {
     if (depth === 0)
       return
@@ -844,7 +845,7 @@ class UnoGeneratorInternal<Theme extends object = object> {
     }
 
     // expand nested shortcuts with variants
-    if (!result) {
+    if (!result && !skipVariantMatch) {
       const matched = isString(input) ? await this.matchVariants(input) : [input]
       for (const match of matched) {
         const [raw, inputWithoutVariant, handles] = match


### PR DESCRIPTION
This PR avoids rerunning top-level variant matching during shortcut lookup.

Becaus `parseToken()` already calls `matchVariants()` before `expandShortcut()`, the branch passes a flag to skip the redundant second `matchVariants()` call for that top-level shortcut miss path.

Recursive shortcut expansion still uses the existing variant matching behavior, so variant-prefixed nested shortcuts continue to work.