### PR TITLE
fix(transformer-directives): track @apply tokens in pseudo selectors

### DIFF
--- a/packages-presets/transformer-directives/src/apply.ts
+++ b/packages-presets/transformer-directives/src/apply.ts
@@ -13,13 +13,13 @@ export async function handleApply(ctx: TransformerDirectivesContext, node: Rule)
   await Promise.all(
     node.block.children.map(async (childNode) => {
       if (childNode.type === 'Raw')
-        return transformDirectives(code, uno, options, filename, childNode.value, childNode.loc!.start.offset)
+        return transformDirectives(code, uno, options, filename, childNode.value, childNode.loc!.start.offset, ctx.tokens)
       await parseApply(ctx, node, childNode)
     }).toArray(),
   )
 }
 
-export async function parseApply({ code, uno, applyVariable }: TransformerDirectivesContext, node: Rule, childNode: CssNode) {
+export async function parseApply({ code, uno, applyVariable, tokens }: TransformerDirectivesContext, node: Rule, childNode: CssNode) {
   const original = code.original
 
   let body: string | undefined
@@ -53,7 +53,12 @@ export async function parseApply({ code, uno, applyVariable }: TransformerDirect
 
   const utils = (
     await Promise.all(
-      classNames.map(i => uno.parseToken(i, '-')),
+      classNames.map(async (i) => {
+        const parsed = await uno.parseToken(i, '-')
+        if (parsed)
+          tokens?.add(i)
+        return parsed
+      }),
     ))
     .filter(notNull)
     .flat()

--- a/packages-presets/transformer-directives/src/index.ts
+++ b/packages-presets/transformer-directives/src/index.ts
@@ -19,7 +19,7 @@ export default function transformerDirectives(options: TransformerDirectivesOpti
       || code.includes('icon(')
       || applyVariables.some(variable => code.includes(variable)),
     transform: (code, id, ctx) => {
-      return transformDirectives(code, ctx.uno, options, id)
+      return transformDirectives(code, ctx.uno, options, id, undefined, undefined, ctx.tokens)
     },
   }
 }

--- a/packages-presets/transformer-directives/src/transform.ts
+++ b/packages-presets/transformer-directives/src/transform.ts
@@ -27,6 +27,7 @@ export async function transformDirectives(
   filename?: string,
   originalCode?: string,
   offset?: number,
+  tokens?: Set<string>,
 ) {
   const applyVariable = resolveApplyVariables(options)
 
@@ -60,6 +61,7 @@ export async function transformDirectives(
     code,
     filename,
     offset,
+    tokens,
   }
 
   const processNode = async (node: CssNode, _item: ListItem<CssNode>, _list: List<CssNode>) => {

--- a/packages-presets/transformer-directives/src/types.ts
+++ b/packages-presets/transformer-directives/src/types.ts
@@ -38,4 +38,5 @@ export interface TransformerDirectivesContext {
   applyVariable: string[]
   offset?: number
   filename?: string
+  tokens?: Set<string>
 }

--- a/test/transformer-directives.test.ts
+++ b/test/transformer-directives.test.ts
@@ -157,6 +157,19 @@ describe('wind3', () => {
       `)
     })
 
+    it('registers apply utilities inside pseudo-class selectors', async () => {
+      const code = new MagicString('.btn:hover { @apply ring ring-red-500; }')
+      const tokens = new Set<string>()
+
+      await transformerDirectives().transform(code, 'fixture.css', {
+        uno,
+        tokens,
+      } as any)
+
+      expect(tokens).toEqual(new Set(['ring', 'ring-red-500']))
+      expect((await uno.generate(tokens)).css).toContain('--un-ring-color')
+    })
+
     it('multiple pseudo-classes', async () => {
       const result = await transform(
         '.btn { @apply sm:hover:bg-white }',


### PR DESCRIPTION
### What changed

Register utilities used by `@apply` with the UnoCSS token set when the directives transformer runs through the plugin context.

### Why

When `@apply` appears inside a pseudo-class selector, for example `.btn:hover { @apply ring ring-red-500; }`, the transformer expands the declarations but the generator may not see the referenced utilities as scanned tokens. As a result, generated utility CSS such as ring color variables can be missing when those classes only exist inside `@apply`.

### Validation

- `pnpm vitest run test/transformer-directives.test.ts`
- `pnpm exec eslint packages-presets/transformer-directives/src/apply.ts packages-presets/transformer-directives/src/index.ts packages-presets/transformer-directives/src/transform.ts packages-presets/transformer-directives/src/types.ts test/transformer-directives.test.ts`

Closes #5076