### PR TITLE
fix(transformer-compile-class): update explicit shortcuts

### DIFF
--- a/packages-presets/transformer-compile-class/src/index.ts
+++ b/packages-presets/transformer-compile-class/src/index.ts
@@ -73,7 +73,7 @@ export default function transformerCompileClass(options: CompileClassOptions = {
     alwaysHash = false,
   } = options
   // #2866
-  const compiledClass = new Set()
+  const compiledClass = new Map<string, string>()
 
   // Provides backwards compatibility. We either accept a trigger string which
   // gets turned into a regexp (like previously) or a regex literal directly.
@@ -89,7 +89,8 @@ export default function transformerCompileClass(options: CompileClassOptions = {
       if (!matches.length)
         return
 
-      const size = compiledClass.size
+      let hasChanges = false
+      const currentClasses = new Map<string, string>()
       for (const match of matches) {
         let body = ((match.length === 4 && match.groups)
           ? expandVariantGroup(match[3].trim())
@@ -121,18 +122,26 @@ export default function transformerCompileClass(options: CompileClassOptions = {
           }
           const className = `${classPrefix}${hash}`
 
-          if (tokens && tokens.has(className) && explicitName) {
-            const existing = uno.config.shortcuts.find(i => i[0] === className)
-            if (existing && existing[1] !== body)
-              throw new Error(`Duplicated compile class name "${className}". One is "${body}" and the other is "${existing[1]}". Please choose different class name or set 'alwaysHash' to 'true'.`)
+          if (explicitName) {
+            const existing = currentClasses.get(className)
+            if (existing && existing !== body)
+              throw new Error(`Duplicated compile class name "${className}". One is "${body}" and the other is "${existing}". Please choose different class name or set 'alwaysHash' to 'true'.`)
           }
+          currentClasses.set(className, body)
 
-          compiledClass.add(className)
+          if (compiledClass.get(className) !== body) {
+            compiledClass.set(className, body)
+            uno.cache.delete(className)
+            uno.blocked.delete(className)
+            hasChanges = true
+          }
           replacements.unshift(className)
-          if (options.layer)
-            uno.config.shortcuts.push([className, body, { layer: options.layer }])
+          const shortcut = options.layer ? [className, body, { layer: options.layer }] : [className, body]
+          const shortcutIndex = uno.config.shortcuts.findIndex(i => i[0] === className)
+          if (shortcutIndex >= 0)
+            uno.config.shortcuts.splice(shortcutIndex, 1, shortcut)
           else
-            uno.config.shortcuts.push([className, body])
+            uno.config.shortcuts.push(shortcut)
 
           if (tokens)
             tokens.add(className)
@@ -141,7 +150,7 @@ export default function transformerCompileClass(options: CompileClassOptions = {
         s.overwrite(start + 1, start + match[0].length - 1, replacements.join(' '))
       }
 
-      if (compiledClass.size > size)
+      if (hasChanges)
         invalidate()
     },
   }

--- a/test/transformer-compile-class.test.ts
+++ b/test/transformer-compile-class.test.ts
@@ -120,6 +120,22 @@ describe('transformer-compile-class', () => {
     }).rejects.toMatchInlineSnapshot(`[Error: Duplicated compile class name "uno-foo". One is "w-2" and the other is "w-1". Please choose different class name or set 'alwaysHash' to 'true'.]`)
   })
 
+  it('custom class name can be updated across transforms', async () => {
+    const invalidateFn = vi.fn()
+    const uno = await createUno()
+
+    const first = await transform('<div class=":uno-foo: font-bold text-lg"/>', uno, invalidateFn)
+    const second = await transform('<div class=":uno-foo: font-bold text-green text-lg"/>', uno, invalidateFn)
+
+    expect(first.code.trim()).toBe('<div class="uno-foo"/>')
+    expect(second.code.trim()).toBe('<div class="uno-foo"/>')
+    expect(second.css).toMatchInlineSnapshot(`
+      "/* layer: shortcuts */
+      .uno-foo{font-size:1.125rem;line-height:1.75rem;--un-text-opacity:1;color:rgb(74 222 128 / var(--un-text-opacity));font-weight:700;}"
+    `)
+    expect(invalidateFn).toHaveBeenCalledTimes(2)
+  })
+
   it('normal class name should not conflicts', async () => {
     const result = await transform(`
 <div class=":uno: w-1 h-1"/>


### PR DESCRIPTION
### What changed

Allow explicitly named compile classes to update across separate transformer runs.

### Why

In dev mode, changing a pre-named compiled class such as `:uno-foo:` reused the same generated class name while the stored shortcut body changed. The transformer treated that as a duplicate-name conflict and required a dev server restart.

This keeps the duplicate-name error for conflicting explicit names within the same transform pass, but updates the stored shortcut and clears the cached generator entry when the same explicit class changes across transforms.

### Validation

- `pnpm vitest run test/transformer-compile-class.test.ts`
- `pnpm exec eslint packages-presets/transformer-compile-class/src/index.ts test/transformer-compile-class.test.ts`

Closes #4926