### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,36 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite


### PR DESCRIPTION
This adds a CVE Lite CLI dependency audit workflow to scan unocss for vulnerable dependencies on every push, pull request, and weekly on Mondays.

CVE Lite CLI is an OWASP Lab Project that reads the pnpm lockfile directly without installing packages, so it runs fast and requires no setup beyond checkout. It queries the OSV database for known vulnerabilities and classifies each finding as a direct or transitive dependency, with copy-and-run fix commands where a safe version is available.

A scan of the current lockfile found 17 findings: 1 critical, 7 high, 5 medium, and 4 low. The workflow is configured with `fail-on: high`, which means CI will block on high and critical findings until they are resolved. SARIF output is enabled and uploaded to GitHub Code Scanning so findings appear in the Security tab alongside other code scanning results.

More details on the tool and its output at https://owasp.org/cve-lite-cli.
