### PR TITLE
fix(core): emit @supports blocks before @media queries

### DIFF
--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -321,7 +321,27 @@ class UnoGeneratorInternal<Theme extends object = object> {
         return layerCache[layer]
 
       let css = Array.from(sheet)
-        .sort((a, b) => ((this.parentOrders.get(a[0]) ?? 0) - (this.parentOrders.get(b[0]) ?? 0)) || a[0]?.localeCompare(b[0] || '') || 0)
+        .sort((a, b) => {
+          const orderA = this.parentOrders.get(a[0]) ?? 0
+          const orderB = this.parentOrders.get(b[0]) ?? 0
+          const orderDiff = orderA - orderB
+          if (orderDiff !== 0)
+            return orderDiff
+
+          const parentA = a[0] || ''
+          const parentB = b[0] || ''
+
+          // @supports (feature queries) should emit BEFORE @media queries
+          // so that @media (e.g. print) can override @supports fallbacks
+          const isSupportsA = parentA.startsWith('@supports')
+          const isSupportsB = parentB.startsWith('@supports')
+          if (isSupportsA && !isSupportsB)
+            return -1
+          if (!isSupportsA && isSupportsB)
+            return 1
+
+          return parentA.localeCompare(parentB) || 0
+        })
         .map(([parent, items]) => {
           const size = items.length
           const sorted: PreparedRule[] = items


### PR DESCRIPTION
Fixes #4813

### Problem
`bg-gray print:bg-transparent` — when printing (with background colors enabled), the background remains gray instead of transparent. The `@supports (color: color-mix(...))` feature query block lands AFTER `@media print` in output CSS, and wins on cascade (same selector specificity, later position).

### Root Cause
`@supports` parent entries created by `colorCSSGenerator` get parentOrder `0`, same as `@media print`. Since `@media` < `@supports` lexicographically, `@media print` sorts first, making `@supports` override it by cascade.

### Fix
Add heuristic in the sort comparator: when both entries have the same `parentOrder`, `@supports` blocks are sorted BEFORE `@media` blocks. This ensures `@media print` (and other overrides) come last in the cascade.