### PR TITLE
feat: add native rsbuild integration

### DIFF
--- a/alias.ts
+++ b/alias.ts
@@ -23,6 +23,7 @@ export const aliasIntegrations: Record<string, string> = {
   '@unocss/nuxt': r('./packages-integrations/nuxt/src/'),
   '@unocss/postcss': r('./packages-integrations/postcss/src/'),
   '@unocss/postcss/esm': r('./packages-integrations/postcss/src/esm.ts'),
+  '@unocss/rsbuild': r('./packages-integrations/rsbuild/src/'),
   '@unocss/runtime': r('./packages-integrations/runtime/src/'),
   '@unocss/scope': r('./packages-integrations/scope/src/'),
   '@unocss/svelte-scoped': r('./packages-integrations/svelte-scoped/src/'),
@@ -71,6 +72,7 @@ export const aliasPresets: Record<string, string> = {
   '@unocss/transformer-directives': r('./packages-presets/transformer-directives/src/'),
   '@unocss/transformer-variant-group': r('./packages-presets/transformer-variant-group/src/'),
   'unocss': r('./packages-presets/unocss/src/'),
+  'unocss/rsbuild': r('./packages-presets/unocss/src/rsbuild.ts'),
   'unocss/vite': r('./packages-presets/unocss/src/vite.ts'),
 }
 

--- a/docs/superpowers/plans/2026-07-13-rsbuild-production-hardening.md
+++ b/docs/superpowers/plans/2026-07-13-rsbuild-production-hardening.md
@@ -1,0 +1,89 @@
+# Rsbuild 2.x Production Hardening Implementation Plan
+
+> **For AI agents:** Required sub-skill: use executing-plans to implement this plan task by task. Track progress with the checkboxes below.
+
+**Goal:** Harden `@unocss/rsbuild` for production use on Rsbuild 2.x and Rspack 2.x while keeping changes isolated from UnoCSS core.
+
+**Architecture:** Keep the native Rspack plugin, loader, and virtual-module design. Remove duplicate loader injection, make external filesystem token updates incremental, bound persistent-cache recovery concurrency, and verify that watch invalidation converges and resources are released.
+
+**Technical stack:** TypeScript, Rspack 2, Rsbuild 2, Vitest, Chokidar, UnoCSS integration helpers.
+
+---
+
+## File Responsibilities
+
+- `packages-integrations/rsbuild/src/rspack.ts`: compiler hooks, loader rule, virtual modules, invalidation lifecycle.
+- `packages-integrations/rsbuild/src/context.ts`: module and external-content token state.
+- `packages-integrations/rsbuild/src/content-watcher.ts`: discovery events for external glob roots.
+- `packages-integrations/rsbuild/src/cache.ts`: bounded persistent-cache recovery.
+- `packages-integrations/rsbuild/src/*.test.ts`: unit and real compiler regression coverage.
+
+### Task 1: Ensure one loader execution per module
+
+**Files:**
+
+- Modify: `packages-integrations/rsbuild/src/rspack.ts`
+- Modify: `packages-integrations/rsbuild/src/rspack.test.ts`
+
+- [ ] Add a regression test with a counting transformer and a Vue-style resource query that fails when the transformer runs more than once.
+- [ ] Run `pnpm -C packages-integrations/rsbuild vitest run src/rspack.test.ts` and confirm the new assertion fails.
+- [ ] Remove mutation of existing Vue rules and keep the single pre-loader rule as the only injection path.
+- [ ] Run the focused test and confirm it passes.
+
+### Task 2: Update external content incrementally
+
+**Files:**
+
+- Modify: `packages-integrations/rsbuild/src/context.ts`
+- Modify: `packages-integrations/rsbuild/src/content-watcher.ts`
+- Modify: `packages-integrations/rsbuild/src/context.test.ts`
+- Modify: `packages-integrations/rsbuild/src/rspack.ts`
+
+- [ ] Add tests proving add, change, and removal update generated CSS without retaining stale utilities.
+- [ ] Add an instrumentation test proving an unchanged external file is not reread during a one-file update.
+- [ ] Run the focused context tests and confirm the incremental API is missing or the reread assertion fails.
+- [ ] Add `updateExternalContent(changed, removed)` to update only affected token entries and filesystem membership.
+- [ ] Treat `ENOENT` during an update as removal and propagate other read errors.
+- [ ] Route Rspack `modifiedFiles` and `removedFiles` through the incremental API.
+- [ ] Make Chokidar forward only new matching files and removals not already covered by known Rspack file dependencies.
+- [ ] Run focused context and Rspack watch tests until they pass repeatedly.
+
+### Task 3: Bound persistent-cache recovery
+
+**Files:**
+
+- Modify: `packages-integrations/rsbuild/src/cache.ts`
+- Create: `packages-integrations/rsbuild/src/cache.test.ts`
+
+- [ ] Add tests for physical-file deduplication, excluded resources, and a maximum active read count.
+- [ ] Run `pnpm -C packages-integrations/rsbuild vitest run src/cache.test.ts` and confirm the concurrency test fails.
+- [ ] Replace unbounded `Promise.all` scheduling with a small local worker pool over deduplicated files.
+- [ ] Keep read and transform errors observable to the compilation.
+- [ ] Run cache tests repeatedly and confirm the concurrency bound is deterministic.
+
+### Task 4: Prove watch convergence and cleanup
+
+**Files:**
+
+- Modify: `packages-integrations/rsbuild/src/rspack.test.ts`
+- Modify: `packages-integrations/rsbuild/src/registry.ts`
+- Modify: `packages-integrations/rsbuild/src/rspack.ts`
+- Modify: `packages-integrations/rsbuild/src/content-watcher.ts`
+
+- [ ] Extend watch tests to count compilations and fail if builds continue after the expected follow-up compilation.
+- [ ] Add registry observability for tests without exporting new public package API.
+- [ ] Add tests proving compiler shutdown removes the context and closes pending watcher work.
+- [ ] Make shutdown and watch close idempotent, with registry cleanup guaranteed once.
+- [ ] Run watch-focused tests at least three consecutive times to catch timing instability.
+
+### Task 5: Full verification
+
+**Files:**
+
+- Modify only if verification exposes a defect in the scoped integration files.
+
+- [ ] Run `pnpm exec eslint packages-integrations/rsbuild/src` and require zero errors and warnings.
+- [ ] Run `pnpm -C packages-integrations/rsbuild run build` and confirm declaration generation succeeds.
+- [ ] Run `pnpm -C packages-integrations/rsbuild run test` at least twice.
+- [ ] Run `pnpm run typecheck`; if workspace packages are not built, record unrelated module-resolution failures separately.
+- [ ] Run `git diff --check` and inspect the final diff for changes outside the approved scope.

--- a/docs/superpowers/specs/2026-07-13-rsbuild-production-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-13-rsbuild-production-hardening-design.md
@@ -1,0 +1,81 @@
+# Rsbuild 2.x Production Hardening Design
+
+## Goal
+
+Make `@unocss/rsbuild` reliable for production use on Rsbuild 2.x and Rspack 2.x without changing UnoCSS core behavior or adding compatibility abstractions for older bundler versions.
+
+## Scope
+
+Changes remain inside `packages-integrations/rsbuild`, except for package metadata required by that package. Public plugin options and exports remain compatible.
+
+The work addresses only risks demonstrated by code inspection or regression tests:
+
+- prevent the UnoCSS loader from running twice for Vue modules;
+- update external filesystem content incrementally after the initial scan;
+- avoid duplicate invalidations for files already tracked by Rspack;
+- bound persistent-cache recovery concurrency;
+- prove that virtual CSS invalidation converges instead of looping;
+- close watchers and registry entries when the compiler shuts down.
+
+It does not introduce a generic watcher framework, modify shared UnoCSS integration code, support Rsbuild 1.x, or add configuration options without a demonstrated use case.
+
+## Architecture
+
+### Loader Pipeline
+
+Use one Rspack pre-loader rule as the only UnoCSS loader entry. The rule processes normal source modules, Vue subresources, and CSS transformer inputs based on the normalized resource identifier. Do not mutate existing Vue rules.
+
+The loader continues to preserve incoming source maps and uses the resource query to distinguish Vue style requests.
+
+### External Content State
+
+`NativeContext` owns the external-file token map and exposes a batch update operation accepting changed and removed absolute paths.
+
+Initial configuration loading performs one glob scan. Subsequent file events follow these rules:
+
+- changed or added matching files are read and re-extracted individually;
+- removed files delete their token entry;
+- configuration changes rebuild glob patterns and perform a full scan;
+- a failed read caused by a concurrent deletion is treated as a removal;
+- unrelated files do not invalidate generated CSS.
+
+Rspack remains responsible for changes to known files. Chokidar watches glob roots to discover newly added files and removals, and forwards only events that Rspack cannot reliably discover through existing file dependencies.
+
+### Persistent Cache Recovery
+
+Cached modules that skipped loaders are restored from source with a small fixed concurrency limit implemented locally. Requests sharing the same physical file are deduplicated. Virtual UnoCSS files and excluded resources are ignored.
+
+No new dependency is added for the limiter because the required behavior is small and package-local.
+
+### CSS Invalidation
+
+Generated CSS is hashed. Virtual modules are rewritten only when the hash changes. A CSS change may cause one follow-up compilation so Rspack can consume the new virtual-module content; the next compilation must observe the same hash and stop invalidating.
+
+## Error Handling
+
+- Watcher setup errors fail the active compilation instead of being ignored.
+- Shutdown is idempotent and clears pending timers and filesystem watchers.
+- External file read errors other than file disappearance propagate to Rspack.
+- Cache recovery read failures propagate because silently missing tokens would produce incomplete CSS.
+
+## Performance Constraints
+
+- No full external-content scan for a single ordinary file change.
+- No unbounded `Promise.all` over cached compilation modules.
+- No duplicate UnoCSS loader execution for one module request.
+- CSS generation caching remains token-content based.
+- Asset replacement continues to inspect only assets containing UnoCSS placeholders.
+
+## Verification
+
+Add or extend tests for:
+
+- one transformer execution per Vue-style module request;
+- external content add, modify, and removal without stale utilities;
+- incremental updates not rereading unchanged external files;
+- persistent-cache recovery deduplication and bounded concurrency;
+- watch mode reaching a stable build count after source and config changes;
+- direct Rspack and wrapped Rsbuild production builds;
+- watcher and context cleanup.
+
+Run package ESLint, package build, package tests, and repository type checking where the workspace build state permits it. Any repository-level failure unrelated to this package must be reported with the failing paths.

--- a/packages-integrations/rsbuild/README.md
+++ b/packages-integrations/rsbuild/README.md
@@ -1,0 +1,38 @@
+# @unocss/rsbuild
+
+Native UnoCSS integration for Rsbuild and Rspack.
+
+## Rsbuild
+
+```ts
+import { defineConfig } from '@rsbuild/core'
+import { pluginUnoCSS } from '@unocss/rsbuild'
+
+export default defineConfig({
+  plugins: [
+    pluginUnoCSS(),
+  ],
+})
+```
+
+Import the virtual CSS entry from your application:
+
+```ts
+import 'uno.css'
+```
+
+## Rspack
+
+```ts
+import { UnoCSSRspackPlugin } from '@unocss/rsbuild/rspack'
+
+export default {
+  plugins: [
+    new UnoCSSRspackPlugin(),
+  ],
+}
+```
+
+## License
+
+MIT License &copy; 2026-PRESENT [UnoCSS Authors](https://github.com/unocss/unocss/graphs/contributors)

--- a/packages-integrations/rsbuild/package.json
+++ b/packages-integrations/rsbuild/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "66.7.5",
   "description": "The native Rsbuild and Rspack integration for UnoCSS",
-  "author": "Anthony Fu <anthonyfu117@hotmail.com>",
+  "author": "eivmosn <eivmosn@163.com>",
   "license": "MIT",
   "funding": "https://github.com/sponsors/antfu",
   "homepage": "https://unocss.dev",
@@ -28,6 +28,14 @@
     "./package.json": "./package.json"
   },
   "types": "./dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*.d.mts",
+        "./*"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],
@@ -59,6 +67,7 @@
   "devDependencies": {
     "@rsbuild/core": "catalog:build",
     "@rspack/core": "catalog:build",
+    "@types/glob-parent": "catalog:types",
     "@unocss/preset-uno": "workspace:*",
     "@unocss/transformer-directives": "workspace:*",
     "@unocss/transformer-variant-group": "workspace:*",

--- a/packages-integrations/rsbuild/package.json
+++ b/packages-integrations/rsbuild/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@unocss/rsbuild",
+  "type": "module",
+  "version": "66.7.5",
+  "description": "The native Rsbuild and Rspack integration for UnoCSS",
+  "author": "Anthony Fu <anthonyfu117@hotmail.com>",
+  "license": "MIT",
+  "funding": "https://github.com/sponsors/antfu",
+  "homepage": "https://unocss.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unocss/unocss.git",
+    "directory": "packages-integrations/rsbuild"
+  },
+  "bugs": {
+    "url": "https://github.com/unocss/unocss/issues"
+  },
+  "keywords": [
+    "unocss",
+    "rsbuild",
+    "rspack"
+  ],
+  "sideEffects": false,
+  "exports": {
+    ".": "./dist/index.mjs",
+    "./loader": "./dist/loader.mjs",
+    "./rspack": "./dist/rspack.mjs",
+    "./package.json": "./package.json"
+  },
+  "types": "./dist/index.d.mts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown --config-loader unrun",
+    "dev": "tsdown --config-loader unrun --watch",
+    "test": "pnpm run build && vitest run"
+  },
+  "peerDependencies": {
+    "@rsbuild/core": "^2.0.0",
+    "@rspack/core": "^2.0.0"
+  },
+  "dependencies": {
+    "@jridgewell/remapping": "catalog:build",
+    "@unocss/config": "workspace:*",
+    "@unocss/core": "workspace:*",
+    "magic-string": "catalog:utils",
+    "pathe": "catalog:utils",
+    "tinyglobby": "catalog:utils",
+    "unplugin-utils": "catalog:utils"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "catalog:build",
+    "@rspack/core": "catalog:build",
+    "@unocss/preset-uno": "workspace:*",
+    "@unocss/transformer-directives": "workspace:*",
+    "@unocss/transformer-variant-group": "workspace:*",
+    "vitest": "catalog:testing"
+  }
+}

--- a/packages-integrations/rsbuild/package.json
+++ b/packages-integrations/rsbuild/package.json
@@ -40,10 +40,17 @@
     "@rsbuild/core": "^2.0.0",
     "@rspack/core": "^2.0.0"
   },
+  "peerDependenciesMeta": {
+    "@rsbuild/core": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@jridgewell/remapping": "catalog:build",
     "@unocss/config": "workspace:*",
     "@unocss/core": "workspace:*",
+    "chokidar": "catalog:utils",
+    "glob-parent": "catalog:utils",
     "magic-string": "catalog:utils",
     "pathe": "catalog:utils",
     "tinyglobby": "catalog:utils",

--- a/packages-integrations/rsbuild/src/cache.test.ts
+++ b/packages-integrations/rsbuild/src/cache.test.ts
@@ -31,7 +31,7 @@ it('deduplicates physical files and bounds concurrent cache reads', async () => 
   const modules = Array.from({ length: 20 }, (_, index) => ({ resource: `/src/module-${index}.ts` }))
   modules.push({ resource: '/src/module-0.ts?query' })
 
-  await restoreCachedModules(compiler, context, modules as Module[])
+  await restoreCachedModules(compiler, context, modules as unknown as Module[])
 
   expect(transformed).toHaveLength(20)
   expect(new Set(transformed).size).toBe(20)

--- a/packages-integrations/rsbuild/src/cache.test.ts
+++ b/packages-integrations/rsbuild/src/cache.test.ts
@@ -1,0 +1,39 @@
+import type { Compiler, Module } from '@rspack/core'
+import type { NativeContext } from './context'
+import { Buffer } from 'node:buffer'
+import { expect, it } from 'vitest'
+import { restoreCachedModules } from './cache'
+
+it('deduplicates physical files and bounds concurrent cache reads', async () => {
+  let activeReads = 0
+  let maxActiveReads = 0
+  const transformed: string[] = []
+  const compiler = {
+    options: { cache: true },
+    inputFileSystem: {
+      readFile(file: string, callback: (error: Error | null, content?: Buffer) => void) {
+        activeReads += 1
+        maxActiveReads = Math.max(maxActiveReads, activeReads)
+        setTimeout(() => {
+          activeReads -= 1
+          callback(null, Buffer.from(file))
+        }, 5)
+      },
+    },
+  } as unknown as Compiler
+  const context = {
+    filter: { shouldExtract: () => true },
+    hasModule: () => false,
+    async transformModule(_source: string, id: string) {
+      transformed.push(id)
+    },
+  } as unknown as NativeContext
+  const modules = Array.from({ length: 20 }, (_, index) => ({ resource: `/src/module-${index}.ts` }))
+  modules.push({ resource: '/src/module-0.ts?query' })
+
+  await restoreCachedModules(compiler, context, modules as Module[])
+
+  expect(transformed).toHaveLength(20)
+  expect(new Set(transformed).size).toBe(20)
+  expect(maxActiveReads).toBeLessThanOrEqual(8)
+})

--- a/packages-integrations/rsbuild/src/cache.test.ts
+++ b/packages-integrations/rsbuild/src/cache.test.ts
@@ -35,5 +35,7 @@ it('deduplicates physical files and bounds concurrent cache reads', async () => 
 
   expect(transformed).toHaveLength(20)
   expect(new Set(transformed).size).toBe(20)
+  expect(transformed).toContain('/src/module-0.ts')
+  expect(transformed).not.toContain('/src/module-0.ts?query')
   expect(maxActiveReads).toBeLessThanOrEqual(8)
 })

--- a/packages-integrations/rsbuild/src/cache.ts
+++ b/packages-integrations/rsbuild/src/cache.ts
@@ -1,0 +1,48 @@
+import type { Compiler, Module } from '@rspack/core'
+import type { NativeContext } from './context'
+
+const CACHE_RECOVERY_CONCURRENCY = 8
+
+export async function restoreCachedModules(
+  compiler: Compiler,
+  context: NativeContext,
+  modules: Iterable<Module>,
+): Promise<void> {
+  if (!compiler.options.cache || !compiler.inputFileSystem)
+    return
+
+  const files = new Set<string>()
+  for (const module of modules) {
+    const resource = (module as Module & { resource?: string }).resource
+    if (!resource || context.hasModule(resource))
+      continue
+    const file = resource.replace(/\?.*$/, '')
+    if (file.includes('.unocss-rsbuild') || !context.filter.shouldExtract(file))
+      continue
+    files.add(file)
+  }
+
+  const queue = [...files]
+  let index = 0
+  const worker = async () => {
+    while (index < queue.length) {
+      const file = queue[index++]
+      await context.transformModule(await readModule(compiler, file), file)
+    }
+  }
+  await Promise.all(Array.from(
+    { length: Math.min(CACHE_RECOVERY_CONCURRENCY, queue.length) },
+    worker,
+  ))
+}
+
+function readModule(compiler: Compiler, file: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    compiler.inputFileSystem!.readFile(file, (error, content) => {
+      if (error)
+        reject(error)
+      else
+        resolve(content?.toString() ?? '')
+    })
+  })
+}

--- a/packages-integrations/rsbuild/src/content-watcher.ts
+++ b/packages-integrations/rsbuild/src/content-watcher.ts
@@ -1,0 +1,94 @@
+import type { Compiler } from '@rspack/core'
+import type { FSWatcher } from 'chokidar'
+import type { NativeContext } from './context'
+import { watch } from 'chokidar'
+
+export class ExternalContentWatcher {
+  private watcher: FSWatcher | undefined
+
+  private synchronized = false
+
+  private timer: ReturnType<typeof setTimeout> | undefined
+
+  private readonly pendingChanges = new Set<string>()
+
+  constructor(
+    private readonly compiler: Compiler,
+    private readonly context: NativeContext,
+    private readonly enabled: boolean,
+  ) {}
+
+  async ensure(): Promise<void> {
+    if (!this.synchronized)
+      await this.sync()
+  }
+
+  async sync(): Promise<void> {
+    await this.close()
+    if (!this.enabled) {
+      this.synchronized = true
+      return
+    }
+
+    const roots = [...this.context.filesystemWatchRoots]
+    if (!roots.length) {
+      this.synchronized = true
+      return
+    }
+
+    const poll = this.compiler.options.watchOptions.poll
+    const watcher = watch(roots, {
+      ignoreInitial: true,
+      ignorePermissionErrors: true,
+      ignored: ['**/{.git,node_modules}/**'],
+      interval: typeof poll === 'number' ? poll : undefined,
+      usePolling: Boolean(poll),
+    })
+    this.watcher = watcher
+    watcher.on('all', (event, file) => this.handleFileEvent(event, file))
+    try {
+      await new Promise<void>((resolve, reject) => {
+        watcher.once('ready', resolve)
+        watcher.once('error', reject)
+      })
+      this.synchronized = true
+    }
+    catch (error) {
+      await this.close()
+      throw error
+    }
+  }
+
+  async close(): Promise<void> {
+    this.synchronized = false
+    if (this.timer)
+      clearTimeout(this.timer)
+    this.timer = undefined
+    this.pendingChanges.clear()
+    const watcher = this.watcher
+    this.watcher = undefined
+    await watcher?.close()
+  }
+
+  private handleFileEvent(event: string, file: string): void {
+    if (!this.context.matchesFilesystemFile(file))
+      return
+
+    if (event !== 'add' || this.context.filesystemFiles.has(file))
+      return
+
+    this.pendingChanges.add(file)
+
+    if (this.timer)
+      clearTimeout(this.timer)
+    // Coalesce rapid filesystem events into one Rspack invalidation.
+    this.timer = setTimeout(() => this.invalidate(), 10)
+  }
+
+  private invalidate(): void {
+    this.timer = undefined
+    const changes = new Set(this.pendingChanges)
+    this.pendingChanges.clear()
+    this.compiler.watching?.invalidateWithChangesAndRemovals(changes, new Set())
+  }
+}

--- a/packages-integrations/rsbuild/src/context.test.ts
+++ b/packages-integrations/rsbuild/src/context.test.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import presetUno from '@unocss/preset-uno'
+import transformerDirectives from '@unocss/transformer-directives'
+import transformerVariantGroup from '@unocss/transformer-variant-group'
+import { afterEach, describe, expect, it } from 'vitest'
+import { NativeContext } from './context'
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { force: true, recursive: true })))
+})
+
+async function createTestContext() {
+  const root = await mkdtemp(join(tmpdir(), 'unocss-rsbuild-context-'))
+  temporaryDirectories.push(root)
+  const context = new NativeContext(root, {
+    configOrPath: {
+      presets: [presetUno()],
+      transformers: [
+        transformerDirectives(),
+        transformerVariantGroup(),
+      ],
+    },
+  })
+  await context.initialize()
+  return context
+}
+
+describe('native context', () => {
+  it('runs all source transformers and directives', async () => {
+    const context = await createTestContext()
+    const vueResult = await context.transformModule(
+      '<template><div class="group-hover:(text-red bg-blue)" /></template>',
+      '/fixture/App.vue',
+    )
+    const cssResult = await context.transformModule(
+      '.content { @apply text-red; --at-apply: bg-yellow; }',
+      '/fixture/App.vue?vue&type=style.css',
+    )
+
+    expect(vueResult.code).toContain('group-hover:text-red group-hover:bg-blue')
+    expect(cssResult.code).toContain('color:')
+    expect(cssResult.code).toContain('background-color:')
+    expect(cssResult.code).not.toContain('@apply')
+  })
+
+  it('replaces tokens when a module changes or is removed', async () => {
+    const context = await createTestContext()
+    const id = '/fixture/view.tsx'
+
+    await context.transformModule('export const view = `<div class="text-red" />`', id)
+    expect((await context.generate()).css).toContain('.text-red')
+
+    await context.transformModule('export const view = `<div class="text-blue" />`', id)
+    const changedCss = (await context.generate()).css
+    expect(changedCss).toContain('.text-blue')
+    expect(changedCss).not.toContain('.text-red')
+
+    context.removeModule(id)
+    const removedCss = (await context.generate()).css
+    expect(removedCss).not.toContain('.text-blue')
+  })
+
+  it('resolves full and named layer virtual modules', async () => {
+    const context = await createTestContext()
+    expect(await context.resolveLayer(await context.resolveVirtualId('uno.css') || '')).toBe('__ALL__')
+    expect(await context.resolveLayer(await context.resolveVirtualId('uno:utilities.css') || '')).toBe('utilities')
+  })
+})

--- a/packages-integrations/rsbuild/src/context.test.ts
+++ b/packages-integrations/rsbuild/src/context.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import presetUno from '@unocss/preset-uno'
@@ -68,5 +68,118 @@ describe('native context', () => {
     const context = await createTestContext()
     expect(await context.resolveLayer(await context.resolveVirtualId('uno.css') || '')).toBe('__ALL__')
     expect(await context.resolveLayer(await context.resolveVirtualId('uno:utilities.css') || '')).toBe('utilities')
+    expect(await context.resolveLayer(await context.resolveVirtualId('uno.css?inline') || '')).toBe('__ALL__')
+    expect(await context.resolveLayer(await context.resolveVirtualId('uno:utilities.css?url') || '')).toBe('utilities')
+  })
+
+  it('honors custom pipeline filters for extraction and transformers', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'unocss-rsbuild-pipeline-'))
+    temporaryDirectories.push(root)
+    const context = new NativeContext(root, {
+      configOrPath: {
+        content: {
+          pipeline: {
+            include: [/\.custom$/],
+          },
+        },
+        presets: [presetUno()],
+        transformers: [transformerVariantGroup()],
+      },
+    })
+    await context.initialize()
+
+    expect(context.filter.shouldTransform('/fixture/view.custom')).toBe(true)
+    const result = await context.transformModule('<div class="hover:(text-red bg-blue)" />', '/fixture/view.custom')
+    expect(result.code).toContain('hover:text-red hover:bg-blue')
+    const css = (await context.generate()).css
+    expect(css).toContain('.hover\\:text-red')
+    expect(css).toContain('.hover\\:bg-blue')
+  })
+
+  it('does not extract utilities from skipped source ranges', async () => {
+    const context = await createTestContext()
+    await context.transformModule(
+      '<!-- @unocss-skip-start --><div class="text-red" /><!-- @unocss-skip-end --><div class="text-blue" />',
+      '/fixture/App.vue',
+    )
+
+    const css = (await context.generate()).css
+    expect(css).toContain('.text-blue')
+    expect(css).not.toContain('.text-red')
+  })
+
+  it('initializes external content once and exposes glob watch roots', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'unocss-rsbuild-initialize-'))
+    temporaryDirectories.push(root)
+    await mkdir(join(root, 'content'), { recursive: true })
+    let inlineCalls = 0
+    const context = new NativeContext(root, {
+      configOrPath: {
+        content: {
+          filesystem: ['content/**/*.html'],
+          inline: [() => {
+            inlineCalls += 1
+            return '<div class="text-green" />'
+          }],
+        },
+        presets: [presetUno()],
+      },
+    })
+
+    await Promise.all([context.initialize(), context.initialize(), context.initialize()])
+    expect(inlineCalls).toBe(1)
+    expect(context.filesystemWatchRoots).toContain(join(root, 'content'))
+    expect(context.matchesFilesystemFile(join(root, 'content', 'new.html'))).toBe(true)
+    expect(context.matchesFilesystemFile(join(root, 'content', 'new.ts'))).toBe(false)
+    expect((await context.generate()).css).toContain('.text-green')
+
+    await writeFile(join(root, 'content', 'new.html'), '<div class="text-blue" />', 'utf8')
+    await context.extractExternalContent()
+    expect((await context.generate()).css).toContain('.text-blue')
+  })
+
+  it('updates only changed external content and removes stale tokens', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'unocss-rsbuild-incremental-content-'))
+    temporaryDirectories.push(root)
+    const contentDirectory = join(root, 'content')
+    const changedFile = join(contentDirectory, 'changed.html')
+    const unchangedFile = join(contentDirectory, 'unchanged.html')
+    await mkdir(contentDirectory, { recursive: true })
+    await Promise.all([
+      writeFile(changedFile, '<div class="text-red" />', 'utf8'),
+      writeFile(unchangedFile, '<div class="text-green" />', 'utf8'),
+    ])
+
+    let transformCalls = 0
+    const context = new NativeContext(root, {
+      configOrPath: {
+        content: { filesystem: ['content/**/*.html'] },
+        presets: [presetUno()],
+        transformers: [{
+          name: 'count-external-transforms',
+          transform() {
+            transformCalls += 1
+          },
+        }],
+      },
+    })
+    await context.initialize()
+    transformCalls = 0
+
+    await writeFile(changedFile, '<div class="text-blue" />', 'utf8')
+    await context.updateExternalContent(new Set([changedFile]), new Set())
+
+    const changedCss = (await context.generate()).css
+    expect(transformCalls).toBe(1)
+    expect(changedCss).toContain('.text-blue')
+    expect(changedCss).toContain('.text-green')
+    expect(changedCss).not.toContain('.text-red')
+
+    await rm(changedFile)
+    await context.updateExternalContent(new Set(), new Set([changedFile]))
+
+    const removedCss = (await context.generate()).css
+    expect(removedCss).toContain('.text-green')
+    expect(removedCss).not.toContain('.text-blue')
   })
 })

--- a/packages-integrations/rsbuild/src/context.ts
+++ b/packages-integrations/rsbuild/src/context.ts
@@ -1,0 +1,254 @@
+import type { GenerateResult, UnocssPluginContext, UserConfig } from '@unocss/core'
+import type { UnoCSSRspackPluginOptions } from './types'
+import fs from 'node:fs/promises'
+import { isAbsolute, resolve } from 'node:path'
+import { glob } from 'tinyglobby'
+import { IGNORE_COMMENT, INCLUDE_COMMENT } from '#integration/constants'
+import { createContext } from '#integration/context'
+import { resolveId, resolveLayer } from '#integration/layers'
+import { createNativeFilter } from './filter'
+import { transformSource } from './transformers'
+
+export class NativeContext {
+  readonly filter
+
+  private readonly base: UnocssPluginContext
+
+  private readonly externalTokens = new Map<string, Set<string>>()
+
+  private readonly moduleSources = new Map<string, string>()
+
+  private readonly moduleTokens = new Map<string, Set<string>>()
+
+  private externalFiles = new Set<string>()
+
+  private generateKey = ''
+
+  private generateResult: GenerateResult | undefined
+
+  private virtualHash = ''
+
+  /**
+   * 创建一次 Rspack 编译器生命周期内共享的 UnoCSS 上下文。
+   *
+   * @param root 项目根目录。
+   * @param options Rspack integration 配置。
+   */
+  constructor(
+    readonly root: string,
+    readonly options: UnoCSSRspackPluginOptions,
+  ) {
+    this.base = createContext(options.configOrPath, options.defaults)
+    this.filter = createNativeFilter(root, options.include, options.exclude)
+  }
+
+  /** 获取当前 UnoCSS 配置依赖的文件列表。 */
+  get configFiles(): string[] {
+    return this.base.getConfigFileList()
+  }
+
+  /** 获取通过 `content.filesystem` 扫描到的外部文件。 */
+  get filesystemFiles(): ReadonlySet<string> {
+    return this.externalFiles
+  }
+
+  /** 获取虚拟 CSS 模块当前使用的内容 hash。 */
+  getVirtualHash(): string {
+    return this.virtualHash
+  }
+
+  /**
+   * 更新虚拟 CSS 模块的内容 hash。
+   *
+   * @param hash 最新生成 CSS 的稳定 hash。
+   */
+  setVirtualHash(hash: string): void {
+    this.virtualHash = hash
+  }
+
+  /** 初始化 UnoCSS 配置并提取外部 content。 */
+  async initialize(): Promise<void> {
+    await this.base.updateRoot(this.root)
+    await this.extractExternalContent()
+  }
+
+  /**
+   * 转换模块源码并更新该模块对应的 token 集合。
+   *
+   * @param source 模块源码。
+   * @param id 带查询参数的模块标识。
+   * @returns transformer 处理后的源码和可选 sourcemap。
+   */
+  async transformModule(source: string, id: string) {
+    await this.base.ready
+    return this.transformModuleInner(source, id)
+  }
+
+  /**
+   * 删除模块及其 token，防止 HMR 后残留无效 utility。
+   *
+   * @param id 模块标识。
+   */
+  removeModule(id: string): void {
+    this.moduleSources.delete(id)
+    this.moduleTokens.delete(id)
+    this.invalidateGenerateCache()
+  }
+
+  /**
+   * 淘汰本轮 compilation 已不存在的模块。
+   *
+   * @param moduleIds 当前 compilation 的模块标识集合。
+   */
+  evictModulesNotIn(moduleIds: ReadonlySet<string>): void {
+    for (const id of this.moduleSources.keys()) {
+      if (!moduleIds.has(id))
+        this.removeModule(id)
+    }
+  }
+
+  /** 重新加载配置，并使用新配置重建所有已知模块和外部 token。 */
+  async reloadConfig(): Promise<void> {
+    await this.base.reloadConfig()
+    this.moduleTokens.clear()
+    this.externalTokens.clear()
+    this.invalidateGenerateCache()
+
+    for (const [id, source] of this.moduleSources)
+      await this.transformModuleInner(source, id)
+
+    await this.extractExternalContent()
+  }
+
+  /** 重新提取 `content.inline` 与 `content.filesystem` 指定的内容。 */
+  async extractExternalContent(): Promise<void> {
+    await this.base.ready
+    const config = await this.base.getConfig() as UserConfig
+    const pendingTokens = new Map<string, Set<string>>()
+    const pendingFiles = new Set<string>()
+
+    for (const [index, item] of (config.content?.inline ?? []).entries()) {
+      const resolved = typeof item === 'function' ? await item() : item
+      const content = typeof resolved === 'string' ? { code: resolved } : resolved
+      const id = content.id ?? `__uno_inline_${index}__`
+      pendingTokens.set(id, await this.extractSource(content.code, id))
+    }
+
+    const patterns = config.content?.filesystem ?? []
+    if (patterns.length) {
+      const files = await glob(patterns, {
+        cwd: this.root,
+        absolute: true,
+        expandDirectories: false,
+        ignore: ['**/{.git,node_modules}/**'],
+      })
+      for (const file of files) {
+        const absoluteFile = isAbsolute(file) ? file : resolve(this.root, file)
+        pendingFiles.add(absoluteFile)
+        pendingTokens.set(absoluteFile, await this.extractSource(await fs.readFile(absoluteFile, 'utf8'), absoluteFile))
+      }
+    }
+
+    this.externalTokens.clear()
+    for (const [id, tokens] of pendingTokens)
+      this.externalTokens.set(id, tokens)
+    this.externalFiles = pendingFiles
+    this.invalidateGenerateCache()
+  }
+
+  /**
+   * 合并当前 token 并生成 CSS，相同 token 集合会复用缓存。
+   *
+   * @param minify 是否压缩生成结果。
+   * @returns UnoCSS 分层生成结果。
+   */
+  async generate(minify = false): Promise<GenerateResult> {
+    await this.base.ready
+    const tokens = this.collectTokens()
+    const key = [...tokens].sort().join('\0')
+    if (this.generateResult && this.generateKey === key)
+      return this.generateResult
+
+    this.generateKey = key
+    this.generateResult = await this.base.uno.generate(tokens, { minify })
+    return this.generateResult
+  }
+
+  /**
+   * 创建绑定当前模块 token 集合的 UnoCSS 插件上下文。
+   *
+   * @param tokens 当前模块独立维护的 token 集合。
+   * @returns 可供官方 transformer 使用的上下文。
+   */
+  getPluginContext(tokens: Set<string>): UnocssPluginContext {
+    const base = this.base
+    return {
+      ...base,
+      tokens,
+      filter: (code, id) => {
+        if (code.includes(IGNORE_COMMENT))
+          return false
+        return code.includes(INCLUDE_COMMENT)
+          || (this.filter.shouldExtract(id) && base.filter(code, id))
+      },
+    }
+  }
+
+  /**
+   * 将 `uno.css` 等公开入口解析为 UnoCSS 虚拟模块标识。
+   *
+   * @param id 待解析的导入标识。
+   * @param importer 导入方模块标识。
+   * @returns 解析后的虚拟标识，非 UnoCSS 入口返回 undefined。
+   */
+  async resolveVirtualId(id: string, importer?: string): Promise<string | undefined> {
+    return resolveId(this.base, id, importer)
+  }
+
+  /**
+   * 解析虚拟模块对应的 CSS layer。
+   *
+   * @param id 已解析的 UnoCSS 虚拟标识。
+   * @returns layer 名称，无法解析时返回 undefined。
+   */
+  async resolveLayer(id: string): Promise<string | undefined> {
+    return resolveLayer(this.base, id)
+  }
+
+  /** 转换单个模块，并原子更新其源码和 token 缓存。 */
+  private async transformModuleInner(source: string, id: string) {
+    const tokens = new Set<string>()
+    const result = await transformSource(this.getPluginContext(tokens), source, id)
+    if (this.filter.shouldExtract(id))
+      await this.base.uno.applyExtractors(result.code, id, tokens)
+
+    this.moduleSources.set(id, source)
+    this.moduleTokens.set(id, tokens)
+    this.invalidateGenerateCache()
+    return result
+  }
+
+  /** 从外部内容中运行 transformer 和 extractor，返回独立 token 集合。 */
+  private async extractSource(source: string, id: string): Promise<Set<string>> {
+    const tokens = new Set<string>()
+    const result = await transformSource(this.getPluginContext(tokens), source, id)
+    await this.base.uno.applyExtractors(result.code, id, tokens)
+    return tokens
+  }
+
+  /** 合并模块与外部内容的 token，并自动去重。 */
+  private collectTokens(): Set<string> {
+    const tokens = new Set<string>()
+    for (const tokenSet of [...this.moduleTokens.values(), ...this.externalTokens.values()]) {
+      for (const token of tokenSet)
+        tokens.add(token)
+    }
+    return tokens
+  }
+
+  /** 使 CSS 生成缓存失效。 */
+  private invalidateGenerateCache(): void {
+    this.generateKey = ''
+    this.generateResult = undefined
+  }
+}

--- a/packages-integrations/rsbuild/src/context.ts
+++ b/packages-integrations/rsbuild/src/context.ts
@@ -1,4 +1,4 @@
-import type { GenerateResult, UnocssPluginContext, UserConfig } from '@unocss/core'
+import type { GenerateResult, UnocssPluginContext } from '@unocss/core'
 import type { UnoCSSRspackPluginOptions } from './types'
 import fs from 'node:fs/promises'
 import { isAbsolute, resolve } from 'node:path'
@@ -114,7 +114,7 @@ export class NativeContext {
 
   async extractExternalContent(): Promise<void> {
     await this.base.ready
-    const config = this.base.uno.config as UserConfig
+    const config = await this.base.getConfig()
     const pendingTokens = new Map<string, Set<string>>()
     const pendingFiles = new Set<string>()
     const pendingWatchRoots = new Set<string>()

--- a/packages-integrations/rsbuild/src/context.ts
+++ b/packages-integrations/rsbuild/src/context.ts
@@ -2,15 +2,18 @@ import type { GenerateResult, UnocssPluginContext, UserConfig } from '@unocss/co
 import type { UnoCSSRspackPluginOptions } from './types'
 import fs from 'node:fs/promises'
 import { isAbsolute, resolve } from 'node:path'
+import globParent from 'glob-parent'
 import { glob } from 'tinyglobby'
-import { IGNORE_COMMENT, INCLUDE_COMMENT } from '#integration/constants'
+import { createFilter } from 'unplugin-utils'
+import { CSS_PLACEHOLDER, IGNORE_COMMENT, INCLUDE_COMMENT, SKIP_COMMENT_RE } from '#integration/constants'
 import { createContext } from '#integration/context'
 import { resolveId, resolveLayer } from '#integration/layers'
+import { getPath } from '#integration/utils'
 import { createNativeFilter } from './filter'
 import { transformSource } from './transformers'
 
 export class NativeContext {
-  readonly filter
+  filter
 
   private readonly base: UnocssPluginContext
 
@@ -22,18 +25,18 @@ export class NativeContext {
 
   private externalFiles = new Set<string>()
 
+  private externalFileFilter: (id: string) => boolean = () => false
+
+  private externalWatchRoots = new Set<string>()
+
   private generateKey = ''
 
   private generateResult: GenerateResult | undefined
 
+  private initializePromise: Promise<void> | undefined
+
   private virtualHash = ''
 
-  /**
-   * 创建一次 Rspack 编译器生命周期内共享的 UnoCSS 上下文。
-   *
-   * @param root 项目根目录。
-   * @param options Rspack integration 配置。
-   */
   constructor(
     readonly root: string,
     readonly options: UnoCSSRspackPluginOptions,
@@ -42,64 +45,53 @@ export class NativeContext {
     this.filter = createNativeFilter(root, options.include, options.exclude)
   }
 
-  /** 获取当前 UnoCSS 配置依赖的文件列表。 */
   get configFiles(): string[] {
     return this.base.getConfigFileList()
   }
 
-  /** 获取通过 `content.filesystem` 扫描到的外部文件。 */
   get filesystemFiles(): ReadonlySet<string> {
     return this.externalFiles
   }
 
-  /** 获取虚拟 CSS 模块当前使用的内容 hash。 */
+  get filesystemWatchRoots(): ReadonlySet<string> {
+    return this.externalWatchRoots
+  }
+
+  matchesFilesystemFile(file: string): boolean {
+    return this.externalFileFilter(file)
+  }
+
   getVirtualHash(): string {
     return this.virtualHash
   }
 
-  /**
-   * 更新虚拟 CSS 模块的内容 hash。
-   *
-   * @param hash 最新生成 CSS 的稳定 hash。
-   */
   setVirtualHash(hash: string): void {
     this.virtualHash = hash
   }
 
-  /** 初始化 UnoCSS 配置并提取外部 content。 */
-  async initialize(): Promise<void> {
-    await this.base.updateRoot(this.root)
-    await this.extractExternalContent()
+  initialize(): Promise<void> {
+    this.initializePromise ??= this.initializeInner().catch((error) => {
+      this.initializePromise = undefined
+      throw error
+    })
+    return this.initializePromise
   }
 
-  /**
-   * 转换模块源码并更新该模块对应的 token 集合。
-   *
-   * @param source 模块源码。
-   * @param id 带查询参数的模块标识。
-   * @returns transformer 处理后的源码和可选 sourcemap。
-   */
   async transformModule(source: string, id: string) {
     await this.base.ready
     return this.transformModuleInner(source, id)
   }
 
-  /**
-   * 删除模块及其 token，防止 HMR 后残留无效 utility。
-   *
-   * @param id 模块标识。
-   */
   removeModule(id: string): void {
     this.moduleSources.delete(id)
     this.moduleTokens.delete(id)
     this.invalidateGenerateCache()
   }
 
-  /**
-   * 淘汰本轮 compilation 已不存在的模块。
-   *
-   * @param moduleIds 当前 compilation 的模块标识集合。
-   */
+  hasModule(id: string): boolean {
+    return this.moduleSources.has(id)
+  }
+
   evictModulesNotIn(moduleIds: ReadonlySet<string>): void {
     for (const id of this.moduleSources.keys()) {
       if (!moduleIds.has(id))
@@ -107,9 +99,9 @@ export class NativeContext {
     }
   }
 
-  /** 重新加载配置，并使用新配置重建所有已知模块和外部 token。 */
   async reloadConfig(): Promise<void> {
     await this.base.reloadConfig()
+    this.refreshFilter()
     this.moduleTokens.clear()
     this.externalTokens.clear()
     this.invalidateGenerateCache()
@@ -120,52 +112,106 @@ export class NativeContext {
     await this.extractExternalContent()
   }
 
-  /** 重新提取 `content.inline` 与 `content.filesystem` 指定的内容。 */
   async extractExternalContent(): Promise<void> {
     await this.base.ready
-    const config = await this.base.getConfig() as UserConfig
+    const config = this.base.uno.config as UserConfig
     const pendingTokens = new Map<string, Set<string>>()
     const pendingFiles = new Set<string>()
+    const pendingWatchRoots = new Set<string>()
 
-    for (const [index, item] of (config.content?.inline ?? []).entries()) {
+    await Promise.all((config.content?.inline ?? []).map(async (item, index) => {
       const resolved = typeof item === 'function' ? await item() : item
       const content = typeof resolved === 'string' ? { code: resolved } : resolved
       const id = content.id ?? `__uno_inline_${index}__`
       pendingTokens.set(id, await this.extractSource(content.code, id))
-    }
+    }))
 
     const patterns = config.content?.filesystem ?? []
     if (patterns.length) {
+      const include = patterns.filter(pattern => !pattern.startsWith('!'))
+      const exclude = patterns
+        .filter(pattern => pattern.startsWith('!'))
+        .map(pattern => pattern.slice(1))
+      this.externalFileFilter = createFilter(
+        include,
+        [...exclude, '**/{.git,node_modules}/**'],
+        { resolve: this.root },
+      )
+      for (const pattern of patterns) {
+        if (pattern.startsWith('!'))
+          continue
+        const parent = globParent(pattern)
+        pendingWatchRoots.add(isAbsolute(parent) ? parent : resolve(this.root, parent))
+      }
       const files = await glob(patterns, {
         cwd: this.root,
         absolute: true,
         expandDirectories: false,
         ignore: ['**/{.git,node_modules}/**'],
       })
-      for (const file of files) {
-        const absoluteFile = isAbsolute(file) ? file : resolve(this.root, file)
-        pendingFiles.add(absoluteFile)
-        pendingTokens.set(absoluteFile, await this.extractSource(await fs.readFile(absoluteFile, 'utf8'), absoluteFile))
+      const batchSize = 50
+      for (let index = 0; index < files.length; index += batchSize) {
+        await Promise.all(files.slice(index, index + batchSize).map(async (file) => {
+          const absoluteFile = isAbsolute(file) ? file : resolve(this.root, file)
+          pendingFiles.add(absoluteFile)
+          pendingTokens.set(absoluteFile, await this.extractSource(await fs.readFile(absoluteFile, 'utf8'), absoluteFile))
+        }))
       }
+    }
+    else {
+      this.externalFileFilter = () => false
     }
 
     this.externalTokens.clear()
     for (const [id, tokens] of pendingTokens)
       this.externalTokens.set(id, tokens)
     this.externalFiles = pendingFiles
+    this.externalWatchRoots = pendingWatchRoots
     this.invalidateGenerateCache()
   }
 
-  /**
-   * 合并当前 token 并生成 CSS，相同 token 集合会复用缓存。
-   *
-   * @param minify 是否压缩生成结果。
-   * @returns UnoCSS 分层生成结果。
-   */
+  async updateExternalContent(
+    changed: ReadonlySet<string>,
+    removed: ReadonlySet<string>,
+  ): Promise<void> {
+    await this.base.ready
+    let invalidated = false
+
+    for (const file of removed) {
+      if (!this.externalFiles.delete(file))
+        continue
+      this.externalTokens.delete(file)
+      invalidated = true
+    }
+
+    await Promise.all([...changed].map(async (file) => {
+      if (!this.externalFileFilter(file))
+        return
+      try {
+        const tokens = await this.extractSource(await fs.readFile(file, 'utf8'), file)
+        const previous = this.externalTokens.get(file)
+        this.externalFiles.add(file)
+        this.externalTokens.set(file, tokens)
+        invalidated ||= !previous || !setsEqual(previous, tokens)
+      }
+      catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT')
+          throw error
+        if (this.externalFiles.delete(file)) {
+          this.externalTokens.delete(file)
+          invalidated = true
+        }
+      }
+    }))
+
+    if (invalidated)
+      this.invalidateGenerateCache()
+  }
+
   async generate(minify = false): Promise<GenerateResult> {
     await this.base.ready
     const tokens = this.collectTokens()
-    const key = [...tokens].sort().join('\0')
+    const key = `${minify}\0${[...tokens].sort().join('\0')}`
     if (this.generateResult && this.generateKey === key)
       return this.generateResult
 
@@ -174,12 +220,6 @@ export class NativeContext {
     return this.generateResult
   }
 
-  /**
-   * 创建绑定当前模块 token 集合的 UnoCSS 插件上下文。
-   *
-   * @param tokens 当前模块独立维护的 token 集合。
-   * @returns 可供官方 transformer 使用的上下文。
-   */
   getPluginContext(tokens: Set<string>): UnocssPluginContext {
     const base = this.base
     return {
@@ -189,38 +229,26 @@ export class NativeContext {
         if (code.includes(IGNORE_COMMENT))
           return false
         return code.includes(INCLUDE_COMMENT)
-          || (this.filter.shouldExtract(id) && base.filter(code, id))
+          || code.includes(CSS_PLACEHOLDER)
+          || this.filter.shouldExtract(id)
       },
     }
   }
 
-  /**
-   * 将 `uno.css` 等公开入口解析为 UnoCSS 虚拟模块标识。
-   *
-   * @param id 待解析的导入标识。
-   * @param importer 导入方模块标识。
-   * @returns 解析后的虚拟标识，非 UnoCSS 入口返回 undefined。
-   */
   async resolveVirtualId(id: string, importer?: string): Promise<string | undefined> {
     return resolveId(this.base, id, importer)
   }
 
-  /**
-   * 解析虚拟模块对应的 CSS layer。
-   *
-   * @param id 已解析的 UnoCSS 虚拟标识。
-   * @returns layer 名称，无法解析时返回 undefined。
-   */
   async resolveLayer(id: string): Promise<string | undefined> {
-    return resolveLayer(this.base, id)
+    return resolveLayer(this.base, getPath(id))
   }
 
-  /** 转换单个模块，并原子更新其源码和 token 缓存。 */
   private async transformModuleInner(source: string, id: string) {
     const tokens = new Set<string>()
-    const result = await transformSource(this.getPluginContext(tokens), source, id)
-    if (this.filter.shouldExtract(id))
-      await this.base.uno.applyExtractors(result.code, id, tokens)
+    const pluginContext = this.getPluginContext(tokens)
+    const result = await transformSource(pluginContext, source, id)
+    if (pluginContext.filter(result.code, id))
+      await this.base.uno.applyExtractors(result.code.replace(SKIP_COMMENT_RE, ''), id, tokens)
 
     this.moduleSources.set(id, source)
     this.moduleTokens.set(id, tokens)
@@ -228,27 +256,56 @@ export class NativeContext {
     return result
   }
 
-  /** 从外部内容中运行 transformer 和 extractor，返回独立 token 集合。 */
   private async extractSource(source: string, id: string): Promise<Set<string>> {
     const tokens = new Set<string>()
-    const result = await transformSource(this.getPluginContext(tokens), source, id)
-    await this.base.uno.applyExtractors(result.code, id, tokens)
+    const pluginContext = this.getPluginContext(tokens)
+    const result = await transformSource(pluginContext, source, id)
+    if (pluginContext.filter(result.code, id))
+      await this.base.uno.applyExtractors(result.code.replace(SKIP_COMMENT_RE, ''), id, tokens)
     return tokens
   }
 
-  /** 合并模块与外部内容的 token，并自动去重。 */
   private collectTokens(): Set<string> {
     const tokens = new Set<string>()
-    for (const tokenSet of [...this.moduleTokens.values(), ...this.externalTokens.values()]) {
+    for (const tokenSet of this.moduleTokens.values()) {
+      for (const token of tokenSet)
+        tokens.add(token)
+    }
+    for (const tokenSet of this.externalTokens.values()) {
       for (const token of tokenSet)
         tokens.add(token)
     }
     return tokens
   }
 
-  /** 使 CSS 生成缓存失效。 */
   private invalidateGenerateCache(): void {
     this.generateKey = ''
     this.generateResult = undefined
   }
+
+  private async initializeInner(): Promise<void> {
+    await this.base.updateRoot(this.root)
+    this.refreshFilter()
+    await this.extractExternalContent()
+  }
+
+  private refreshFilter(): void {
+    const pipeline = this.base.uno.config.content?.pipeline
+    this.filter = createNativeFilter(
+      this.root,
+      this.options.include ?? (pipeline === false ? undefined : pipeline?.include),
+      this.options.exclude ?? (pipeline === false ? undefined : pipeline?.exclude),
+      pipeline === false,
+    )
+  }
+}
+
+function setsEqual(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  if (left.size !== right.size)
+    return false
+  for (const value of left) {
+    if (!right.has(value))
+      return false
+  }
+  return true
 }

--- a/packages-integrations/rsbuild/src/filter.ts
+++ b/packages-integrations/rsbuild/src/filter.ts
@@ -1,0 +1,46 @@
+import { isAbsolute, relative } from 'node:path'
+import { cssIdRE } from '@unocss/core'
+import { createFilter } from 'unplugin-utils'
+import { defaultPipelineExclude, defaultPipelineInclude } from '#integration/defaults'
+
+export interface NativeFilter {
+  shouldExtract: (id: string) => boolean
+  shouldTransform: (id: string) => boolean
+}
+
+/**
+ * 创建同时服务源码提取与 transformer pipeline 的模块过滤器。
+ *
+ * @param root 项目根目录。
+ * @param include 用户自定义包含规则。
+ * @param exclude 用户自定义排除规则。
+ * @returns 归一化 Rspack resource 后的过滤器。
+ */
+export function createNativeFilter(
+  root: string,
+  include?: Array<string | RegExp>,
+  exclude?: Array<string | RegExp>,
+): NativeFilter {
+  const sourceFilter = createFilter(
+    include ?? defaultPipelineInclude,
+    exclude ?? defaultPipelineExclude,
+    { resolve: root },
+  )
+
+  return {
+    /** 判断模块是否应参与 utility token 提取。 */
+    shouldExtract(id) {
+      return !cssIdRE.test(id) && sourceFilter(normalizeId(root, id))
+    },
+    /** 判断模块是否应进入 UnoCSS transformer pipeline。 */
+    shouldTransform(id) {
+      return cssIdRE.test(id) || sourceFilter(normalizeId(root, id))
+    },
+  }
+}
+
+/** 将绝对 resource 和查询参数归一化为 filter 可匹配的项目相对路径。 */
+function normalizeId(root: string, id: string): string {
+  const cleanId = id.replace(/\?.*$/, '')
+  return isAbsolute(cleanId) ? relative(root, cleanId) : cleanId
+}

--- a/packages-integrations/rsbuild/src/filter.ts
+++ b/packages-integrations/rsbuild/src/filter.ts
@@ -1,3 +1,4 @@
+import type { FilterPattern } from '@unocss/core'
 import { isAbsolute, relative } from 'node:path'
 import { cssIdRE } from '@unocss/core'
 import { createFilter } from 'unplugin-utils'
@@ -8,38 +9,30 @@ export interface NativeFilter {
   shouldTransform: (id: string) => boolean
 }
 
-/**
- * 创建同时服务源码提取与 transformer pipeline 的模块过滤器。
- *
- * @param root 项目根目录。
- * @param include 用户自定义包含规则。
- * @param exclude 用户自定义排除规则。
- * @returns 归一化 Rspack resource 后的过滤器。
- */
 export function createNativeFilter(
   root: string,
-  include?: Array<string | RegExp>,
-  exclude?: Array<string | RegExp>,
+  include?: FilterPattern,
+  exclude?: FilterPattern,
+  disabled = false,
 ): NativeFilter {
-  const sourceFilter = createFilter(
-    include ?? defaultPipelineInclude,
-    exclude ?? defaultPipelineExclude,
-    { resolve: root },
-  )
+  const sourceFilter = disabled
+    ? () => false
+    : createFilter(
+        include ?? defaultPipelineInclude,
+        exclude ?? defaultPipelineExclude,
+        { resolve: root },
+      )
 
   return {
-    /** 判断模块是否应参与 utility token 提取。 */
     shouldExtract(id) {
       return !cssIdRE.test(id) && sourceFilter(normalizeId(root, id))
     },
-    /** 判断模块是否应进入 UnoCSS transformer pipeline。 */
     shouldTransform(id) {
       return cssIdRE.test(id) || sourceFilter(normalizeId(root, id))
     },
   }
 }
 
-/** 将绝对 resource 和查询参数归一化为 filter 可匹配的项目相对路径。 */
 function normalizeId(root: string, id: string): string {
   const cleanId = id.replace(/\?.*$/, '')
   return isAbsolute(cleanId) ? relative(root, cleanId) : cleanId

--- a/packages-integrations/rsbuild/src/index.ts
+++ b/packages-integrations/rsbuild/src/index.ts
@@ -1,0 +1,31 @@
+import type { RsbuildPlugin } from '@rsbuild/core'
+import type { UnoCSSRsbuildPluginOptions } from './types'
+import { UnoCSSRspackPlugin } from './rspack'
+
+export { UnoCSSRspackPlugin, unoCSSRspackPlugin } from './rspack'
+export type { UnoCSSRsbuildPluginOptions, UnoCSSRspackPluginOptions } from './types'
+
+/**
+ * 创建原生 UnoCSS Rsbuild 插件。
+ *
+ * @param options UnoCSS 与 Rspack integration 配置。
+ * @returns 可加入 Rsbuild `plugins` 的插件实例。
+ */
+export function pluginUnoCSS<Theme extends object = object>(
+  options: UnoCSSRsbuildPluginOptions<Theme> = {},
+): RsbuildPlugin {
+  return {
+    name: 'unocss:rsbuild',
+    enforce: 'pre',
+    setup(api) {
+      api.modifyRspackConfig((config) => {
+        config.plugins ??= []
+        config.plugins.unshift(new UnoCSSRspackPlugin({
+          ...options,
+          root: options.root ?? api.context.rootPath,
+          autoCssRule: false,
+        }))
+      })
+    },
+  }
+}

--- a/packages-integrations/rsbuild/src/index.ts
+++ b/packages-integrations/rsbuild/src/index.ts
@@ -5,12 +5,6 @@ import { UnoCSSRspackPlugin } from './rspack'
 export { UnoCSSRspackPlugin, unoCSSRspackPlugin } from './rspack'
 export type { UnoCSSRsbuildPluginOptions, UnoCSSRspackPluginOptions } from './types'
 
-/**
- * 创建原生 UnoCSS Rsbuild 插件。
- *
- * @param options UnoCSS 与 Rspack integration 配置。
- * @returns 可加入 Rsbuild `plugins` 的插件实例。
- */
 export function pluginUnoCSS<Theme extends object = object>(
   options: UnoCSSRsbuildPluginOptions<Theme> = {},
 ): RsbuildPlugin {

--- a/packages-integrations/rsbuild/src/loader.ts
+++ b/packages-integrations/rsbuild/src/loader.ts
@@ -1,4 +1,4 @@
-import type { LoaderContext } from '@rspack/core'
+import type { LoaderContext, RawSourceMap } from '@rspack/core'
 import { getHashPlaceholder, getLayerPlaceholder } from '#integration/layers'
 import { getContext } from './registry'
 
@@ -9,7 +9,7 @@ interface LoaderOptions {
 export default function unoCSSLoader(
   this: LoaderContext<LoaderOptions>,
   source: string,
-  inputMap?: object,
+  inputMap?: string | RawSourceMap,
 ): void {
   const callback = this.async()
   const { contextId } = this.getOptions()
@@ -42,7 +42,7 @@ export default function unoCSSLoader(
       }
 
       const result = await context.transformModule(source, id)
-      callback(null, result.code, result.map ?? inputMap)
+      callback(null, result.code, result.map ? JSON.stringify(result.map) : inputMap)
     })
     .catch(error => callback(error as Error))
 }

--- a/packages-integrations/rsbuild/src/loader.ts
+++ b/packages-integrations/rsbuild/src/loader.ts
@@ -1,0 +1,48 @@
+import type { LoaderContext } from '@rspack/core'
+import { getHashPlaceholder, getLayerPlaceholder } from '#integration/layers'
+import { getContext } from './registry'
+
+interface LoaderOptions {
+  contextId: string
+}
+
+/**
+ * 在 Rspack loader pipeline 中运行 UnoCSS transformer 或生成虚拟 CSS 占位符。
+ *
+ * @param source 当前模块源码。
+ * @param inputMap 上游 loader 传入的 sourcemap。
+ */
+export default function unoCSSLoader(
+  this: LoaderContext<LoaderOptions>,
+  source: string,
+  inputMap?: object,
+): void {
+  const callback = this.async()
+  const { contextId } = this.getOptions()
+  const context = getContext(contextId)
+
+  if (!context) {
+    callback(new Error(`[unocss] Missing native context "${contextId}".`))
+    return
+  }
+
+  if (this.resourcePath.includes('.unocss-rsbuild')) {
+    const layer = new URLSearchParams(this.resourceQuery.slice(1)).get('uno-layer') ?? '__ALL__'
+    const hash = context.getVirtualHash()
+    const hashPlaceholder = hash ? getHashPlaceholder(hash) : ''
+    callback(null, `${hashPlaceholder}${getLayerPlaceholder(layer)}`, inputMap)
+    return
+  }
+
+  const id = this.resourceQuery.includes('type=style') && !/\.(?:css|less|sass|scss|styl|stylus)(?:$|\?)/.test(this.resource)
+    ? `${this.resource}.css`
+    : this.resource
+  if (!context.filter.shouldTransform(id)) {
+    callback(null, source, inputMap)
+    return
+  }
+
+  context.transformModule(source, id)
+    .then(result => callback(null, result.code, result.map ?? inputMap))
+    .catch(error => callback(error as Error))
+}

--- a/packages-integrations/rsbuild/src/loader.ts
+++ b/packages-integrations/rsbuild/src/loader.ts
@@ -6,12 +6,6 @@ interface LoaderOptions {
   contextId: string
 }
 
-/**
- * 在 Rspack loader pipeline 中运行 UnoCSS transformer 或生成虚拟 CSS 占位符。
- *
- * @param source 当前模块源码。
- * @param inputMap 上游 loader 传入的 sourcemap。
- */
 export default function unoCSSLoader(
   this: LoaderContext<LoaderOptions>,
   source: string,
@@ -26,23 +20,29 @@ export default function unoCSSLoader(
     return
   }
 
-  if (this.resourcePath.includes('.unocss-rsbuild')) {
-    const layer = new URLSearchParams(this.resourceQuery.slice(1)).get('uno-layer') ?? '__ALL__'
-    const hash = context.getVirtualHash()
-    const hashPlaceholder = hash ? getHashPlaceholder(hash) : ''
-    callback(null, `${hashPlaceholder}${getLayerPlaceholder(layer)}`, inputMap)
-    return
-  }
+  context.initialize()
+    .then(async () => {
+      for (const file of context.configFiles)
+        this.addDependency(file)
 
-  const id = this.resourceQuery.includes('type=style') && !/\.(?:css|less|sass|scss|styl|stylus)(?:$|\?)/.test(this.resource)
-    ? `${this.resource}.css`
-    : this.resource
-  if (!context.filter.shouldTransform(id)) {
-    callback(null, source, inputMap)
-    return
-  }
+      if (this.resourcePath.includes('.unocss-rsbuild')) {
+        const layer = new URLSearchParams(this.resourceQuery.slice(1)).get('uno-layer') ?? '__ALL__'
+        const hash = context.getVirtualHash()
+        const hashPlaceholder = hash ? getHashPlaceholder(hash) : ''
+        callback(null, `${hashPlaceholder}${getLayerPlaceholder(layer)}`, inputMap)
+        return
+      }
 
-  context.transformModule(source, id)
-    .then(result => callback(null, result.code, result.map ?? inputMap))
+      const id = this.resourceQuery.includes('type=style') && !/\.(?:css|less|sass|scss|styl|stylus)(?:$|\?)/.test(this.resource)
+        ? `${this.resource}.css`
+        : this.resource
+      if (!context.filter.shouldTransform(id)) {
+        callback(null, source, inputMap)
+        return
+      }
+
+      const result = await context.transformModule(source, id)
+      callback(null, result.code, result.map ?? inputMap)
+    })
     .catch(error => callback(error as Error))
 }

--- a/packages-integrations/rsbuild/src/registry.ts
+++ b/packages-integrations/rsbuild/src/registry.ts
@@ -1,0 +1,54 @@
+import type { NativeContext } from './context'
+import process from 'node:process'
+
+interface RegistryState {
+  contexts: Map<string, NativeContext>
+  sequence: number
+}
+
+const registryKey = Symbol.for('@unocss/rsbuild/context-registry')
+const globalRegistry = globalThis as typeof globalThis & {
+  [registryKey]?: RegistryState
+}
+
+/** 获取当前进程共享的 loader context registry。 */
+function getRegistry(): RegistryState {
+  globalRegistry[registryKey] ??= {
+    contexts: new Map(),
+    sequence: 0,
+  }
+  return globalRegistry[registryKey]
+}
+
+/**
+ * 注册 compiler 对应的 UnoCSS context。
+ *
+ * @param context 待注册的原生 integration 上下文。
+ * @returns 传递给 Rspack loader 的唯一 context ID。
+ */
+export function registerContext(context: NativeContext): string {
+  const registry = getRegistry()
+  registry.sequence += 1
+  const id = `${process.pid}-${registry.sequence}`
+  registry.contexts.set(id, context)
+  return id
+}
+
+/**
+ * 按 ID 获取 loader 所属的 UnoCSS context。
+ *
+ * @param id context 唯一标识。
+ * @returns 已注册 context，不存在时返回 undefined。
+ */
+export function getContext(id: string): NativeContext | undefined {
+  return getRegistry().contexts.get(id)
+}
+
+/**
+ * 注销 compiler context，释放进程级引用。
+ *
+ * @param id context 唯一标识。
+ */
+export function unregisterContext(id: string): void {
+  getRegistry().contexts.delete(id)
+}

--- a/packages-integrations/rsbuild/src/registry.ts
+++ b/packages-integrations/rsbuild/src/registry.ts
@@ -11,7 +11,6 @@ const globalRegistry = globalThis as typeof globalThis & {
   [registryKey]?: RegistryState
 }
 
-/** 获取当前进程共享的 loader context registry。 */
 function getRegistry(): RegistryState {
   globalRegistry[registryKey] ??= {
     contexts: new Map(),
@@ -20,12 +19,6 @@ function getRegistry(): RegistryState {
   return globalRegistry[registryKey]
 }
 
-/**
- * 注册 compiler 对应的 UnoCSS context。
- *
- * @param context 待注册的原生 integration 上下文。
- * @returns 传递给 Rspack loader 的唯一 context ID。
- */
 export function registerContext(context: NativeContext): string {
   const registry = getRegistry()
   registry.sequence += 1
@@ -34,21 +27,14 @@ export function registerContext(context: NativeContext): string {
   return id
 }
 
-/**
- * 按 ID 获取 loader 所属的 UnoCSS context。
- *
- * @param id context 唯一标识。
- * @returns 已注册 context，不存在时返回 undefined。
- */
 export function getContext(id: string): NativeContext | undefined {
   return getRegistry().contexts.get(id)
 }
 
-/**
- * 注销 compiler context，释放进程级引用。
- *
- * @param id context 唯一标识。
- */
 export function unregisterContext(id: string): void {
   getRegistry().contexts.delete(id)
+}
+
+export function getRegisteredContextCount(): number {
+  return getRegistry().contexts.size
 }

--- a/packages-integrations/rsbuild/src/rsbuild.test.ts
+++ b/packages-integrations/rsbuild/src/rsbuild.test.ts
@@ -1,0 +1,53 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createRsbuild } from '@rsbuild/core'
+import presetUno from '@unocss/preset-uno'
+import { glob } from 'tinyglobby'
+import { afterEach, expect, it } from 'vitest'
+// This integration test intentionally verifies the built package.
+// eslint-disable-next-line antfu/no-import-dist
+import { pluginUnoCSS } from '../dist/index.mjs'
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { force: true, recursive: true })))
+})
+
+it('integrates with the Rsbuild CSS inline query pipeline', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'unocss-rsbuild-inline-'))
+  temporaryDirectories.push(root)
+  const sourceDirectory = join(root, 'src')
+  const outputDirectory = join(root, 'dist')
+  await mkdir(sourceDirectory, { recursive: true })
+  await writeFile(
+    join(sourceDirectory, 'index.jsx'),
+    'import uno from "uno.css?inline"; export const css = uno; export const view = `<div class="text-red"></div>`;',
+    'utf8',
+  )
+
+  const rsbuild = await createRsbuild({
+    cwd: root,
+    config: {
+      mode: 'production',
+      output: {
+        distPath: { root: outputDirectory },
+      },
+      plugins: [
+        pluginUnoCSS({
+          configOrPath: { presets: [presetUno()] },
+        }),
+      ],
+      source: {
+        entry: { index: './src/index.jsx' },
+      },
+    },
+  })
+  await rsbuild.build()
+
+  const files = await glob('**/*.js', { cwd: outputDirectory, absolute: true })
+  const output = (await Promise.all(files.map(file => readFile(file, 'utf8')))).join('\n')
+  expect(output).toContain('.text-red')
+  expect(output).not.toContain('#--unocss')
+})

--- a/packages-integrations/rsbuild/src/rspack.test.ts
+++ b/packages-integrations/rsbuild/src/rspack.test.ts
@@ -1,4 +1,4 @@
-import type { Stats } from '@rspack/core'
+import type { Compiler, Stats, Watching } from '@rspack/core'
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -29,7 +29,7 @@ it('updates generated CSS during native Rspack watch', async () => {
   )
   await writeFile(join(sourceDirectory, 'view.jsx'), 'export const view = `<div class="text-red"></div>`;', 'utf8')
 
-  const compiler = rspack({
+  const compiler: Compiler = rspack({
     context: root,
     mode: 'development',
     entry: './src/index.js',
@@ -103,7 +103,7 @@ it('runs transformers once for modules matched by existing rules', async () => {
 
   let transformCalls = 0
   const registeredContexts = getRegisteredContextCount()
-  const compiler = rspack({
+  const compiler: Compiler = rspack({
     context: root,
     mode: 'production',
     entry: './src/App.vue',
@@ -149,7 +149,7 @@ it('watches newly added external content files', async () => {
   ])
   await writeFile(join(sourceDirectory, 'index.js'), 'import "uno.css";', 'utf8')
 
-  const compiler = rspack({
+  const compiler: Compiler = rspack({
     context: root,
     mode: 'development',
     entry: './src/index.js',
@@ -210,7 +210,7 @@ it('reloads config and invalidates transformed modules', async () => {
   await writeFile(join(sourceDirectory, 'view.jsx'), 'export const view = `<div class="TOKEN"></div>`;', 'utf8')
   await writeTransformerConfig(configFile, 'text-red')
 
-  const compiler = rspack({
+  const compiler: Compiler = rspack({
     context: root,
     mode: 'development',
     entry: './src/index.js',
@@ -269,7 +269,7 @@ function assertStats(stats: Stats | undefined): asserts stats is Stats {
     throw new Error(stats.toString({ all: false, errors: true }))
 }
 
-function runCompiler(compiler: ReturnType<typeof rspack>): Promise<void> {
+function runCompiler(compiler: Compiler): Promise<void> {
   return new Promise((resolve, reject) => {
     compiler.run((error, stats) => {
       if (error) {
@@ -295,16 +295,12 @@ async function readCss(outputDirectory: string): Promise<string> {
 }
 
 function closeCompiler(
-  compiler: ReturnType<typeof rspack>,
-  watching: ReturnType<ReturnType<typeof rspack>['watch']>,
+  compiler: Compiler,
+  watching: Watching,
   resolve: () => void,
   reject: (error: Error) => void,
 ): void {
-  watching.close((watchError) => {
-    if (watchError) {
-      reject(watchError)
-      return
-    }
+  watching.close(() => {
     compiler.close((closeError) => {
       if (closeError)
         reject(closeError)

--- a/packages-integrations/rsbuild/src/rspack.test.ts
+++ b/packages-integrations/rsbuild/src/rspack.test.ts
@@ -1,5 +1,5 @@
 import type { Stats } from '@rspack/core'
-import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { rspack } from '@rspack/core'
@@ -21,7 +21,11 @@ it('updates generated CSS during native Rspack watch', async () => {
   const sourceDirectory = join(root, 'src')
   const outputDirectory = join(root, 'dist')
   await import('node:fs/promises').then(fs => fs.mkdir(sourceDirectory, { recursive: true }))
-  await writeFile(join(sourceDirectory, 'index.js'), 'import "uno.css"; import "./view.jsx";', 'utf8')
+  await writeFile(
+    join(sourceDirectory, 'index.js'),
+    'import "uno.css?test"; import "uno:utilities.css?test"; import "./view.jsx";',
+    'utf8',
+  )
   await writeFile(join(sourceDirectory, 'view.jsx'), 'export const view = `<div class="text-red"></div>`;', 'utf8')
 
   const compiler = rspack({
@@ -29,6 +33,7 @@ it('updates generated CSS during native Rspack watch', async () => {
     mode: 'development',
     entry: './src/index.js',
     experiments: { css: true },
+    watchOptions: { poll: 50 },
     output: {
       path: outputDirectory,
       filename: 'bundle.js',
@@ -44,7 +49,7 @@ it('updates generated CSS during native Rspack watch', async () => {
   await new Promise<void>((resolve, reject) => {
     let builds = 0
     const timeout = setTimeout(() => reject(new Error('Rspack watch did not emit updated UnoCSS within 15 seconds.')), 15_000)
-    const watching = compiler.watch({}, async (error, stats) => {
+    const watching = compiler.watch({ poll: 50 }, async (error, stats) => {
       try {
         if (error)
           throw error
@@ -61,11 +66,179 @@ it('updates generated CSS during native Rspack watch', async () => {
           return
         expect(css).not.toContain('.text-red')
         clearTimeout(timeout)
-        watching.close(() => resolve())
+        closeCompiler(compiler, watching, resolve, reject)
       }
       catch (watchError) {
         clearTimeout(timeout)
-        watching.close(() => reject(watchError))
+        closeCompiler(compiler, watching, () => reject(watchError), reject)
+      }
+    })
+  })
+})
+
+it('runs transformers once for modules matched by existing rules', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'unocss-rspack-loader-once-'))
+  temporaryDirectories.push(root)
+  const sourceDirectory = join(root, 'src')
+  const outputDirectory = join(root, 'dist')
+  const loaderFile = join(root, 'passthrough-loader.cjs')
+  await mkdir(sourceDirectory, { recursive: true })
+  await writeFile(loaderFile, 'module.exports = source => source', 'utf8')
+  await writeFile(join(sourceDirectory, 'App.vue'), 'export default `<div class="text-red"></div>`', 'utf8')
+
+  let transformCalls = 0
+  const compiler = rspack({
+    context: root,
+    mode: 'production',
+    entry: './src/App.vue',
+    module: {
+      rules: [{ test: /\.vue$/, type: 'javascript/auto', use: [loaderFile] }],
+    },
+    output: {
+      path: outputDirectory,
+      filename: 'bundle.js',
+    },
+    plugins: [
+      new UnoCSSRspackPlugin({
+        configOrPath: {
+          presets: [presetUno()],
+          transformers: [{
+            name: 'count-transformer-runs',
+            transform() {
+              transformCalls += 1
+            },
+          }],
+        },
+        root,
+      }),
+    ],
+  })
+
+  await runCompiler(compiler)
+
+  expect(transformCalls).toBe(1)
+})
+
+it('watches newly added external content files', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'unocss-rspack-content-watch-'))
+  temporaryDirectories.push(root)
+  const sourceDirectory = join(root, 'src')
+  const contentDirectory = join(root, 'content')
+  const outputDirectory = join(root, 'dist')
+  await Promise.all([
+    mkdir(sourceDirectory, { recursive: true }),
+    mkdir(contentDirectory, { recursive: true }),
+  ])
+  await writeFile(join(sourceDirectory, 'index.js'), 'import "uno.css";', 'utf8')
+
+  const compiler = rspack({
+    context: root,
+    mode: 'development',
+    entry: './src/index.js',
+    experiments: { css: true },
+    watchOptions: { poll: 50 },
+    output: {
+      path: outputDirectory,
+      filename: 'bundle.js',
+    },
+    plugins: [
+      new UnoCSSRspackPlugin({
+        configOrPath: {
+          content: { filesystem: ['content/**/*.html'] },
+          presets: [presetUno()],
+        },
+        root,
+      }),
+    ],
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    let created = false
+    const timeout = setTimeout(() => reject(new Error('Rspack watch did not detect newly added UnoCSS content within 15 seconds.')), 15_000)
+    const watching = compiler.watch({ poll: 50 }, async (error, stats) => {
+      try {
+        if (error)
+          throw error
+        assertStats(stats)
+        const css = await readCss(outputDirectory)
+        if (!created) {
+          created = true
+          setTimeout(() => {
+            writeFile(join(contentDirectory, 'new.html'), '<div class="text-green"></div>', 'utf8').catch(reject)
+          }, 100)
+          return
+        }
+        if (!css.includes('.text-green'))
+          return
+        clearTimeout(timeout)
+        closeCompiler(compiler, watching, resolve, reject)
+      }
+      catch (watchError) {
+        clearTimeout(timeout)
+        closeCompiler(compiler, watching, () => reject(watchError), reject)
+      }
+    })
+  })
+})
+
+it('reloads config and invalidates transformed modules', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'unocss-rspack-config-watch-'))
+  temporaryDirectories.push(root)
+  const sourceDirectory = join(root, 'src')
+  const outputDirectory = join(root, 'dist')
+  const configFile = join(root, 'uno.config.ts')
+  await mkdir(sourceDirectory, { recursive: true })
+  await writeFile(join(sourceDirectory, 'index.js'), 'import "uno.css"; import "./view.jsx";', 'utf8')
+  await writeFile(join(sourceDirectory, 'view.jsx'), 'export const view = `<div class="TOKEN"></div>`;', 'utf8')
+  await writeTransformerConfig(configFile, 'text-red')
+
+  const compiler = rspack({
+    context: root,
+    mode: 'development',
+    entry: './src/index.js',
+    experiments: { css: true },
+    watchOptions: { poll: 50 },
+    output: {
+      path: outputDirectory,
+      filename: 'bundle.js',
+    },
+    plugins: [
+      new UnoCSSRspackPlugin({
+        configOrPath: configFile,
+        root,
+      }),
+    ],
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    let configChanged = false
+    const timeout = setTimeout(() => reject(new Error('Rspack watch did not reload the UnoCSS config within 15 seconds.')), 15_000)
+    const watching = compiler.watch({ poll: 50 }, async (error, stats) => {
+      try {
+        if (error)
+          throw error
+        assertStats(stats)
+        const [css, js] = await Promise.all([
+          readCss(outputDirectory),
+          readFile(join(outputDirectory, 'bundle.js'), 'utf8'),
+        ])
+        if (!configChanged && css.includes('.text-red') && js.includes('text-red')) {
+          configChanged = true
+          setTimeout(() => {
+            writeTransformerConfig(configFile, 'text-blue').catch(reject)
+          }, 100)
+          return
+        }
+        if (!configChanged || !css.includes('.text-blue') || !js.includes('text-blue'))
+          return
+        expect(css).not.toContain('.text-red')
+        expect(js).not.toContain('text-red')
+        clearTimeout(timeout)
+        closeCompiler(compiler, watching, resolve, reject)
+      }
+      catch (watchError) {
+        clearTimeout(timeout)
+        closeCompiler(compiler, watching, () => reject(watchError), reject)
       }
     })
   })
@@ -78,8 +251,66 @@ function assertStats(stats: Stats | undefined): asserts stats is Stats {
     throw new Error(stats.toString({ all: false, errors: true }))
 }
 
+function runCompiler(compiler: ReturnType<typeof rspack>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    compiler.run((error, stats) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      try {
+        assertStats(stats)
+      }
+      catch (statsError) {
+        reject(statsError)
+        return
+      }
+      compiler.close(closeError => closeError ? reject(closeError) : resolve())
+    })
+  })
+}
+
 async function readCss(outputDirectory: string): Promise<string> {
   const files = await readdir(outputDirectory)
   const cssFiles = files.filter(file => file.endsWith('.css'))
   return (await Promise.all(cssFiles.map(file => readFile(join(outputDirectory, file), 'utf8')))).join('\n')
+}
+
+function closeCompiler(
+  compiler: ReturnType<typeof rspack>,
+  watching: ReturnType<ReturnType<typeof rspack>['watch']>,
+  resolve: () => void,
+  reject: (error: Error) => void,
+): void {
+  watching.close((watchError) => {
+    if (watchError) {
+      reject(watchError)
+      return
+    }
+    compiler.close((closeError) => {
+      if (closeError)
+        reject(closeError)
+      else
+        resolve()
+    })
+  })
+}
+
+async function writeTransformerConfig(file: string, replacement: string): Promise<void> {
+  await writeFile(
+    file,
+    `export default {
+  rules: [
+    ['text-red', { color: 'red' }],
+    ['text-blue', { color: 'blue' }],
+  ],
+  transformers: [{
+    name: 'test-transformer',
+    transform(source) {
+      source.replaceAll('TOKEN', '${replacement}')
+    },
+  }],
+}\n`,
+    'utf8',
+  )
 }

--- a/packages-integrations/rsbuild/src/rspack.test.ts
+++ b/packages-integrations/rsbuild/src/rspack.test.ts
@@ -1,0 +1,85 @@
+import type { Stats } from '@rspack/core'
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { rspack } from '@rspack/core'
+import presetUno from '@unocss/preset-uno'
+import { afterEach, expect, it } from 'vitest'
+// This integration test intentionally verifies the built package and loader path.
+// eslint-disable-next-line antfu/no-import-dist
+import { UnoCSSRspackPlugin } from '../dist/rspack.mjs'
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { force: true, recursive: true })))
+})
+
+it('updates generated CSS during native Rspack watch', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'unocss-rspack-watch-'))
+  temporaryDirectories.push(root)
+  const sourceDirectory = join(root, 'src')
+  const outputDirectory = join(root, 'dist')
+  await import('node:fs/promises').then(fs => fs.mkdir(sourceDirectory, { recursive: true }))
+  await writeFile(join(sourceDirectory, 'index.js'), 'import "uno.css"; import "./view.jsx";', 'utf8')
+  await writeFile(join(sourceDirectory, 'view.jsx'), 'export const view = `<div class="text-red"></div>`;', 'utf8')
+
+  const compiler = rspack({
+    context: root,
+    mode: 'development',
+    entry: './src/index.js',
+    experiments: { css: true },
+    output: {
+      path: outputDirectory,
+      filename: 'bundle.js',
+    },
+    plugins: [
+      new UnoCSSRspackPlugin({
+        configOrPath: { presets: [presetUno()] },
+        root,
+      }),
+    ],
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    let builds = 0
+    const timeout = setTimeout(() => reject(new Error('Rspack watch did not emit updated UnoCSS within 15 seconds.')), 15_000)
+    const watching = compiler.watch({}, async (error, stats) => {
+      try {
+        if (error)
+          throw error
+        assertStats(stats)
+        builds += 1
+        const css = await readCss(outputDirectory)
+        if (builds === 1) {
+          expect(css).toContain('.text-red')
+          expect(css).not.toContain('#--unocss-hash--')
+          await writeFile(join(sourceDirectory, 'view.jsx'), 'export const view = `<div class="text-blue"></div>`;', 'utf8')
+          return
+        }
+        if (!css.includes('.text-blue'))
+          return
+        expect(css).not.toContain('.text-red')
+        clearTimeout(timeout)
+        watching.close(() => resolve())
+      }
+      catch (watchError) {
+        clearTimeout(timeout)
+        watching.close(() => reject(watchError))
+      }
+    })
+  })
+})
+
+function assertStats(stats: Stats | undefined): asserts stats is Stats {
+  if (!stats)
+    throw new Error('Rspack did not return stats.')
+  if (stats.hasErrors())
+    throw new Error(stats.toString({ all: false, errors: true }))
+}
+
+async function readCss(outputDirectory: string): Promise<string> {
+  const files = await readdir(outputDirectory)
+  const cssFiles = files.filter(file => file.endsWith('.css'))
+  return (await Promise.all(cssFiles.map(file => readFile(join(outputDirectory, file), 'utf8')))).join('\n')
+}

--- a/packages-integrations/rsbuild/src/rspack.test.ts
+++ b/packages-integrations/rsbuild/src/rspack.test.ts
@@ -8,6 +8,7 @@ import { afterEach, expect, it } from 'vitest'
 // This integration test intentionally verifies the built package and loader path.
 // eslint-disable-next-line antfu/no-import-dist
 import { UnoCSSRspackPlugin } from '../dist/rspack.mjs'
+import { getRegisteredContextCount } from './registry'
 
 const temporaryDirectories: string[] = []
 
@@ -48,6 +49,7 @@ it('updates generated CSS during native Rspack watch', async () => {
 
   await new Promise<void>((resolve, reject) => {
     let builds = 0
+    let stabilityTimer: ReturnType<typeof setTimeout> | undefined
     const timeout = setTimeout(() => reject(new Error('Rspack watch did not emit updated UnoCSS within 15 seconds.')), 15_000)
     const watching = compiler.watch({ poll: 50 }, async (error, stats) => {
       try {
@@ -65,8 +67,21 @@ it('updates generated CSS during native Rspack watch', async () => {
         if (!css.includes('.text-blue'))
           return
         expect(css).not.toContain('.text-red')
-        clearTimeout(timeout)
-        closeCompiler(compiler, watching, resolve, reject)
+        if (stabilityTimer)
+          clearTimeout(stabilityTimer)
+        const stableBuilds = builds
+        stabilityTimer = setTimeout(() => {
+          try {
+            expect(builds).toBe(stableBuilds)
+            expect(builds).toBeLessThanOrEqual(4)
+            clearTimeout(timeout)
+            closeCompiler(compiler, watching, resolve, reject)
+          }
+          catch (stabilityError) {
+            clearTimeout(timeout)
+            closeCompiler(compiler, watching, () => reject(stabilityError), reject)
+          }
+        }, 250)
       }
       catch (watchError) {
         clearTimeout(timeout)
@@ -87,6 +102,7 @@ it('runs transformers once for modules matched by existing rules', async () => {
   await writeFile(join(sourceDirectory, 'App.vue'), 'export default `<div class="text-red"></div>`', 'utf8')
 
   let transformCalls = 0
+  const registeredContexts = getRegisteredContextCount()
   const compiler = rspack({
     context: root,
     mode: 'production',
@@ -113,10 +129,12 @@ it('runs transformers once for modules matched by existing rules', async () => {
       }),
     ],
   })
+  expect(getRegisteredContextCount()).toBe(registeredContexts + 1)
 
   await runCompiler(compiler)
 
   expect(transformCalls).toBe(1)
+  expect(getRegisteredContextCount()).toBe(registeredContexts)
 })
 
 it('watches newly added external content files', async () => {

--- a/packages-integrations/rsbuild/src/rspack.ts
+++ b/packages-integrations/rsbuild/src/rspack.ts
@@ -65,9 +65,8 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
         await contentWatcher.sync()
         return
       }
-      if (options.watch && this.hasExternalContentChange(context, modified, removed)) {
-        await context.extractExternalContent()
-      }
+      if (options.watch)
+        await context.updateExternalContent(modified, removed)
       for (const file of removed)
         context.removeModule(file)
       await contentWatcher.ensure()
@@ -229,18 +228,6 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
         layers.add(layer)
     }
     return [...layers]
-  }
-
-  private hasExternalContentChange(
-    context: NativeContext,
-    modified: ReadonlySet<string>,
-    removed: ReadonlySet<string>,
-  ): boolean {
-    for (const file of [...modified, ...removed]) {
-      if (context.filesystemFiles.has(file) || context.matchesFilesystemFile(file))
-        return true
-    }
-    return false
   }
 }
 

--- a/packages-integrations/rsbuild/src/rspack.ts
+++ b/packages-integrations/rsbuild/src/rspack.ts
@@ -12,6 +12,8 @@ import {
   HASH_PLACEHOLDER_RE,
   LAYER_PLACEHOLDER_RE,
 } from '#integration/layers'
+import { restoreCachedModules } from './cache'
+import { ExternalContentWatcher } from './content-watcher'
 import { NativeContext } from './context'
 import { registerContext, unregisterContext } from './registry'
 
@@ -19,24 +21,18 @@ const pluginName = 'unocss:rspack-native'
 const loaderPath = fileURLToPath(new URL('./loader.mjs', import.meta.url))
 
 export class UnoCSSRspackPlugin<Theme extends object = object> implements RspackPluginInstance {
-  /**
-   * 创建原生 UnoCSS Rspack 插件。
-   *
-   * @param userOptions UnoCSS 与 Rspack integration 配置。
-   */
   constructor(private readonly userOptions: UnoCSSRspackPluginOptions<Theme> = {}) {}
 
-  /**
-   * 注册 loader、虚拟模块、CSS 生成和 watch invalidation hooks。
-   *
-   * @param compiler Rspack compiler 实例。
-   */
   apply(compiler: Compiler): void {
     const options = {
       ...this.userOptions,
       root: this.userOptions.root ?? compiler.context,
       watch: this.userOptions.watch ?? true,
       autoCssRule: this.userOptions.autoCssRule ?? true,
+      defaults: {
+        envMode: compiler.options.mode === 'development' ? 'dev' as const : 'build' as const,
+        ...this.userOptions.defaults,
+      },
     }
     const context = new NativeContext(options.root, options)
     const contextId = registerContext(context)
@@ -50,6 +46,7 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
     virtualLayers.set(virtualAllPath, LAYER_MARK_ALL)
     let virtualHash = ''
     let shouldInvalidate = false
+    const contentWatcher = new ExternalContentWatcher(compiler, context, options.watch)
 
     virtualModules.apply(compiler)
     this.injectLoader(compiler, context, contextId)
@@ -60,16 +57,20 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
     compiler.hooks.beforeCompile.tapPromise(pluginName, () => context.initialize())
 
     compiler.hooks.watchRun.tapPromise(pluginName, async (watchCompiler) => {
+      await context.initialize()
       const modified = watchCompiler.modifiedFiles ?? new Set<string>()
       const removed = watchCompiler.removedFiles ?? new Set<string>()
-      if (context.configFiles.some(file => modified.has(file))) {
+      if (context.configFiles.some(file => modified.has(file) || removed.has(file))) {
         await context.reloadConfig()
+        await contentWatcher.sync()
         return
       }
-      if ([...context.filesystemFiles].some(file => modified.has(file) || removed.has(file)))
+      if (options.watch && this.hasExternalContentChange(context, modified, removed)) {
         await context.extractExternalContent()
+      }
       for (const file of removed)
         context.removeModule(file)
+      await contentWatcher.ensure()
     })
 
     compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
@@ -81,10 +82,14 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
             currentModules.add(resource)
         }
         context.evictModulesNotIn(currentModules)
+        // Cached modules may skip loaders, so restore their tokens from source.
+        await restoreCachedModules(compiler, context, modules)
         for (const file of context.configFiles)
           compilation.fileDependencies.add(file)
-        for (const file of context.filesystemFiles)
-          compilation.fileDependencies.add(file)
+        if (options.watch) {
+          for (const file of context.filesystemFiles)
+            compilation.fileDependencies.add(file)
+        }
       })
 
       compilation.hooks.processAssets.tapPromise(
@@ -93,30 +98,37 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
           stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
         },
         async () => {
+          const assets = compilation.getAssets()
+            .map(asset => ({ asset, source: asset.source.source() }))
+            .filter(({ source }) => source.includes('#--unocss'))
+          if (!assets.length && !compiler.watchMode)
+            return
+
           const result = await context.generate(compiler.options.mode === 'production')
           const importedLayers = this.getImportedLayers(compilation.modules, virtualLayers)
 
-          for (const asset of compilation.getAssets()) {
-            const original = asset.source.source().toString()
+          for (const { asset, source } of assets) {
+            const original = source.toString()
+            const replacement = new sources.ReplaceSource(asset.source, asset.name)
             let replaced = false
             let escapeCss: ReturnType<typeof getCssEscaperForJsContent> | undefined
-            const code = original
-              .replace(HASH_PLACEHOLDER_RE, '')
-              .replace(LAYER_PLACEHOLDER_RE, (_match, layer, escapeView) => {
-                replaced = true
-                escapeCss ??= getCssEscaperForJsContent(escapeView.trim())
-                const css = layer.trim() === LAYER_MARK_ALL
-                  ? result.getLayers(undefined, importedLayers)
-                  : (result.getLayer(layer.trim()) ?? '')
-                return escapeCss(css)
-              })
 
-            if (replaced) {
-              compilation.updateAsset(
-                asset.name,
-                new sources.SourceMapSource(code, asset.name, asset.source.map() as never),
-              )
+            for (const match of original.matchAll(HASH_PLACEHOLDER_RE)) {
+              replaced = true
+              replacement.replace(match.index, match.index + match[0].length - 1, '')
             }
+            for (const match of original.matchAll(LAYER_PLACEHOLDER_RE)) {
+              replaced = true
+              const layer = match[1].trim()
+              escapeCss ??= getCssEscaperForJsContent(match[2]?.trim() ?? '')
+              const css = layer === LAYER_MARK_ALL
+                ? result.getLayers(undefined, importedLayers)
+                : (result.getLayer(layer) ?? '')
+              replacement.replace(match.index, match.index + match[0].length - 1, escapeCss(css))
+            }
+
+            if (replaced)
+              compilation.updateAsset(asset.name, replacement)
           }
 
           if (!compiler.watchMode)
@@ -140,13 +152,23 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
       if (!shouldInvalidate || !compiler.watching)
         return
       shouldInvalidate = false
-      setTimeout(() => compiler.watching?.invalidate(), 0)
+      setTimeout(() => {
+        compiler.watching?.invalidateWithChangesAndRemovals(
+          new Set([virtualAllPath, virtualLayerPath]),
+          new Set(),
+        )
+      }, 0)
     })
 
-    compiler.hooks.shutdown?.tap(pluginName, () => unregisterContext(contextId))
+    compiler.hooks.watchClose.tap(pluginName, () => {
+      void contentWatcher.close()
+    })
+    compiler.hooks.shutdown.tapPromise(pluginName, async () => {
+      await contentWatcher.close()
+      unregisterContext(contextId)
+    })
   }
 
-  /** 为普通源码和 Vue SFC 的实际 loader chain 注入 UnoCSS loader。 */
   private injectLoader(compiler: Compiler, context: NativeContext, contextId: string): void {
     const loader = {
       loader: loaderPath,
@@ -159,22 +181,8 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
       test: resource => typeof resource === 'string' && context.filter.shouldTransform(resource),
       use: [loader],
     })
-
-    for (const item of compiler.options.module.rules) {
-      if (!item || typeof item !== 'object')
-        continue
-      const rule = item as {
-        test?: RegExp
-        use?: Array<string | { loader?: string, options?: unknown }>
-      }
-      if (!(rule.test instanceof RegExp) || !new RegExp(rule.test.source, rule.test.flags.replace('g', '')).test('component.vue'))
-        continue
-      if (Array.isArray(rule.use))
-        rule.use.push(loader)
-    }
   }
 
-  /** 将公开 UnoCSS CSS 入口解析到预注册的 Rspack 虚拟模块。 */
   private resolveVirtualModules(
     compiler: Compiler,
     context: NativeContext,
@@ -190,26 +198,28 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
         const layer = await context.resolveLayer(resolvedId)
         if (!layer)
           return
+        const queryIndex = resolvedId.indexOf('?')
+        const query = queryIndex >= 0 ? resolvedId.slice(queryIndex) : ''
         if (layer === LAYER_MARK_ALL) {
-          data.request = virtualAllPath
+          const request = `${virtualAllPath}${query}`
+          virtualLayers.set(request, LAYER_MARK_ALL)
+          data.request = request
           return
         }
-        const request = `${virtualLayerPath}?uno-layer=${encodeURIComponent(layer)}`
+        const request = `${virtualLayerPath}${query}${query ? '&' : '?'}uno-layer=${encodeURIComponent(layer)}`
         virtualLayers.set(request, layer)
         data.request = request
       })
     })
   }
 
-  /** 为直接使用 Rspack 的场景注入虚拟 CSS module rule。 */
   private injectCssRule(compiler: Compiler): void {
     compiler.options.module.rules.push({
-      test: /[\\/|]\.unocss-rsbuild[\\/|].+\.css$/,
+      test: /[\\/]\.unocss-rsbuild[\\/].+\.css$/,
       type: 'css/auto',
     })
   }
 
-  /** 收集本轮 compilation 实际导入的命名 layer。 */
   private getImportedLayers(modules: Iterable<Module>, virtualLayers: Map<string, string>): string[] {
     const layers = new Set<string>()
     for (const module of modules) {
@@ -220,14 +230,20 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
     }
     return [...layers]
   }
+
+  private hasExternalContentChange(
+    context: NativeContext,
+    modified: ReadonlySet<string>,
+    removed: ReadonlySet<string>,
+  ): boolean {
+    for (const file of [...modified, ...removed]) {
+      if (context.filesystemFiles.has(file) || context.matchesFilesystemFile(file))
+        return true
+    }
+    return false
+  }
 }
 
-/**
- * 创建原生 UnoCSS Rspack 插件实例。
- *
- * @param options UnoCSS 与 Rspack integration 配置。
- * @returns 可加入 Rspack `plugins` 的插件实例。
- */
 export function unoCSSRspackPlugin<Theme extends object = object>(
   options: UnoCSSRspackPluginOptions<Theme> = {},
 ): UnoCSSRspackPlugin<Theme> {

--- a/packages-integrations/rsbuild/src/rspack.ts
+++ b/packages-integrations/rsbuild/src/rspack.ts
@@ -46,7 +46,15 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
     virtualLayers.set(virtualAllPath, LAYER_MARK_ALL)
     let virtualHash = ''
     let shouldInvalidate = false
+    let invalidateTimer: ReturnType<typeof setTimeout> | undefined
     const contentWatcher = new ExternalContentWatcher(compiler, context, options.watch)
+
+    const clearPendingInvalidation = () => {
+      if (invalidateTimer)
+        clearTimeout(invalidateTimer)
+      invalidateTimer = undefined
+      shouldInvalidate = false
+    }
 
     virtualModules.apply(compiler)
     this.injectLoader(compiler, context, contextId)
@@ -151,7 +159,8 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
       if (!shouldInvalidate || !compiler.watching)
         return
       shouldInvalidate = false
-      setTimeout(() => {
+      invalidateTimer = setTimeout(() => {
+        invalidateTimer = undefined
         compiler.watching?.invalidateWithChangesAndRemovals(
           new Set([virtualAllPath, virtualLayerPath]),
           new Set(),
@@ -160,9 +169,11 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
     })
 
     compiler.hooks.watchClose.tap(pluginName, () => {
+      clearPendingInvalidation()
       void contentWatcher.close()
     })
     compiler.hooks.shutdown.tapPromise(pluginName, async () => {
+      clearPendingInvalidation()
       await contentWatcher.close()
       unregisterContext(contextId)
     })

--- a/packages-integrations/rsbuild/src/rspack.ts
+++ b/packages-integrations/rsbuild/src/rspack.ts
@@ -1,0 +1,235 @@
+import type { Compiler, Module, RspackPluginInstance } from '@rspack/core'
+import type { UnoCSSRspackPluginOptions } from './types'
+import { createHash } from 'node:crypto'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Compilation, rspack, sources } from '@rspack/core'
+import { LAYER_MARK_ALL } from '#integration/constants'
+import {
+  getCssEscaperForJsContent,
+  getHashPlaceholder,
+  getLayerPlaceholder,
+  HASH_PLACEHOLDER_RE,
+  LAYER_PLACEHOLDER_RE,
+} from '#integration/layers'
+import { NativeContext } from './context'
+import { registerContext, unregisterContext } from './registry'
+
+const pluginName = 'unocss:rspack-native'
+const loaderPath = fileURLToPath(new URL('./loader.mjs', import.meta.url))
+
+export class UnoCSSRspackPlugin<Theme extends object = object> implements RspackPluginInstance {
+  /**
+   * 创建原生 UnoCSS Rspack 插件。
+   *
+   * @param userOptions UnoCSS 与 Rspack integration 配置。
+   */
+  constructor(private readonly userOptions: UnoCSSRspackPluginOptions<Theme> = {}) {}
+
+  /**
+   * 注册 loader、虚拟模块、CSS 生成和 watch invalidation hooks。
+   *
+   * @param compiler Rspack compiler 实例。
+   */
+  apply(compiler: Compiler): void {
+    const options = {
+      ...this.userOptions,
+      root: this.userOptions.root ?? compiler.context,
+      watch: this.userOptions.watch ?? true,
+      autoCssRule: this.userOptions.autoCssRule ?? true,
+    }
+    const context = new NativeContext(options.root, options)
+    const contextId = registerContext(context)
+    const virtualAllPath = join(context.root, 'node_modules', '.unocss-rsbuild', 'uno.css')
+    const virtualLayerPath = join(context.root, 'node_modules', '.unocss-rsbuild', 'uno-layer.css')
+    const virtualModules = new rspack.experiments.VirtualModulesPlugin({
+      [virtualAllPath]: getLayerPlaceholder(LAYER_MARK_ALL),
+      [virtualLayerPath]: getLayerPlaceholder(LAYER_MARK_ALL),
+    })
+    const virtualLayers = new Map<string, string>()
+    virtualLayers.set(virtualAllPath, LAYER_MARK_ALL)
+    let virtualHash = ''
+    let shouldInvalidate = false
+
+    virtualModules.apply(compiler)
+    this.injectLoader(compiler, context, contextId)
+    this.resolveVirtualModules(compiler, context, virtualAllPath, virtualLayerPath, virtualLayers)
+    if (options.autoCssRule)
+      this.injectCssRule(compiler)
+
+    compiler.hooks.beforeCompile.tapPromise(pluginName, () => context.initialize())
+
+    compiler.hooks.watchRun.tapPromise(pluginName, async (watchCompiler) => {
+      const modified = watchCompiler.modifiedFiles ?? new Set<string>()
+      const removed = watchCompiler.removedFiles ?? new Set<string>()
+      if (context.configFiles.some(file => modified.has(file))) {
+        await context.reloadConfig()
+        return
+      }
+      if ([...context.filesystemFiles].some(file => modified.has(file) || removed.has(file)))
+        await context.extractExternalContent()
+      for (const file of removed)
+        context.removeModule(file)
+    })
+
+    compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
+      compilation.hooks.finishModules.tapPromise(pluginName, async (modules) => {
+        const currentModules = new Set<string>()
+        for (const module of modules) {
+          const resource = (module as Module & { resource?: string }).resource
+          if (resource)
+            currentModules.add(resource)
+        }
+        context.evictModulesNotIn(currentModules)
+        for (const file of context.configFiles)
+          compilation.fileDependencies.add(file)
+        for (const file of context.filesystemFiles)
+          compilation.fileDependencies.add(file)
+      })
+
+      compilation.hooks.processAssets.tapPromise(
+        {
+          name: pluginName,
+          stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
+        },
+        async () => {
+          const result = await context.generate(compiler.options.mode === 'production')
+          const importedLayers = this.getImportedLayers(compilation.modules, virtualLayers)
+
+          for (const asset of compilation.getAssets()) {
+            const original = asset.source.source().toString()
+            let replaced = false
+            let escapeCss: ReturnType<typeof getCssEscaperForJsContent> | undefined
+            const code = original
+              .replace(HASH_PLACEHOLDER_RE, '')
+              .replace(LAYER_PLACEHOLDER_RE, (_match, layer, escapeView) => {
+                replaced = true
+                escapeCss ??= getCssEscaperForJsContent(escapeView.trim())
+                const css = layer.trim() === LAYER_MARK_ALL
+                  ? result.getLayers(undefined, importedLayers)
+                  : (result.getLayer(layer.trim()) ?? '')
+                return escapeCss(css)
+              })
+
+            if (replaced) {
+              compilation.updateAsset(
+                asset.name,
+                new sources.SourceMapSource(code, asset.name, asset.source.map() as never),
+              )
+            }
+          }
+
+          if (!compiler.watchMode)
+            return
+
+          const allCss = result.getLayers(undefined, importedLayers)
+          const hash = createHash('sha256').update(allCss).digest('hex').slice(0, 12)
+          if (virtualHash === hash)
+            return
+          virtualHash = hash
+          context.setVirtualHash(hash)
+          const content = `${getHashPlaceholder(hash)}${getLayerPlaceholder(LAYER_MARK_ALL)}`
+          virtualModules.writeModule(virtualAllPath, content)
+          virtualModules.writeModule(virtualLayerPath, content)
+          shouldInvalidate = true
+        },
+      )
+    })
+
+    compiler.hooks.done.tap(pluginName, () => {
+      if (!shouldInvalidate || !compiler.watching)
+        return
+      shouldInvalidate = false
+      setTimeout(() => compiler.watching?.invalidate(), 0)
+    })
+
+    compiler.hooks.shutdown?.tap(pluginName, () => unregisterContext(contextId))
+  }
+
+  /** 为普通源码和 Vue SFC 的实际 loader chain 注入 UnoCSS loader。 */
+  private injectLoader(compiler: Compiler, context: NativeContext, contextId: string): void {
+    const loader = {
+      loader: loaderPath,
+      options: { contextId },
+      parallel: false,
+    }
+
+    compiler.options.module.rules.unshift({
+      enforce: 'pre',
+      test: resource => typeof resource === 'string' && context.filter.shouldTransform(resource),
+      use: [loader],
+    })
+
+    for (const item of compiler.options.module.rules) {
+      if (!item || typeof item !== 'object')
+        continue
+      const rule = item as {
+        test?: RegExp
+        use?: Array<string | { loader?: string, options?: unknown }>
+      }
+      if (!(rule.test instanceof RegExp) || !new RegExp(rule.test.source, rule.test.flags.replace('g', '')).test('component.vue'))
+        continue
+      if (Array.isArray(rule.use))
+        rule.use.push(loader)
+    }
+  }
+
+  /** 将公开 UnoCSS CSS 入口解析到预注册的 Rspack 虚拟模块。 */
+  private resolveVirtualModules(
+    compiler: Compiler,
+    context: NativeContext,
+    virtualAllPath: string,
+    virtualLayerPath: string,
+    virtualLayers: Map<string, string>,
+  ): void {
+    compiler.hooks.normalModuleFactory.tap(pluginName, (factory) => {
+      factory.hooks.beforeResolve.tapPromise(pluginName, async (data) => {
+        const resolvedId = await context.resolveVirtualId(data.request, data.contextInfo.issuer)
+        if (!resolvedId)
+          return
+        const layer = await context.resolveLayer(resolvedId)
+        if (!layer)
+          return
+        if (layer === LAYER_MARK_ALL) {
+          data.request = virtualAllPath
+          return
+        }
+        const request = `${virtualLayerPath}?uno-layer=${encodeURIComponent(layer)}`
+        virtualLayers.set(request, layer)
+        data.request = request
+      })
+    })
+  }
+
+  /** 为直接使用 Rspack 的场景注入虚拟 CSS module rule。 */
+  private injectCssRule(compiler: Compiler): void {
+    compiler.options.module.rules.push({
+      test: /[\\/|]\.unocss-rsbuild[\\/|].+\.css$/,
+      type: 'css/auto',
+    })
+  }
+
+  /** 收集本轮 compilation 实际导入的命名 layer。 */
+  private getImportedLayers(modules: Iterable<Module>, virtualLayers: Map<string, string>): string[] {
+    const layers = new Set<string>()
+    for (const module of modules) {
+      const resource = (module as Module & { resource?: string }).resource
+      const layer = resource ? virtualLayers.get(resource) : undefined
+      if (layer && layer !== LAYER_MARK_ALL)
+        layers.add(layer)
+    }
+    return [...layers]
+  }
+}
+
+/**
+ * 创建原生 UnoCSS Rspack 插件实例。
+ *
+ * @param options UnoCSS 与 Rspack integration 配置。
+ * @returns 可加入 Rspack `plugins` 的插件实例。
+ */
+export function unoCSSRspackPlugin<Theme extends object = object>(
+  options: UnoCSSRspackPluginOptions<Theme> = {},
+): UnoCSSRspackPlugin<Theme> {
+  return new UnoCSSRspackPlugin(options)
+}

--- a/packages-integrations/rsbuild/src/rspack.ts
+++ b/packages-integrations/rsbuild/src/rspack.ts
@@ -34,7 +34,10 @@ export class UnoCSSRspackPlugin<Theme extends object = object> implements Rspack
         ...this.userOptions.defaults,
       },
     }
-    const context = new NativeContext(options.root, options)
+    const context = new NativeContext(
+      options.root,
+      options as unknown as UnoCSSRspackPluginOptions,
+    )
     const contextId = registerContext(context)
     const virtualAllPath = join(context.root, 'node_modules', '.unocss-rsbuild', 'uno.css')
     const virtualLayerPath = join(context.root, 'node_modules', '.unocss-rsbuild', 'uno-layer.css')

--- a/packages-integrations/rsbuild/src/transformers.ts
+++ b/packages-integrations/rsbuild/src/transformers.ts
@@ -6,14 +6,6 @@ import { applyTransformers } from '#integration/transformers'
 
 const enforceOrder: SourceCodeTransformerEnforce[] = ['pre', 'default', 'post']
 
-/**
- * 按 UnoCSS 官方 enforce 顺序运行全部源码 transformer。
- *
- * @param context 当前模块绑定的 UnoCSS 插件上下文。
- * @param source 原始模块源码。
- * @param id 模块标识。
- * @returns 转换后的源码和合并后的 sourcemap。
- */
 export async function transformSource(
   context: UnocssPluginContext,
   source: string,

--- a/packages-integrations/rsbuild/src/transformers.ts
+++ b/packages-integrations/rsbuild/src/transformers.ts
@@ -1,0 +1,45 @@
+import type { EncodedSourceMap } from '@jridgewell/remapping'
+import type { SourceCodeTransformerEnforce, UnocssPluginContext } from '@unocss/core'
+import remapping from '@jridgewell/remapping'
+import MagicString from 'magic-string'
+import { applyTransformers } from '#integration/transformers'
+
+const enforceOrder: SourceCodeTransformerEnforce[] = ['pre', 'default', 'post']
+
+/**
+ * 按 UnoCSS 官方 enforce 顺序运行全部源码 transformer。
+ *
+ * @param context 当前模块绑定的 UnoCSS 插件上下文。
+ * @param source 原始模块源码。
+ * @param id 模块标识。
+ * @returns 转换后的源码和合并后的 sourcemap。
+ */
+export async function transformSource(
+  context: UnocssPluginContext,
+  source: string,
+  id: string,
+) {
+  let code = source
+  const maps: EncodedSourceMap[] = []
+
+  for (const enforce of enforceOrder) {
+    const result = await applyTransformers(context, code, id, enforce)
+    if (!result)
+      continue
+    code = result.code
+    if (result.map)
+      maps.push(result.map as EncodedSourceMap)
+  }
+
+  if (code === source)
+    return { code }
+
+  const map = maps.length === 1
+    ? maps[0]
+    : remapping([...maps].reverse(), () => null)
+
+  return {
+    code,
+    map: map ?? new MagicString(code).generateMap({ hires: true, source: id }),
+  }
+}

--- a/packages-integrations/rsbuild/src/types.ts
+++ b/packages-integrations/rsbuild/src/types.ts
@@ -1,0 +1,18 @@
+import type { UserConfig, UserConfigDefaults } from '@unocss/core'
+
+export interface UnoCSSRspackPluginOptions<Theme extends object = object> {
+  configOrPath?: string | UserConfig<Theme>
+  defaults?: UserConfigDefaults<Theme>
+  root?: string
+  include?: Array<string | RegExp>
+  exclude?: Array<string | RegExp>
+  watch?: boolean
+  autoCssRule?: boolean
+}
+
+export type UnoCSSRsbuildPluginOptions<Theme extends object = object> = UnoCSSRspackPluginOptions<Theme>
+
+export interface TransformResult {
+  code: string
+  map?: object
+}

--- a/packages-integrations/rsbuild/src/types.ts
+++ b/packages-integrations/rsbuild/src/types.ts
@@ -2,7 +2,7 @@ import type { FilterPattern, UserConfig, UserConfigDefaults } from '@unocss/core
 
 export interface UnoCSSRspackPluginOptions<Theme extends object = object> {
   configOrPath?: string | UserConfig<Theme>
-  defaults?: UserConfigDefaults<Theme>
+  defaults?: UserConfigDefaults
   root?: string
   include?: FilterPattern
   exclude?: FilterPattern

--- a/packages-integrations/rsbuild/src/types.ts
+++ b/packages-integrations/rsbuild/src/types.ts
@@ -1,11 +1,11 @@
-import type { UserConfig, UserConfigDefaults } from '@unocss/core'
+import type { FilterPattern, UserConfig, UserConfigDefaults } from '@unocss/core'
 
 export interface UnoCSSRspackPluginOptions<Theme extends object = object> {
   configOrPath?: string | UserConfig<Theme>
   defaults?: UserConfigDefaults<Theme>
   root?: string
-  include?: Array<string | RegExp>
-  exclude?: Array<string | RegExp>
+  include?: FilterPattern
+  exclude?: FilterPattern
   watch?: boolean
   autoCssRule?: boolean
 }

--- a/packages-integrations/rsbuild/tsdown.config.ts
+++ b/packages-integrations/rsbuild/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown'
+import { aliasVirtual } from '../../alias'
+
+export default defineConfig({
+  entry: [
+    'src/index.ts',
+    'src/rspack.ts',
+    'src/loader.ts',
+  ],
+  clean: true,
+  dts: true,
+  alias: aliasVirtual,
+  exports: true,
+  failOnWarn: true,
+  publint: 'ci-only',
+  attw: {
+    enabled: 'ci-only',
+    ignoreRules: ['cjs-resolves-to-esm'],
+  },
+})

--- a/packages-integrations/rsbuild/vitest.config.ts
+++ b/packages-integrations/rsbuild/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineProject } from 'vitest/config'
+import { aliasDeprecated, aliasEngine, aliasPresets, aliasVirtual } from '../../alias'
+
+export default defineProject({
+  resolve: {
+    alias: {
+      ...aliasEngine,
+      ...aliasPresets,
+      ...aliasDeprecated,
+      ...aliasVirtual,
+    },
+  },
+  test: {
+    name: 'rsbuild:unit',
+    testTimeout: 30_000,
+  },
+})

--- a/packages-presets/unocss/package.json
+++ b/packages-presets/unocss/package.json
@@ -44,6 +44,7 @@
     "./preset-wind": "./dist/preset-wind.mjs",
     "./preset-wind3": "./dist/preset-wind3.mjs",
     "./preset-wind4": "./dist/preset-wind4.mjs",
+    "./rsbuild": "./dist/rsbuild.mjs",
     "./vite": "./dist/vite.mjs",
     "./webpack": {
       "import": "./dist/webpack.mjs",
@@ -73,6 +74,7 @@
   "peerDependencies": {
     "@unocss/astro": "workspace:*",
     "@unocss/postcss": "workspace:*",
+    "@unocss/rsbuild": "workspace:*",
     "@unocss/webpack": "workspace:*"
   },
   "peerDependenciesMeta": {
@@ -80,6 +82,9 @@
       "optional": true
     },
     "@unocss/postcss": {
+      "optional": true
+    },
+    "@unocss/rsbuild": {
       "optional": true
     },
     "@unocss/webpack": {
@@ -108,6 +113,7 @@
   "devDependencies": {
     "@unocss/astro": "workspace:*",
     "@unocss/postcss": "workspace:*",
+    "@unocss/rsbuild": "workspace:*",
     "@unocss/webpack": "workspace:*"
   }
 }

--- a/packages-presets/unocss/src/rsbuild.ts
+++ b/packages-presets/unocss/src/rsbuild.ts
@@ -5,12 +5,6 @@ import { pluginUnoCSS } from '@unocss/rsbuild'
 
 export * from '@unocss/rsbuild'
 
-/**
- * 创建带有默认 Wind3 预设的 UnoCSS Rsbuild 插件。
- *
- * @param options Rsbuild integration 配置，可覆盖扫描范围、配置文件和默认 UnoCSS 配置。
- * @returns 可直接加入 Rsbuild `plugins` 的插件实例。
- */
 export default function UnocssRsbuildPlugin<Theme extends object>(
   options: UnoCSSRsbuildPluginOptions<Theme> = {},
 ): RsbuildPlugin {

--- a/packages-presets/unocss/src/rsbuild.ts
+++ b/packages-presets/unocss/src/rsbuild.ts
@@ -1,6 +1,5 @@
 import type { RsbuildPlugin } from '@rsbuild/core'
 import type { UnoCSSRsbuildPluginOptions } from '@unocss/rsbuild'
-import presetWind3 from '@unocss/preset-wind3'
 import { pluginUnoCSS } from '@unocss/rsbuild'
 
 export * from '@unocss/rsbuild'
@@ -8,11 +7,5 @@ export * from '@unocss/rsbuild'
 export default function UnocssRsbuildPlugin<Theme extends object>(
   options: UnoCSSRsbuildPluginOptions<Theme> = {},
 ): RsbuildPlugin {
-  return pluginUnoCSS({
-    ...options,
-    defaults: {
-      presets: [presetWind3()],
-      ...options.defaults,
-    },
-  })
+  return pluginUnoCSS(options)
 }

--- a/packages-presets/unocss/src/rsbuild.ts
+++ b/packages-presets/unocss/src/rsbuild.ts
@@ -1,0 +1,24 @@
+import type { RsbuildPlugin } from '@rsbuild/core'
+import type { UnoCSSRsbuildPluginOptions } from '@unocss/rsbuild'
+import presetWind3 from '@unocss/preset-wind3'
+import { pluginUnoCSS } from '@unocss/rsbuild'
+
+export * from '@unocss/rsbuild'
+
+/**
+ * 创建带有默认 Wind3 预设的 UnoCSS Rsbuild 插件。
+ *
+ * @param options Rsbuild integration 配置，可覆盖扫描范围、配置文件和默认 UnoCSS 配置。
+ * @returns 可直接加入 Rsbuild `plugins` 的插件实例。
+ */
+export default function UnocssRsbuildPlugin<Theme extends object>(
+  options: UnoCSSRsbuildPluginOptions<Theme> = {},
+): RsbuildPlugin {
+  return pluginUnoCSS({
+    ...options,
+    defaults: {
+      presets: [presetWind3()],
+      ...options.defaults,
+    },
+  })
+}

--- a/packages-presets/unocss/tsdown.config.ts
+++ b/packages-presets/unocss/tsdown.config.ts
@@ -21,6 +21,7 @@ export default defineConfig([
     name: 'ESM only',
     entry: [
       'src/index.ts',
+      'src/rsbuild.ts',
       'src/vite.ts',
       'src/astro.ts',
       'src/preset-uno.ts',
@@ -38,6 +39,9 @@ export default defineConfig([
     dts: true,
     deps: {
       neverBundle: [
+        '@rsbuild/core',
+        '@rspack/core',
+        '@unocss/rsbuild',
         'astro',
         'vite',
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ catalogs:
     '@types/fs-extra':
       specifier: ^11.0.4
       version: 11.0.4
+    '@types/glob-parent':
+      specifier: ^5.1.3
+      version: 5.1.3
     '@types/js-yaml':
       specifier: ^4.0.9
       version: 4.0.9
@@ -1232,6 +1235,9 @@ importers:
       '@rspack/core':
         specifier: catalog:build
         version: 2.1.3(@swc/helpers@0.5.23)
+      '@types/glob-parent':
+        specifier: catalog:types
+        version: 5.1.3
       '@unocss/preset-uno':
         specifier: workspace:*
         version: link:../../packages-deprecated/preset-uno
@@ -5525,6 +5531,9 @@ packages:
 
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
+  '@types/glob-parent@5.1.3':
+    resolution: {integrity: sha512-p+NciRH8TRvrgISOCQ55CP+lktMmDpOXsp4spULIIz0L4aJ6G9zFX+N0UZ2xulmJRgaQLRxXIp4xHdL6YOQjDg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -14455,6 +14464,8 @@ snapshots:
     dependencies:
       '@types/jsonfile': 6.1.4
       '@types/node': 25.9.4
+
+  '@types/glob-parent@5.1.3': {}
 
   '@types/hast@3.0.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,12 @@ catalogs:
     '@jridgewell/remapping':
       specifier: ^2.3.5
       version: 2.3.5
+    '@rsbuild/core':
+      specifier: ^2.1.5
+      version: 2.1.5
+    '@rspack/core':
+      specifier: ^2.1.3
+      version: 2.1.3
     brotli-size:
       specifier: ^4.0.0
       version: 4.0.0
@@ -487,7 +493,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: catalog:eslint
-        version: 9.1.0(@typescript-eslint/rule-tester@8.59.3)(@typescript-eslint/typescript-estree@8.62.0)(@typescript-eslint/utils@8.62.0)(@unocss/eslint-plugin@66.7.3)(@vue/compiler-sfc@3.5.38)(eslint-plugin-format@2.0.1)(eslint@10.5.0)(svelte-eslint-parser@1.8.0)(typescript@6.0.3)(vitest@4.1.9)
+        version: 9.1.0(@typescript-eslint/rule-tester@8.59.3)(@typescript-eslint/typescript-estree@8.62.0)(@typescript-eslint/utils@8.62.0)(@unocss/eslint-plugin@66.7.5)(@vue/compiler-sfc@3.5.38)(eslint-plugin-format@2.0.1)(eslint@10.5.0)(svelte-eslint-parser@1.8.0)(typescript@6.0.3)(vitest@4.1.9)
       '@antfu/ni':
         specifier: catalog:utils
         version: 30.2.0
@@ -1187,6 +1193,49 @@ importers:
         specifier: catalog:utils
         version: 0.2.17
 
+  packages-integrations/rsbuild:
+    dependencies:
+      '@jridgewell/remapping':
+        specifier: catalog:build
+        version: 2.3.5
+      '@unocss/config':
+        specifier: workspace:*
+        version: link:../../packages-engine/config
+      '@unocss/core':
+        specifier: workspace:*
+        version: link:../../packages-engine/core
+      magic-string:
+        specifier: catalog:utils
+        version: 0.30.21
+      pathe:
+        specifier: catalog:utils
+        version: 2.0.3
+      tinyglobby:
+        specifier: catalog:utils
+        version: 0.2.17
+      unplugin-utils:
+        specifier: catalog:utils
+        version: 0.3.1
+    devDependencies:
+      '@rsbuild/core':
+        specifier: catalog:build
+        version: 2.1.5(core-js@3.49.0)
+      '@rspack/core':
+        specifier: catalog:build
+        version: 2.1.3(@swc/helpers@0.5.23)
+      '@unocss/preset-uno':
+        specifier: workspace:*
+        version: link:../../packages-deprecated/preset-uno
+      '@unocss/transformer-directives':
+        specifier: workspace:*
+        version: link:../../packages-presets/transformer-directives
+      '@unocss/transformer-variant-group':
+        specifier: workspace:*
+        version: link:../../packages-presets/transformer-variant-group
+      vitest:
+        specifier: catalog:testing
+        version: 4.1.9(@types/node@25.9.4)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6)(vite@8.1.0)
+
   packages-integrations/runtime:
     dependencies:
       '@iconify/utils':
@@ -1342,7 +1391,7 @@ importers:
         version: 0.2.17
       unplugin:
         specifier: catalog:utils
-        version: 3.2.0(esbuild@0.28.0)(rolldown@1.1.2)(rollup@4.62.2)(vite@8.1.0)(webpack@5.106.2)
+        version: 3.2.0(@rspack/core@2.1.3)(esbuild@0.28.0)(rolldown@1.1.2)(rollup@4.62.2)(vite@8.1.0)(webpack@5.106.2)
       unplugin-utils:
         specifier: catalog:utils
         version: 0.3.1
@@ -1608,6 +1657,9 @@ importers:
       '@unocss/postcss':
         specifier: workspace:*
         version: link:../../packages-integrations/postcss
+      '@unocss/rsbuild':
+        specifier: workspace:*
+        version: link:../../packages-integrations/rsbuild
       '@unocss/webpack':
         specifier: workspace:*
         version: link:../../packages-integrations/webpack
@@ -5126,6 +5178,96 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rsbuild/core@2.1.5':
+    resolution: {integrity: sha512-7TW4U1SH7VxQZzSTIOzvwj5lo9uNTmGpsmTXFr4axQAE4giLDKP3kVUA1ZW4P3/Mz4QQJJyvZP29mVcb8kZCfg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
+  '@rspack/binding-darwin-arm64@2.1.3':
+    resolution: {integrity: sha512-oOGI0RSL89Ehu9T22rugmfUY9OC2eBqLMeWRYsu7bhlUrjoXeVfGBBSEXCse666BQ1sAiM8hD/k7nqVria/okQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.1.3':
+    resolution: {integrity: sha512-sVqWXNiFTMXAyN362y6IA+eJc8LXZKfHdhEJ/zDuMmRp+u2IvhgaF8tk3vX/OmeB9jydVjySijuiqk8No/FoCA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu@2.1.3':
+    resolution: {integrity: sha512-aCy9Zli/2Qf+Ee5otXfFQ6mhv5fEyn0wIoBVmouqtJoqOO21et6UTtJ+LHLsMDolwGLyHERAljeSFSmYX3/O5A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-musl@2.1.3':
+    resolution: {integrity: sha512-flIE7eluz0d21Fn28EVm3vPwoJooOSqtmjLFVSuOMcoCbwV9clfor195oIrAppp/W7dL/3XquFuVfrsa01Jy8Q==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.3':
+    resolution: {integrity: sha512-yojg8elye1nhsNeGncw0NrZ4pMGF7NVebR80CLg72TXyzfYwFJlFTdU5yUYb1Gy+JXIvrSCwzQt2QkyiEvmkfg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-musl@2.1.3':
+    resolution: {integrity: sha512-6PvbXb3FOK4X3S5QGvoSW/sqExmsvAoPnQ/YSFrXvTphkXFezA7wnobmGBHT8JQP31hcFRzJHIZSIOKktzSzzg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-x64-gnu@2.1.3':
+    resolution: {integrity: sha512-lMXjoGKf0SnviH596fmTszgtnXLHmWOoE90G8grG9MvKVa3pelRmfps5ewZL9s8ENf3NXRfOxIhIf/M9as6MqA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-musl@2.1.3':
+    resolution: {integrity: sha512-0esT35v7pW2ZsJTMc/zDUHwpNXlPqyUCyuiLJvrAAUcdENrgOVe4DmFrgVJ2hwqI4GjeN1VBnGRJ8c+edAHH5w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-wasm32-wasi@2.1.3':
+    resolution: {integrity: sha512-UsrDjD59UEP0mhfN/Z+uTc3vLgiUvIr+mn92WC1sbQi9gtZohTYvaQYFhWuMkBqsACGcmZp704JAbbSrVrVYCA==}
+    cpu: [wasm32]
+
+  '@rspack/binding-win32-arm64-msvc@2.1.3':
+    resolution: {integrity: sha512-42RS/SwKBTkNvXIPZXqTn0yEFN8zwGRfRe/ly0GDvPp/KxpLMFWxJmLxgtoLompU+0UCGvV4KpcBENt3oWs6BA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@2.1.3':
+    resolution: {integrity: sha512-thk43H1JHHbetNF3txcsGXeOwZi2m6Luf/uVUqNORXjxr5VV8woHAgaAx4QXVZRg70z1VDjd8mBWnHBnKI0FGA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.1.3':
+    resolution: {integrity: sha512-ObaUcj+BHo/aBL1weyM3orApaHyAR5Phr3YNEpQEifxjZbNKM1iO5X5prN4OqEv3H+7o5e/Wh9Fy3N7Vvd+psA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding@2.1.3':
+    resolution: {integrity: sha512-4UGXJqUHmm36tWG1GgFZz3p8sQ5JuSgWI+gq1xPPoihS41uYJL3cXuJnirTeWsmVrusmYZTQhgU3tl3VYGcJYg==}
+
+  '@rspack/core@2.1.3':
+    resolution: {integrity: sha512-1iGnxLrP+iyY0ZSjLZeQTaxrISpQz4yLyqJPmaF/l4uw27/dBcrloszAeLOJQ9jiv7EJtU0T5zB+LOFPpivIxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -5238,6 +5380,9 @@ packages:
     resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
     peerDependencies:
       acorn: ^8.9.0
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
@@ -5623,17 +5768,17 @@ packages:
     peerDependencies:
       vue: '>=3.5.18'
 
-  '@unocss/config@66.7.3':
-    resolution: {integrity: sha512-r1a1Pggt0rvnUvrltA77feEEq6PtNodpOxVbhwJ/sYGR6dwstSBEVmNP/Oe4ApUDax5nxZchP+VQ+RctNMs0zg==}
+  '@unocss/config@66.7.5':
+    resolution: {integrity: sha512-dkPl9glhEahJ+Xoja5ZseKKnH+vZaeaKQzg8b0otcKcPPNrHQgu1nu3QgfeOjnXOGrjZIotHwUeVtt4ZA2Skgg==}
 
-  '@unocss/core@66.7.3':
-    resolution: {integrity: sha512-UBfEXpW8NKACeEeUddvPDRuuroDtByO3ZHocs/SqqOEybs5Qb9oWdMJMj1DSe960RvzucLPDtOeCFL2gilzRVA==}
+  '@unocss/core@66.7.5':
+    resolution: {integrity: sha512-UdJb8MiMywcau8QrWEVgUAz0kvoFHyR+sACwYCgmBh/BpKJGyR/zw/Ys3wvysbm0f+i/20VGBex/QQxYVlzdyQ==}
 
-  '@unocss/eslint-plugin@66.7.3':
-    resolution: {integrity: sha512-/eq0r8yDNUPSAVUAD82LtznhfxcUZZXsq572sUUI2fBMgxuJ4iFyuZydQaxGRHGpp7Nb9038iZYsXCxdCNlWEQ==}
+  '@unocss/eslint-plugin@66.7.5':
+    resolution: {integrity: sha512-VCOY8w/y+o/2Vm6QqDgKZmX7XUjU0y/22ScI6AU0CxYtKUjHukUFubKgvn7/iRHiJEhrgtpxF1kDLvkNzhsklg==}
 
-  '@unocss/rule-utils@66.7.3':
-    resolution: {integrity: sha512-DKg1Rr/pxc5owCbFTpF1hXGoSqZjX7EzgfOkgO9R0VDnsufXIf776xUw7I3PWKXMMdC3SLnY6jT9bhlnZ6aM7w==}
+  '@unocss/rule-utils@66.7.5':
+    resolution: {integrity: sha512-/AKHBRF6ZOexE3EDDv8ZEYh40P5e2Eha41IYUbE1wjigW7++ssmvimSTdufJzZvU5DGP++E3B3WEsFPprZMjAg==}
 
   '@valibot/to-json-schema@1.7.0':
     resolution: {integrity: sha512-Y3pPVibbIOHzohrlxSINvO7w/bvXkoYS3BQHoImV9ynE+bXKf171bdMucPurV2zp7gdmt0L1HCcNAsbo7cFRQw==}
@@ -7979,10 +8124,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.3.6:
-    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
-    engines: {node: 20 || >=22}
-
   lru-cache@11.4.0:
     resolution: {integrity: sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==}
     engines: {node: 20 || >=22}
@@ -9722,10 +9863,6 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -10888,7 +11025,7 @@ snapshots:
 
   '@andrewbranch/untar.js@1.0.3': {}
 
-  '@antfu/eslint-config@9.1.0(@typescript-eslint/rule-tester@8.59.3)(@typescript-eslint/typescript-estree@8.62.0)(@typescript-eslint/utils@8.62.0)(@unocss/eslint-plugin@66.7.3)(@vue/compiler-sfc@3.5.38)(eslint-plugin-format@2.0.1)(eslint@10.5.0)(svelte-eslint-parser@1.8.0)(typescript@6.0.3)(vitest@4.1.9)':
+  '@antfu/eslint-config@9.1.0(@typescript-eslint/rule-tester@8.59.3)(@typescript-eslint/typescript-estree@8.62.0)(@typescript-eslint/utils@8.62.0)(@unocss/eslint-plugin@66.7.5)(@vue/compiler-sfc@3.5.38)(eslint-plugin-format@2.0.1)(eslint@10.5.0)(svelte-eslint-parser@1.8.0)(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 1.6.0
@@ -10928,7 +11065,7 @@ snapshots:
       vue-eslint-parser: 10.4.1(eslint@10.5.0)
       yaml-eslint-parser: 2.0.0
     optionalDependencies:
-      '@unocss/eslint-plugin': 66.7.3(eslint@10.5.0)(typescript@6.0.3)
+      '@unocss/eslint-plugin': 66.7.5(eslint@10.5.0)(typescript@6.0.3)
       eslint-plugin-format: 2.0.1(eslint@10.5.0)
       svelte-eslint-parser: 1.8.0(svelte@5.56.4)
     transitivePeerDependencies:
@@ -10953,7 +11090,7 @@ snapshots:
       fzf: 0.5.2
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
 
   '@antfu/ni@30.2.0':
     dependencies:
@@ -12118,7 +12255,7 @@ snapshots:
       '@nuxt/kit': 4.4.5(magicast@0.5.3)
       chokidar: 5.0.0
       pathe: 2.0.3
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -12947,7 +13084,7 @@ snapshots:
       simple-git: 3.36.0
       sirv: 3.0.2
       structured-clone-es: 2.0.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       vite: 8.1.0(@types/node@25.9.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.5)(vite@8.1.0)
       vite-plugin-vue-tracer: 1.4.0(vite@8.1.0)(vue@3.5.38)
@@ -12977,7 +13114,7 @@ snapshots:
       rc9: 3.0.1
       scule: 1.3.0
       semver: 7.8.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
       untyped: 2.0.0
@@ -13388,7 +13525,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.133.0':
@@ -13976,6 +14113,76 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@rsbuild/core@2.1.5(core-js@3.49.0)':
+    dependencies:
+      '@rspack/core': 2.1.3(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    optionalDependencies:
+      core-js: 3.49.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rspack/binding-darwin-arm64@2.1.3':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.1.3':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@2.1.3':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.1.3':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.3':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.3':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@2.1.3':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.3':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.1.3':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.1.3':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@2.1.3':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.3':
+    optional: true
+
+  '@rspack/binding@2.1.3':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.3
+      '@rspack/binding-darwin-x64': 2.1.3
+      '@rspack/binding-linux-arm64-gnu': 2.1.3
+      '@rspack/binding-linux-arm64-musl': 2.1.3
+      '@rspack/binding-linux-riscv64-gnu': 2.1.3
+      '@rspack/binding-linux-riscv64-musl': 2.1.3
+      '@rspack/binding-linux-x64-gnu': 2.1.3
+      '@rspack/binding-linux-x64-musl': 2.1.3
+      '@rspack/binding-wasm32-wasi': 2.1.3
+      '@rspack/binding-win32-arm64-msvc': 2.1.3
+      '@rspack/binding-win32-ia32-msvc': 2.1.3
+      '@rspack/binding-win32-x64-msvc': 2.1.3
+
+  '@rspack/core@2.1.3(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.1.3
+    optionalDependencies:
+      '@swc/helpers': 0.5.23
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@shikijs/core@3.23.0':
@@ -14119,6 +14326,10 @@ snapshots:
   '@sveltejs/acorn-typescript@1.0.10(acorn@8.17.0)':
     dependencies:
       acorn: 8.17.0
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
 
   '@tailwindcss/node@4.3.0':
     dependencies:
@@ -14530,23 +14741,23 @@ snapshots:
       unhead: 2.1.15
       vue: 3.5.38(typescript@6.0.3)
 
-  '@unocss/config@66.7.3':
+  '@unocss/config@66.7.5':
     dependencies:
-      '@unocss/core': 66.7.3
+      '@unocss/core': 66.7.5
       colorette: 2.0.20
       consola: 3.4.2
       unconfig: 7.5.0
     optional: true
 
-  '@unocss/core@66.7.3':
+  '@unocss/core@66.7.5':
     optional: true
 
-  '@unocss/eslint-plugin@66.7.3(eslint@10.5.0)(typescript@6.0.3)':
+  '@unocss/eslint-plugin@66.7.5(eslint@10.5.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/utils': 8.62.0(eslint@10.5.0)(typescript@6.0.3)
-      '@unocss/config': 66.7.3
-      '@unocss/core': 66.7.3
-      '@unocss/rule-utils': 66.7.3
+      '@unocss/config': 66.7.5
+      '@unocss/core': 66.7.5
+      '@unocss/rule-utils': 66.7.5
       magic-string: 0.30.21
       synckit: 0.11.13
     transitivePeerDependencies:
@@ -14555,9 +14766,9 @@ snapshots:
       - typescript
     optional: true
 
-  '@unocss/rule-utils@66.7.3':
+  '@unocss/rule-utils@66.7.5':
     dependencies:
-      '@unocss/core': 66.7.3
+      '@unocss/core': 66.7.5
       magic-string: 0.30.21
     optional: true
 
@@ -14734,7 +14945,7 @@ snapshots:
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vitest: 4.1.9(@types/node@25.9.4)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6)(vite@8.1.0)
 
@@ -15279,7 +15490,7 @@ snapshots:
       smol-toml: 1.6.1
       svgo: 4.0.1
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tsconfck: 3.1.6(typescript@6.0.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
@@ -16228,7 +16439,7 @@ snapshots:
       jsonc-eslint-parser: 3.1.0
       pathe: 2.0.3
       pnpm-workspace-yaml: 1.6.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       yaml: 2.9.0
       yaml-eslint-parser: 2.0.0
 
@@ -17028,7 +17239,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.3.6
+      lru-cache: 11.5.1
       parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
@@ -17253,8 +17464,6 @@ snapshots:
       js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
-
-  lru-cache@11.3.6: {}
 
   lru-cache@11.4.0: {}
 
@@ -19517,7 +19726,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   supports-color@10.2.2: {}
@@ -19662,7 +19871,7 @@ snapshots:
       pnpm-workspace-yaml: 1.6.1
       restore-cursor: 5.1.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unconfig: 7.5.0
       yaml: 2.9.0
 
@@ -19695,7 +19904,7 @@ snapshots:
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -19726,11 +19935,6 @@ snapshots:
   tinyexec@1.1.2: {}
 
   tinyexec@1.2.4: {}
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -19969,7 +20173,7 @@ snapshots:
       pkg-types: 2.3.1
       scule: 1.3.0
       strip-literal: 3.1.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
     optionalDependencies:
@@ -20051,7 +20255,7 @@ snapshots:
       mlly: 1.8.2
       obug: 2.1.1
       picomatch: 4.0.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
       vue: 3.5.38(typescript@6.0.3)
@@ -20081,12 +20285,13 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.2.0(esbuild@0.28.0)(rolldown@1.1.2)(rollup@4.62.2)(vite@8.1.0)(webpack@5.106.2):
+  unplugin@3.2.0(@rspack/core@2.1.3)(esbuild@0.28.0)(rolldown@1.1.2)(rollup@4.62.2)(vite@8.1.0)(webpack@5.106.2):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
+      '@rspack/core': 2.1.3(@swc/helpers@0.5.23)
       esbuild: 0.28.0
       rolldown: 1.1.2
       rollup: 4.62.2
@@ -20202,7 +20407,7 @@ snapshots:
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.1.0
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       vite: 7.3.3(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -20318,7 +20523,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.14
       rollup: 4.60.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.4
       fsevents: 2.3.3
@@ -20335,7 +20540,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.14
       rollup: 4.60.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.4
       fsevents: 2.3.3
@@ -20351,7 +20556,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.14
       rolldown: 1.0.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.4
       esbuild: 0.28.0
@@ -20469,13 +20674,13 @@ snapshots:
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.0(@types/node@25.9.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
@@ -20491,7 +20696,7 @@ snapshots:
   vscode-ext-gen@1.6.0:
     dependencies:
       cac: 6.7.14
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
 
   vscode-jsonrpc@8.2.0: {}
 
@@ -20553,7 +20758,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.4
       scule: 1.3.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
       vue: 3.5.38(typescript@6.0.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ catalogs:
     fzf:
       specifier: ^0.5.2
       version: 0.5.2
+    glob-parent:
+      specifier: ^6.0.2
+      version: 6.0.2
     js-yaml:
       specifier: ^4.2.0
       version: 4.2.0
@@ -1204,6 +1207,12 @@ importers:
       '@unocss/core':
         specifier: workspace:*
         version: link:../../packages-engine/core
+      chokidar:
+        specifier: catalog:utils
+        version: 5.0.0
+      glob-parent:
+        specifier: catalog:utils
+        version: 6.0.2
       magic-string:
         specifier: catalog:utils
         version: 0.30.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,6 +41,8 @@ overrides:
 catalogs:
   build:
     '@jridgewell/remapping': ^2.3.5
+    '@rsbuild/core': ^2.1.5
+    '@rspack/core': ^2.1.3
     brotli-size: ^4.0.0
     bumpp: ^11.1.0
     gzip-size: ^6.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -123,6 +123,7 @@ catalogs:
     '@types/connect': ^3.4.38
     '@types/css-tree': ^2.3.11
     '@types/fs-extra': ^11.0.4
+    '@types/glob-parent': ^5.1.3
     '@types/js-yaml': ^4.0.9
     '@types/markdown-it-link-attributes': ^3.0.5
     '@types/node': ^25.9.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -152,6 +152,7 @@ catalogs:
     fs-extra: ^11.3.5
     fuse.js: ^7.4.2
     fzf: ^0.5.2
+    glob-parent: ^6.0.2
     js-yaml: ^4.2.0
     knitwork: ^1.3.0
     lint-staged: ^17.0.8

--- a/virtual-shared/docs/src/packages.ts
+++ b/virtual-shared/docs/src/packages.ts
@@ -16,6 +16,7 @@ export const allPackages = [
   "@unocss/language-server",
   "@unocss/nuxt",
   "@unocss/postcss",
+  "@unocss/rsbuild",
   "@unocss/runtime",
   "@unocss/scope",
   "@unocss/svelte-scoped",
@@ -48,6 +49,7 @@ export const allPackages = [
 export const bundlePackages = [
   "@unocss/autocomplete",
   "@unocss/core",
+  "@unocss/rsbuild",
   "@unocss/rule-utils",
   "@unocss/transformer-attributify-jsx",
   "@unocss/transformer-compile-class",

--- a/virtual-shared/docs/src/unocss-bundle.ts
+++ b/virtual-shared/docs/src/unocss-bundle.ts
@@ -5,6 +5,7 @@
 export const unocssBundle = new Map([
   ["@unocss/autocomplete", () => import('@unocss/autocomplete')] as any,
   ["@unocss/core", () => import('@unocss/core')] as any,
+  ["@unocss/rsbuild", () => import('@unocss/rsbuild')] as any,
   ["@unocss/rule-utils", () => import('@unocss/rule-utils')] as any,
   ["@unocss/transformer-attributify-jsx", () => import('@unocss/transformer-attributify-jsx')] as any,
   ["@unocss/transformer-compile-class", () => import('@unocss/transformer-compile-class')] as any,


### PR DESCRIPTION
### Background and Motivation

UnoCSS first introduced Rspack and Rsbuild support in [[PR #4173](https://github.com/unocss/unocss/pull/4173)](https://github.com/unocss/unocss/pull/4173) through `@unocss/webpack/rspack`. However, that implementation reused the generic Webpack-oriented unplugin pipeline rather than integrating directly with the Rsbuild and Rspack compilation, caching, and watch lifecycles.

The limitations became visible in [[Rsbuild issue #4615](https://github.com/web-infra-dev/rsbuild/issues/4615)](https://github.com/web-infra-dev/rsbuild/issues/4615): changes to utility classes did not reliably update the generated CSS through HMR, requiring a full page refresh. Disabling the Rspack cache could work around the problem, but at the cost of slower rebuilds and HMR. The existing integration could also skip UnoCSS transformers, causing features such as variant groups, `@apply`, `@screen`, and `theme()` to behave inconsistently. Since the underlying problem was in the UnoCSS integration layer rather than Rsbuild itself, the issue was closed pending improvements on the UnoCSS side.

To address these limitations, we implemented a dedicated `@unocss/rsbuild` integration that connects directly to the Rsbuild 2 and Rspack loader, compilation, cache, watch, and virtual-module lifecycles. It incrementally tracks module and external-content changes, restores UnoCSS tokens for cached modules, removes stale tokens, and invalidates virtual CSS only when necessary. This enables reliable HMR without disabling the Rspack cache.

The new integration also runs UnoCSS transformers and directives correctly, supports layered virtual CSS, Rsbuild CSS inline queries, custom pipeline filters, configuration hot reload, and external glob watching. This removes the need to combine the Rspack and PostCSS integrations or sacrifice cache performance. The behavior is covered by tests for Rsbuild and Rspack builds, watch convergence, cache recovery, configuration reloads, transformer execution, and incremental content updates.

Implemented with the assistance of Codex (GPT-5.6 Sol).