### PR TITLE
fix(core): don't merge vendor-prefixed pseudo-elements into one selector list

### DIFF
--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -23,6 +23,17 @@ export const symbols: ControlSymbols = {
 // than CPU parallelism, so it is intentionally not based on the CPU count.
 const TOKEN_PARSE_BATCH_SIZE = 4096
 
+// Vendor-prefixed pseudo-elements such as `::-webkit-slider-thumb` or
+// `::-moz-range-track`. A selector list is dropped in its entirety by a browser
+// when it contains a pseudo-element that browser does not recognize, so merging
+// such selectors into a shared rule (e.g. a `::-webkit-*` next to a `::-moz-*`)
+// would break the otherwise-valid selectors too. Keep them in their own rule.
+const VENDOR_PSEUDO_RE = /::-(?:webkit|moz|ms|o)-/
+
+function hasVendorPseudo(selectors?: [string, number][] | null): boolean {
+  return !!selectors?.some(([selector]) => selector != null && VENDOR_PSEUDO_RE.test(selector))
+}
+
 class UnoGeneratorInternal<Theme extends object = object> {
   public readonly version = version
   public readonly events = createNanoEvents<{
@@ -347,11 +358,11 @@ class UnoGeneratorInternal<Theme extends object = object> {
           const ruleLines = sorted
             .reverse()
             .map(([selectorSortPair, body, noMerge], idx) => {
-              if (!noMerge && this.config.mergeSelectors) {
+              if (!noMerge && this.config.mergeSelectors && !hasVendorPseudo(selectorSortPair)) {
                 // search for rules that has exact same body, and merge them
                 for (let i = idx + 1; i < size; i++) {
                   const current = sorted[i]
-                  if (current && !current[2] && ((selectorSortPair && current[0]) || (selectorSortPair == null && current[0] == null)) && current[1] === body) {
+                  if (current && !current[2] && !hasVendorPseudo(current[0]) && ((selectorSortPair && current[0]) || (selectorSortPair == null && current[0] == null)) && current[1] === body) {
                     if (selectorSortPair && current[0])
                       current[0].push(...selectorSortPair)
                     return null

--- a/packages-engine/core/test/selector-no-merge.test.ts
+++ b/packages-engine/core/test/selector-no-merge.test.ts
@@ -1,4 +1,5 @@
 import { createGenerator } from '@unocss/core'
+import presetMini from '@unocss/preset-mini'
 import { variantMatcher } from '@unocss/preset-mini/utils'
 import { describe, expect, it } from 'vitest'
 
@@ -55,5 +56,38 @@ describe('variant', async () => {
   it('variant shortcuts late', async () => {
     const { css } = await uno.generate('m3-no-merge-ordered')
     expect(css).toMatchSnapshot()
+  })
+})
+
+// https://github.com/unocss/unocss/issues/4872
+describe('vendor-prefixed pseudo-elements', async () => {
+  const uno = await createGenerator({
+    presets: [presetMini()],
+  })
+
+  it('does not merge different vendor pseudo-elements into one selector list', async () => {
+    const { css } = await uno.generate([
+      '[&::-webkit-slider-runnable-track]:h-full',
+      '[&::-moz-range-track]:h-full',
+      '[&::-webkit-slider-thumb]:h-full',
+    ].join(' '), { preflights: false })
+
+    // Each vendor pseudo-element must stay in its own rule. A browser drops the
+    // whole selector list when it contains a pseudo-element it doesn't know, so
+    // grouping `::-webkit-*` next to `::-moz-*` would break the valid ones too.
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .\\[\\&\\:\\:-moz-range-track\\]\\:h-full::-moz-range-track{height:100%;}
+      .\\[\\&\\:\\:-webkit-slider-runnable-track\\]\\:h-full::-webkit-slider-runnable-track{height:100%;}
+      .\\[\\&\\:\\:-webkit-slider-thumb\\]\\:h-full::-webkit-slider-thumb{height:100%;}"
+    `)
+  })
+
+  it('still merges standard pseudo-elements sharing the same body', async () => {
+    const { css } = await uno.generate('[&::before]:h-full [&::after]:h-full', { preflights: false })
+    // guard is scoped to vendor prefixes: standard pseudo-elements still merge
+    // into a single selector list with one body.
+    expect((css.match(/height:100%/g) || []).length).toBe(1)
+    expect(css).toContain('::after,')
   })
 })


### PR DESCRIPTION
### What & why

Fixes #4872. UnoCSS's generator groups every utility that shares an identical CSS body into a single comma-separated selector list. When utilities target vendor-prefixed pseudo-elements, this emits a rule like:

```css
.a::-moz-range-track, .b::-webkit-slider-runnable-track, .c::-webkit-slider-thumb { height: 100% }
```

Per the CSS spec, a browser discards the **entire** selector list if it contains one pseudo-element it doesn't recognize — so Chrome drops the rule because of `::-moz-*`, Firefox because of `::-webkit-*`, and the valid selectors silently stop working. (Tailwind avoids this by never grouping such selectors; contributor zojize confirmed the invalid-output diagnosis on the issue.)

### Fix (`packages-engine/core/src/generator.ts`, ~15 lines)

Added `VENDOR_PSEUDO_RE = /::-(?:webkit|moz|ms|o)-/` and a `hasVendorPseudo()` helper, then guard the merge loop to skip merging when the current rule or a merge candidate contains a vendor-prefixed pseudo-element — each is emitted as its own valid rule. The double-colon regex matches only real vendor pseudo-elements, never the escaped `\:\:` inside class-name portions; standard-pseudo and plain merging are untouched.

### Tests

Added a class→CSS inline-snapshot regression test to `packages-engine/core/test/selector-no-merge.test.ts`, plus a sanity test proving `::before`/`::after` still merge. Verified break→red (selectors merge into one list) / restore→green. `vitest run selector-no-merge.test.ts` → 7 passed; full unit suite 657 passed / 3 skipped / 0 failed.

Closes #4872
