### PR TITLE
fix(playground): await prettier when formatting panels

### DIFF
--- a/packages-integrations/inspector/client/composables/usePrettify.ts
+++ b/packages-integrations/inspector/client/composables/usePrettify.ts
@@ -38,11 +38,3 @@ export function usePrettify(content: MaybeRefOrGetter<string | undefined>, toggl
 export function useCSSPrettify(content: MaybeRefOrGetter<string | undefined>, toggle: MaybeRefOrGetter<boolean> = true) {
   return usePrettify(content, toggle, 'css')
 }
-
-export function useHTMLPrettify(content: MaybeRefOrGetter<string | undefined>, toggle: MaybeRefOrGetter<boolean> = true) {
-  return usePrettify(content, toggle, 'html')
-}
-
-export function useJSPrettify(content: MaybeRefOrGetter<string | undefined>, toggle: MaybeRefOrGetter<boolean> = true) {
-  return usePrettify(content, toggle, 'babel')
-}

--- a/packages-integrations/inspector/client/composables/usePrettify.ts
+++ b/packages-integrations/inspector/client/composables/usePrettify.ts
@@ -6,28 +6,32 @@ import parserCSS from 'prettier/parser-postcss'
 import prettier from 'prettier/standalone'
 import { toValue } from 'vue'
 
-export function usePrettify(content: MaybeRefOrGetter<string | undefined>, toggle: MaybeRefOrGetter<boolean>, type: 'css' | 'babel' | 'html') {
+export async function prettify(content: string | undefined, type: 'css' | 'babel' | 'html') {
   const plugins = {
     css: parserCSS,
     html: parserHTML,
     babel: parserBabel,
   }
+  try {
+    return await prettier.format(content || '', {
+      parser: type,
+      plugins: [plugins[type]],
+      singleQuote: true,
+      semi: false,
+    })
+  }
+  catch (e: any) {
+    console.error(e)
+    return `/* Error on prettifying: ${e.message} */\n${content || ''}`
+  }
+}
+
+export function usePrettify(content: MaybeRefOrGetter<string | undefined>, toggle: MaybeRefOrGetter<boolean>, type: 'css' | 'babel' | 'html') {
   return computedAsync(async () => {
     if (!toValue(toggle))
       return toValue(content) || '/* empty */'
 
-    try {
-      return await prettier.format(toValue(content) || '', {
-        parser: type,
-        plugins: [plugins[type]],
-        singleQuote: true,
-        semi: false,
-      })
-    }
-    catch (e: any) {
-      console.error(e)
-      return `/* Error on prettifying: ${e.message} */\n${toValue(content) || ''}`
-    }
+    return prettify(toValue(content), type)
   })
 }
 

--- a/playground/src/composables/prettier.ts
+++ b/playground/src/composables/prettier.ts
@@ -1,15 +1,15 @@
-import { useCSSPrettify, useHTMLPrettify, useJSPrettify } from '../../../packages-integrations/inspector/client/composables/usePrettify'
+import { prettify, useCSSPrettify } from '../../../packages-integrations/inspector/client/composables/usePrettify'
 
-export function formatHTML() {
-  inputHTML.value = useHTMLPrettify(options.value.transformHtml ? transformedHTML : inputHTML).value
+export async function formatHTML() {
+  inputHTML.value = await prettify(toValue(options.value.transformHtml ? transformedHTML : inputHTML), 'html')
 }
 
-export function formatConfig() {
-  customConfigRaw.value = useJSPrettify(customConfigRaw).value
+export async function formatConfig() {
+  customConfigRaw.value = await prettify(customConfigRaw.value, 'babel')
 }
 
-export function formatCSS() {
-  customCSS.value = useCSSPrettify(options.value.transformCustomCSS ? transformedCSS : customCSS).value
+export async function formatCSS() {
+  customCSS.value = await prettify(toValue(options.value.transformCustomCSS ? transformedCSS : customCSS), 'css')
 }
 
 export const isCSSPrettify = ref(false)


### PR DESCRIPTION
## Summary

This PR fixes the playground's **Format** buttons, and removes two `use*Prettify` wrappers that no longer have callers.