### PR TITLE
fix(examples): disable hmrTopLevelAwait in the sveltekit example

### DIFF
--- a/examples/sveltekit/vite.config.ts
+++ b/examples/sveltekit/vite.config.ts
@@ -4,7 +4,11 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [
-    UnoCSS(),
+    UnoCSS({
+      // top-level await in the HMR code crashes WebKit builds without the fix
+      // for https://bugs.webkit.org/show_bug.cgi?id=242740 (see #5007)
+      hmrTopLevelAwait: false,
+    }),
     sveltekit(),
   ],
 })


### PR DESCRIPTION
Fixes the sveltekit example on WebKit engines that haven't shipped the 242740 fix. Mechanism in https://github.com/unocss/unocss/issues/5007#issuecomment-5095849100. Verified the served `/__uno.css` no longer contains a top-level await.
