### PR TITLE
ci: add core benchmark reporting

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,79 @@
+name: Core benchmark
+
+on:
+  push:
+    branches:
+      - main
+    paths: &core-paths
+      - packages-engine/core/**
+      - scripts/benchmark-summary.mjs
+      - vitest.config.ts
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - .github/workflows/benchmark.yml
+  pull_request:
+    branches:
+      - main
+    paths: *core-paths
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install
+
+      - name: Build core
+        run: pnpm --filter @unocss/core build
+
+      - name: Run core benchmarks
+        run: |
+          mkdir -p .bench/current
+          pnpm exec vitest bench packages-engine/core/test --run --project unit --outputJson .bench/current/core-bench.json
+
+      - name: Locate base benchmark
+        id: base
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          run_id="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${BASE_SHA}&status=success&per_page=100" --jq '.workflow_runs[] | select(.name == "Core benchmark") | .id' | head -n 1 || true)"
+          echo "run-id=${run_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Download base benchmark
+        if: steps.base.outputs.run-id != ''
+        uses: actions/download-artifact@v7
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.base.outputs.run-id }}
+          name: core-benchmark-${{ github.event.pull_request.base.sha }}
+          path: .bench/base
+
+      - name: Write benchmark summary
+        run: |
+          if [ -f .bench/base/core-bench.json ]; then
+            node scripts/benchmark-summary.mjs .bench/current/core-bench.json .bench/base/core-bench.json
+          else
+            node scripts/benchmark-summary.mjs .bench/current/core-bench.json
+          fi
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: core-benchmark-${{ github.sha }}
+          path: .bench/current/core-bench.json

--- a/packages-engine/core/package.json
+++ b/packages-engine/core/package.json
@@ -33,7 +33,7 @@
     "dist"
   ],
   "scripts": {
-    "bench": "pnpm --dir ../.. exec vitest bench packages-engine/core/test/generate.bench.ts --run --project unit",
+    "bench": "pnpm --dir ../.. exec vitest bench packages-engine/core/test --run --project unit",
     "build": "tsdown",
     "dev": "tsdown --watch"
   },

--- a/packages-engine/core/test/core.bench.ts
+++ b/packages-engine/core/test/core.bench.ts
@@ -1,0 +1,100 @@
+import { createGenerator, resolveConfig } from '@unocss/core'
+import { bench, describe } from 'vitest'
+import {
+  customRuleProfile,
+  customRuleToken,
+  defaultProfile,
+  extractionSource,
+  variantProfile,
+  variantToken,
+  workloads,
+} from './performance-fixtures'
+
+const defaultGenerator = await createGenerator(defaultProfile)
+const variantGenerator = await createGenerator(variantProfile)
+await defaultGenerator.parseToken('matched-1')
+
+describe('configuration resolution', () => {
+  bench('default profile', async () => {
+    void (await resolveConfig(defaultProfile)).rulesSize
+  })
+
+  bench('variant-heavy profile', async () => {
+    void (await resolveConfig(variantProfile)).rulesSize
+  })
+
+  bench('custom-rule profile', async () => {
+    void (await resolveConfig(customRuleProfile)).rulesSize
+  })
+})
+
+describe('extraction', () => {
+  bench('typical workload', async () => {
+    void (await defaultGenerator.applyExtractors(extractionSource)).size
+  })
+})
+
+describe('token parsing', () => {
+  bench('cold generator and default token', async () => {
+    const generator = await createGenerator(defaultProfile)
+    void (await generator.parseToken('matched-1'))?.length
+  })
+
+  bench('warm default token', async () => {
+    void (await defaultGenerator.parseToken('matched-1'))?.length
+  })
+
+  bench('variant-heavy token', async () => {
+    const generator = await createGenerator(variantProfile)
+    void (await generator.parseToken(variantToken))?.length
+  })
+
+  bench('custom-rule token', async () => {
+    const generator = await createGenerator(customRuleProfile)
+    void (await generator.parseToken(customRuleToken))?.length
+  })
+})
+
+describe('variant matching', () => {
+  bench('variant-heavy token', async () => {
+    void (await variantGenerator.matchVariants(variantToken)).length
+  })
+})
+
+describe('generation', () => {
+  for (const [name, tokens] of Object.entries(workloads)) {
+    bench(`default profile, ${name} workload`, async () => {
+      const generator = await createGenerator(defaultProfile)
+      const result = await generator.generate(tokens, { preflights: false, safelist: false })
+      void result.matched.size
+    })
+
+    bench(`variant-heavy profile, ${name} workload`, async () => {
+      const generator = await createGenerator(variantProfile)
+      const result = await generator.generate(
+        tokens.map(token => token.startsWith('matched-') ? `hover:${token}` : token),
+        { preflights: false, safelist: false },
+      )
+      void result.matched.size
+    })
+
+    bench(`custom-rule profile, ${name} workload`, async () => {
+      const generator = await createGenerator(customRuleProfile)
+      const result = await generator.generate(
+        tokens.map(token => token.startsWith('matched-') ? token.replace('matched-', 'value-') : token),
+        { preflights: false, safelist: false },
+      )
+      void result.matched.size
+    })
+  }
+})
+
+describe('generation with css serialization', () => {
+  for (const [name, tokens] of Object.entries(workloads)) {
+    bench(name, async () => {
+      const generator = await createGenerator(defaultProfile)
+      const result = await generator.generate(tokens, { safelist: false })
+      void result.css.length
+    })
+  }
+})

--- a/packages-engine/core/test/performance-fixtures.test.ts
+++ b/packages-engine/core/test/performance-fixtures.test.ts
@@ -1,0 +1,80 @@
+import { createGenerator } from '@unocss/core'
+import { describe, expect, it } from 'vitest'
+import {
+  customRuleProfile,
+  customRuleToken,
+  defaultProfile,
+  variantProfile,
+  variantToken,
+  workloads,
+} from './performance-fixtures'
+
+async function expectWorkloadResult(
+  config: typeof defaultProfile,
+  tokens: string[],
+  expectedTokens: string[],
+  rule: (token: string) => string,
+) {
+  const uno = await createGenerator(config)
+  const result = await uno.generate(tokens, { preflights: false, safelist: false })
+
+  expect([...result.matched]).toEqual(expectedTokens)
+  expect(result.css).toBe([
+    '/* layer: default */',
+    ...expectedTokens
+      .toSorted()
+      .map(rule),
+  ].join('\n'))
+}
+
+describe('performance fixtures', () => {
+  it('generates the expected default-profile output for each workload', async () => {
+    for (const tokens of Object.values(workloads)) {
+      const expectedTokens = tokens.filter(token => token.startsWith('matched-'))
+      await expectWorkloadResult(
+        defaultProfile,
+        tokens,
+        expectedTokens,
+        token => `.${token}{--matched:${token.slice('matched-'.length)};}`,
+      )
+    }
+  })
+
+  it('generates the expected variant-profile output for each workload', async () => {
+    for (const tokens of Object.values(workloads)) {
+      const variantTokens = tokens.map(token => token.startsWith('matched-') ? `hover:${token}` : token)
+      const expectedTokens = variantTokens.filter(token => token.startsWith('hover:matched-'))
+      await expectWorkloadResult(
+        variantProfile,
+        variantTokens,
+        expectedTokens,
+        token => `.hover\\:${token.slice('hover:'.length)}:hover{--matched:${token.slice('hover:matched-'.length)};}`,
+      )
+    }
+  })
+
+  it('generates the expected custom-rule output for each workload', async () => {
+    for (const tokens of Object.values(workloads)) {
+      const customRuleTokens = tokens.map(token => token.startsWith('matched-') ? token.replace('matched-', 'value-') : token)
+      const expectedTokens = customRuleTokens.filter(token => token.startsWith('value-'))
+      await expectWorkloadResult(
+        customRuleProfile,
+        customRuleTokens,
+        expectedTokens,
+        token => `.${token}{--value:${token.slice('value-'.length)};}`,
+      )
+    }
+  })
+
+  it('generates the expected individual variant and custom rule output', async () => {
+    const variantGenerator = await createGenerator(variantProfile)
+    const variantResult = await variantGenerator.generate([variantToken], { preflights: false, safelist: false })
+    expect([...variantResult.matched]).toEqual([variantToken])
+    expect(variantResult.css).toBe('/* layer: default */\n.hover\\:matched-1:hover{--matched:1;}')
+
+    const customRuleGenerator = await createGenerator(customRuleProfile)
+    const customRuleResult = await customRuleGenerator.generate([customRuleToken], { preflights: false, safelist: false })
+    expect([...customRuleResult.matched]).toEqual([customRuleToken])
+    expect(customRuleResult.css).toBe('/* layer: default */\n.value-1{--value:1;}')
+  })
+})

--- a/packages-engine/core/test/performance-fixtures.ts
+++ b/packages-engine/core/test/performance-fixtures.ts
@@ -1,0 +1,59 @@
+import type { DynamicRule, UserConfig } from '@unocss/core'
+
+const matchedToken = (index: number) => `matched-${index}`
+
+function createTokens(size: number) {
+  const matchedCount = Math.max(1, Math.floor(size * 0.1))
+  return Array.from(
+    { length: size },
+    (_, index) => index < matchedCount ? matchedToken(index) : `candidate-${index}`,
+  )
+}
+
+const dynamicRule: DynamicRule = [/^matched-(\d+)$/, ([, index]) => ({ '--matched': index })]
+
+export const workloads = {
+  typical: createTokens(2_000),
+  large: createTokens(25_000),
+}
+
+export const extractionSource = workloads.typical.join(' ')
+
+export const defaultProfile: UserConfig = {
+  rules: [
+    ['static-token', { color: 'red' }],
+    dynamicRule,
+  ],
+  preflights: [
+    {
+      getCSS: () => '*,::before{box-sizing:border-box}',
+    },
+  ],
+}
+
+export const variantProfile: UserConfig = {
+  ...defaultProfile,
+  variants: [
+    {
+      match: (matcher) => {
+        if (!matcher.startsWith('hover:'))
+          return
+        return {
+          matcher: matcher.slice('hover:'.length),
+          selector: selector => `${selector}:hover`,
+        }
+      },
+    },
+  ],
+}
+
+export const customRuleProfile: UserConfig = {
+  ...defaultProfile,
+  rules: [
+    dynamicRule,
+    [/^value-(\d+)$/, ([, index]: RegExpMatchArray) => ({ '--value': index })],
+  ],
+}
+
+export const variantToken = 'hover:matched-1'
+export const customRuleToken = 'value-1'

--- a/scripts/benchmark-summary.mjs
+++ b/scripts/benchmark-summary.mjs
@@ -1,0 +1,50 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import process from 'node:process'
+
+const [currentPath, basePath] = process.argv.slice(2)
+
+if (!currentPath)
+  throw new Error('Usage: benchmark-summary.mjs <current-result> [base-result]')
+
+function collectBenchmarks(result) {
+  return new Map(result.files.flatMap(file => file.groups.flatMap(group => group.benchmarks.map(benchmark => [
+    `${group.fullName} > ${benchmark.name}`,
+    benchmark.median,
+  ]))))
+}
+
+function formatMilliseconds(milliseconds) {
+  if (milliseconds < 1)
+    return `${(milliseconds * 1_000).toFixed(2)} µs`
+  return `${milliseconds.toFixed(2)} ms`
+}
+
+function formatDelta(current, base) {
+  if (base == null)
+    return 'No baseline'
+
+  const delta = ((current - base) / base) * 100
+  return `${delta > 0 ? '+' : ''}${delta.toFixed(1)}%`
+}
+
+const current = collectBenchmarks(JSON.parse(await readFile(currentPath, 'utf8')))
+const base = basePath ? collectBenchmarks(JSON.parse(await readFile(basePath, 'utf8'))) : undefined
+const rows = [...current]
+  .sort(([left], [right]) => left.localeCompare(right))
+  .map(([name, median]) => `| ${name} | ${formatMilliseconds(median)} | ${formatDelta(median, base?.get(name))} |`)
+
+const summary = [
+  '## Core benchmark',
+  '',
+  base ? 'Compared with the pull request base commit.' : 'No baseline result is available for this commit.',
+  '',
+  '| Benchmark | Median | Change |',
+  '| --- | ---: | ---: |',
+  ...rows,
+  '',
+].join('\n')
+
+if (process.env.GITHUB_STEP_SUMMARY)
+  await writeFile(process.env.GITHUB_STEP_SUMMARY, summary, { flag: 'a' })
+else
+  process.stdout.write(summary)


### PR DESCRIPTION
## What changes

This PR establishes a repeatable performance loop for `@unocss/core`. It adds deterministic benchmarks and report-only CI output without changing the core runtime behavior.

## Benchmark coverage

- configuration resolution for default, variant-heavy, and custom-rule profiles
- extraction, cold and warm token parsing, and variant matching
- generation for deterministic 2,000- and 25,000-token workloads
- generation with CSS serialization
- exact-output fixture tests for every workload and profile

## CI reporting

A dedicated Ubuntu/Node 22 workflow runs only for core-related changes. It builds `@unocss/core`, writes the current Vitest JSON artifact, downloads the pull request base artifact when available, and adds median timings plus deltas to the job summary. Missing base artifacts report absolute timings without failing the workflow.