### PR TITLE
feat(reset, preset-wind4): port new tailwind changes

### DIFF
--- a/packages-presets/preset-wind4/src/preflights/reset.ts
+++ b/packages-presets/preset-wind4/src/preflights/reset.ts
@@ -43,8 +43,13 @@ html,
   tab-size: 4; /* 3 */
   font-family: var(
     --default-font-family,
-    ui-sans-serif,
-    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    'Noto Sans',
+    Arial,
     sans-serif,
     'Apple Color Emoji',
     'Segoe UI Emoji',
@@ -181,7 +186,7 @@ table {
   Use the modern Firefox focus style for all focusable elements.
 */
 
-:-moz-focusring {
+:-moz-focusring:where(:not(iframe)) {
   outline: auto;
 }
 

--- a/packages-presets/reset/tailwind-v4.css
+++ b/packages-presets/reset/tailwind-v4.css
@@ -31,7 +31,8 @@ html,
   -webkit-text-size-adjust: 100%; /* 2 */
   tab-size: 4; /* 3 */
   font-family:
-    ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", Arial,
+    sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol", "Noto Color Emoji"; /* 4 */
   font-feature-settings: normal; /* 5 */
   font-variation-settings: normal; /* 6 */
@@ -155,7 +156,7 @@ table {
   Use the modern Firefox focus style for all focusable elements.
 */
 
-:-moz-focusring {
+:-moz-focusring:where(:not(iframe)) {
   outline: auto;
 }
 

--- a/test/assets/output/preset-wind4-reset.css
+++ b/test/assets/output/preset-wind4-reset.css
@@ -40,8 +40,13 @@ html,
   tab-size: 4; /* 3 */
   font-family: var(
     --default-font-family,
-    ui-sans-serif,
-    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    'Noto Sans',
+    Arial,
     sans-serif,
     'Apple Color Emoji',
     'Segoe UI Emoji',
@@ -178,7 +183,7 @@ table {
   Use the modern Firefox focus style for all focusable elements.
 */
 
-:-moz-focusring {
+:-moz-focusring:where(:not(iframe)) {
   outline: auto;
 }
 


### PR DESCRIPTION
Port two changes from Tailwind to the `tailwind-v4` reset:

https://github.com/tailwindlabs/tailwindcss/pull/20292
https://github.com/tailwindlabs/tailwindcss/pull/20318

Note the latter changes the default font stack to fix inappropriate use of `system-ui`, which could change the appearance on existing sites depending on their configuration.