### PR TITLE
perf(core): optimize token parse batching

### DIFF
--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -17,11 +17,9 @@ export const symbols: ControlSymbols = {
   body: '$$symbol-body' as unknown as ControlSymbols['body'],
 }
 
-// Chosen from benchmarks on a 24k-token project: 4096 retained most of the
-// benefit of smaller batches, outperformed 8192, and keeps smaller generations
-// on the existing single-batch path. This limits event-loop pressure rather
-// than CPU parallelism, so it is intentionally not based on the CPU count.
-const TOKEN_PARSE_BATCH_SIZE = 4096
+// This limits event-loop pressure rather than CPU parallelism, so it is
+// intentionally not based on the CPU count.
+const TOKEN_PARSE_BATCH_SIZE = 1024
 
 class TokenProcessor<Theme extends object> {
   private cache = new Map<string, StringifiedUtil<Theme>[] | null>()
@@ -322,9 +320,11 @@ class UnoGeneratorInternal<Theme extends object = object> {
 
     const tokenList = Array.from(tokens)
     for (let offset = 0; offset < tokenList.length; offset += TOKEN_PARSE_BATCH_SIZE) {
-      await Promise.all(tokenList
-        .slice(offset, offset + TOKEN_PARSE_BATCH_SIZE)
-        .map(async (raw) => {
+      const batchSize = Math.min(TOKEN_PARSE_BATCH_SIZE, tokenList.length - offset)
+      const tokenPromises: Promise<void>[] = []
+      for (let index = 0; index < batchSize; index++) {
+        const raw = tokenList[offset + index]
+        tokenPromises[index] = (async () => {
           if (matched.has(raw))
             return
 
@@ -351,7 +351,9 @@ class UnoGeneratorInternal<Theme extends object = object> {
             if (layer)
               layerSet.add(layer)
           }
-        }))
+        })()
+      }
+      await Promise.all(tokenPromises)
     }
     await (async () => {
       if (!preflights)

--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -17,9 +17,11 @@ export const symbols: ControlSymbols = {
   body: '$$symbol-body' as unknown as ControlSymbols['body'],
 }
 
-// This limits event-loop pressure rather than CPU parallelism, so it is
-// intentionally not based on the CPU count.
-const TOKEN_PARSE_BATCH_SIZE = 1024
+// Chosen from benchmarks on a 24k-token project: 4096 retained most of the
+// benefit of smaller batches, outperformed 8192, and keeps smaller generations
+// on the existing single-batch path. This limits event-loop pressure rather
+// than CPU parallelism, so it is intentionally not based on the CPU count.
+const TOKEN_PARSE_BATCH_SIZE = 4096
 
 class TokenProcessor<Theme extends object> {
   private cache = new Map<string, StringifiedUtil<Theme>[] | null>()

--- a/packages-engine/core/test/rule-async.test.ts
+++ b/packages-engine/core/test/rule-async.test.ts
@@ -44,3 +44,26 @@ it('preflight at the end', async () => {
   await uno.generate('rule')
   expect(order).eql([1, 2])
 })
+
+it('waits for a token batch before parsing the next batch', async () => {
+  let firstBatchFinished = false
+  const uno = await createGenerator({
+    rules: [
+      [/^token-(\d+)$/, async ([, index]) => {
+        if (index === '0') {
+          await new Promise(resolve => setTimeout(resolve, 0))
+          firstBatchFinished = true
+        }
+        else if (index === '1024') {
+          expect(firstBatchFinished).toBe(true)
+        }
+        return { color: index }
+      }],
+    ],
+  })
+
+  const tokens = Array.from({ length: 1025 }, (_, index) => `token-${index}`)
+  const result = await uno.generate(tokens, { preflights: false })
+
+  expect(result.matched.size).toBe(tokens.length)
+})

--- a/packages-engine/core/test/rule-async.test.ts
+++ b/packages-engine/core/test/rule-async.test.ts
@@ -54,7 +54,7 @@ it('waits for a token batch before parsing the next batch', async () => {
           await new Promise(resolve => setTimeout(resolve, 0))
           firstBatchFinished = true
         }
-        else if (index === '1024') {
+        else if (index === '4096') {
           expect(firstBatchFinished).toBe(true)
         }
         return { color: index }
@@ -62,7 +62,7 @@ it('waits for a token batch before parsing the next batch', async () => {
     ],
   })
 
-  const tokens = Array.from({ length: 1025 }, (_, index) => `token-${index}`)
+  const tokens = Array.from({ length: 4097 }, (_, index) => `token-${index}`)
   const result = await uno.generate(tokens, { preflights: false })
 
   expect(result.matched.size).toBe(tokens.length)


### PR DESCRIPTION
## Summary

Reduce token parsing allocation overhead without changing batch scheduling behavior.

## Changes

- Build each token parse promise batch by index instead of allocating a `slice()` and mapped array.
- Retain the 4,096-token batch boundary to preserve async parse completion order and generated CSS declaration order.
- Add a boundary regression test for the 4,097th token.

## Performance impact

The token parser remains `O(n)`. This change removes per-batch token-array copying and mapping, reducing allocation and callback overhead while preserving the established batching semantics.