### PR TITLE
perf(core): avoid blocklist allocation

### DIFF
--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -72,9 +72,16 @@ class TokenProcessor<Theme extends object> {
   }
 
   isBlocked(raw: string, blocklist: BlocklistRule[]) {
-    return !raw || blocklist
-      .map(e => Array.isArray(e) ? e[0] : e)
-      .some(e => typeof e === 'function' ? e(raw) : isString(e) ? e === raw : e.test(raw))
+    if (!raw)
+      return true
+
+    for (const rule of blocklist) {
+      const value = Array.isArray(rule) ? rule[0] : rule
+      if (typeof value === 'function' ? value(raw) : isString(value) ? value === raw : value.test(raw))
+        return true
+    }
+
+    return false
   }
 
   getBlocked(raw: string, blocklist: BlocklistRule[]) {

--- a/packages-engine/core/test/blocklist.test.ts
+++ b/packages-engine/core/test/blocklist.test.ts
@@ -3,6 +3,28 @@ import presetWind3 from '@unocss/preset-wind3'
 import { describe, expect, it } from 'vitest'
 
 describe('blocklist', () => {
+  it('matches each rule type, including metadata tuples', async () => {
+    const uno = await createGenerator({
+      blocklist: [
+        'string-rule',
+        /^regexp-/,
+        token => token === 'function-rule',
+        ['tuple-string', { message: 'string metadata' }],
+        [/^tuple-regexp-/, { message: 'regexp metadata' }],
+        [token => token === 'tuple-function', { message: 'function metadata' }],
+      ],
+    })
+
+    expect(uno.isBlocked('')).toBe(true)
+    expect(uno.isBlocked('string-rule')).toBe(true)
+    expect(uno.isBlocked('regexp-rule')).toBe(true)
+    expect(uno.isBlocked('function-rule')).toBe(true)
+    expect(uno.isBlocked('tuple-string')).toBe(true)
+    expect(uno.isBlocked('tuple-regexp-rule')).toBe(true)
+    expect(uno.isBlocked('tuple-function')).toBe(true)
+    expect(uno.isBlocked('allowed-rule')).toBe(false)
+  })
+
   it('basic', async () => {
     const uno = await createGenerator({
       presets: [


### PR DESCRIPTION
## Summary

Reduce allocation overhead during blocklist matching.

## Changes

- Replace the allocating `map(...).some(...)` chain with a direct early-return loop.
- Preserve string, regular expression, function, and metadata-tuple blocklist rules.
- Add regression coverage for each supported rule type and empty tokens.

## Performance impact

Worst-case matching remains `O(b)` for `b` blocklist rules. The direct loop eliminates the prior `O(b)` intermediate array allocation and stops immediately when a rule matches.