### PR TITLE
fix(vscode): fix extension publish by renaming after build

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/packages-integrations/vscode"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/packages-integrations/vscode/dist/**/*.js"
+      ]
+    }
+  ]
+}

--- a/packages-integrations/vscode/package.json
+++ b/packages-integrations/vscode/package.json
@@ -146,11 +146,11 @@
   },
   "scripts": {
     "build": "pnpm run update && tsdown",
-    "dev": "tsx ./scripts/dev.ts && tsdown --watch src",
+    "dev": "tsx ./scripts/dev.ts",
     "publish": "tsx ./scripts/publish.ts",
     "prepare": "nr update",
     "update": "vscode-ext-gen --scope=unocss --output src/generated/meta.ts",
-    "pack": "npx @vscode/vsce package --no-dependencies"
+    "pack": "tsx ./scripts/pack.ts"
   },
   "devDependencies": {
     "@types/vscode": "^1.96.0",

--- a/packages-integrations/vscode/scripts/dev.ts
+++ b/packages-integrations/vscode/scripts/dev.ts
@@ -1,15 +1,28 @@
-import fs from 'fs-extra'
+import process from 'node:process'
+import { execa } from 'execa'
+import { readPackage, vscodeRoot, withTempName } from './utils'
 
-async function run() {
+async function dev() {
   // Change package.json name to "unocss" temporary
   // as VS Code will append it with the publisher, causing the dev extension fail to override the production extension.
-  const json = await fs.readJSON(new URL('../package.json', import.meta.url))
-  if (json.name !== 'unocss') {
-    json.name = 'unocss'
-    await fs.writeJSON(new URL('../package.json', import.meta.url), json, { spaces: 2, EOL: '\n' })
-
+  const { rawJSON, pkg } = await readPackage()
+  if (pkg.name !== 'unocss')
     console.log('Update package.json name to "unocss"')
-  }
+
+  await withTempName(rawJSON, async () => {
+    const child = execa('tsdown', ['--watch', 'src'], { cwd: vscodeRoot, stdio: 'inherit' })
+
+    for (const signal of ['SIGINT', 'SIGTERM'] as const)
+      process.once(signal, () => child.kill(signal))
+
+    try {
+      await child
+    }
+    catch (error) {
+      if (!(error instanceof Error) || !('signal' in error))
+        throw error
+    }
+  })
 }
 
-run()
+await dev()

--- a/packages-integrations/vscode/scripts/pack.ts
+++ b/packages-integrations/vscode/scripts/pack.ts
@@ -1,0 +1,11 @@
+import { execa } from 'execa'
+import { readPackage, vscodeRoot, withTempName } from './utils'
+
+async function pack() {
+  const { rawJSON } = await readPackage()
+  await withTempName(rawJSON, async () => {
+    await execa('npx', ['@vscode/vsce', 'package', '--no-dependencies'], { cwd: vscodeRoot, stdio: 'inherit' })
+  })
+}
+
+await pack()

--- a/packages-integrations/vscode/scripts/publish.ts
+++ b/packages-integrations/vscode/scripts/publish.ts
@@ -1,35 +1,23 @@
 import process from 'node:process'
-import { dirname, join } from 'path'
-import { fileURLToPath } from 'url'
 import { execa } from 'execa'
-import fs from 'fs-extra'
-
-const dir = typeof __dirname === 'string' ? __dirname : dirname(fileURLToPath(import.meta.url))
-const root = dirname(dir)
+import { readPackage, vscodeRoot, withTempName } from './utils'
 
 async function publish() {
-  const pkgPath = join(root, 'package.json')
-  const rawJSON = await fs.readFile(pkgPath, 'utf-8')
-  const pkg = JSON.parse(rawJSON)
+  const { rawJSON, pkg } = await readPackage()
   if (!/^[\d.]+$/.test(pkg.version)) {
     console.warn(`VS Code release skipped because the version ${pkg.version} is not a stable release.`)
     return
   }
-  pkg.name = 'unocss'
-  await fs.writeJSON(pkgPath, pkg, { spaces: 2 })
 
-  await execa('npm', ['run', 'build'], { cwd: root, stdio: 'inherit' })
+  await execa('npm', ['run', 'build'], { cwd: vscodeRoot, stdio: 'inherit' })
 
-  try {
+  await withTempName(rawJSON, async () => {
     console.log('\nPublish to VSCE...\n')
-    await execa('npx', ['@vscode/vsce', 'publish', '--no-dependencies', '-p', process.env.VSCE_TOKEN!], { cwd: root, stdio: 'inherit' })
+    await execa('npx', ['@vscode/vsce', 'publish', '--no-dependencies', '-p', process.env.VSCE_TOKEN!], { cwd: vscodeRoot, stdio: 'inherit' })
 
     console.log('\nPublish to OVSE...\n')
-    await execa('npx', ['ovsx', 'publish', '--no-dependencies', '-p', process.env.OVSX_TOKEN!], { cwd: root, stdio: 'inherit' })
-  }
-  finally {
-    await fs.writeFile(pkgPath, rawJSON, 'utf-8')
-  }
+    await execa('npx', ['ovsx', 'publish', '--no-dependencies', '-p', process.env.OVSX_TOKEN!], { cwd: vscodeRoot, stdio: 'inherit' })
+  })
 }
 
-publish()
+await publish()

--- a/packages-integrations/vscode/scripts/utils.ts
+++ b/packages-integrations/vscode/scripts/utils.ts
@@ -1,0 +1,26 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+const dir = typeof __dirname === 'string' ? __dirname : dirname(fileURLToPath(import.meta.url))
+export const vscodeRoot = dirname(dir)
+
+export async function readPackage() {
+  const pkgPath = join(vscodeRoot, 'package.json')
+  const rawJSON = await readFile(pkgPath, 'utf-8')
+  return { pkgPath, rawJSON, pkg: JSON.parse(rawJSON) }
+}
+
+export async function withTempName<T>(rawJSON: string, fn: () => Promise<T>): Promise<T> {
+  const pkgPath = join(vscodeRoot, 'package.json')
+  const pkg = JSON.parse(rawJSON)
+  pkg.name = 'unocss'
+  await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`, 'utf-8')
+
+  try {
+    return await fn()
+  }
+  finally {
+    await writeFile(pkgPath, rawJSON, 'utf-8')
+  }
+}


### PR DESCRIPTION
`verifyDepsBeforeRun: install` option (enabled by default in v11) triggers an install and writes back `@unocss/vscode` before publishing, which broke the VS Code extension's release.

Also share rename helpers across dev/pack/publish and add launch config.