### PR TITLE
fix(vite): use internal virtual CSS ids

### DIFF
--- a/packages-integrations/vite/src/modes/per-module.ts
+++ b/packages-integrations/vite/src/modes/per-module.ts
@@ -6,6 +6,7 @@ import { resolveId, resolveLayer } from '#integration/layers'
 import { getPath } from '#integration/utils'
 
 const VIRTUAL_PREFIX = '/@unocss/'
+const VIRTUAL_ID_PREFIX = '\0/@unocss/'
 const SCOPE_IMPORT_RE = / from (['"])(@unocss\/scope)\1/
 
 export function PerModuleModePlugin(ctx: UnocssPluginContext): Plugin[] {
@@ -15,7 +16,7 @@ export function PerModuleModePlugin(ctx: UnocssPluginContext): Plugin[] {
   const invalidate = (hash: string) => {
     if (!server)
       return
-    const id = `${VIRTUAL_PREFIX}${hash}.css`
+    const id = `${VIRTUAL_ID_PREFIX}${hash}.css`
     const mod = server.moduleGraph.getModuleById(id)
     if (!mod)
       return
@@ -23,8 +24,8 @@ export function PerModuleModePlugin(ctx: UnocssPluginContext): Plugin[] {
     server.ws.send({
       type: 'update',
       updates: [{
-        acceptedPath: id,
-        path: id,
+        acceptedPath: `${VIRTUAL_PREFIX}${hash}.css`,
+        path: `${VIRTUAL_PREFIX}${hash}.css`,
         timestamp: +Date.now(),
         type: 'js-update',
       }],
@@ -99,13 +100,16 @@ export function PerModuleModePlugin(ctx: UnocssPluginContext): Plugin[] {
         }
       },
       resolveId(id) {
-        return id.startsWith(VIRTUAL_PREFIX) ? id : null
+        if (id.startsWith(VIRTUAL_PREFIX))
+          return `${VIRTUAL_ID_PREFIX}${id.slice(VIRTUAL_PREFIX.length)}`
+        return id.startsWith(VIRTUAL_ID_PREFIX) ? id : null
       },
       load(id) {
-        if (!id.startsWith(VIRTUAL_PREFIX))
+        if (!id.startsWith(VIRTUAL_ID_PREFIX))
           return null
 
-        const hash = id.slice(VIRTUAL_PREFIX.length, -'.css'.length)
+        const path = getPath(id)
+        const hash = path.slice(VIRTUAL_ID_PREFIX.length, -'.css'.length)
 
         const [source, css] = moduleMap.get(hash) || []
 

--- a/test/virtual-modules.test.ts
+++ b/test/virtual-modules.test.ts
@@ -1,0 +1,28 @@
+import { resolve } from 'node:path'
+import UnoCSS from '@unocss/vite'
+import * as vite from 'vite'
+import { describe, expect, it } from 'vitest'
+
+describe('virtual module ids', () => {
+  it('keeps virtual CSS requests internal for Vite SSR', async () => {
+    const server = await vite.createServer({
+      root: resolve(import.meta.dirname, 'fixtures/vite'),
+      configFile: false,
+      logLevel: 'error',
+      server: { middlewareMode: true },
+      plugins: [UnoCSS({ configFile: false, inspector: false, mode: 'per-module' })],
+    })
+
+    try {
+      expect((await server.pluginContainer.resolveId('/__uno.css?inline'))?.id)
+        .toBe('\0__uno.css?inline')
+      expect((await server.pluginContainer.resolveId('virtual:uno.css'))?.id)
+        .toBe('\0__uno.css')
+      expect((await server.pluginContainer.resolveId('/@unocss/test.css?inline'))?.id)
+        .toBe('\0/@unocss/test.css?inline')
+    }
+    finally {
+      await server.close()
+    }
+  })
+})

--- a/virtual-shared/integration/src/context.ts
+++ b/virtual-shared/integration/src/context.ts
@@ -120,8 +120,8 @@ export function createContext<Config extends UserConfig<any> = UserConfig<any>>(
     if (vmpCache.has(prefix))
       return vmpCache.get(prefix)!
 
-    const RESOLVED_ID_WITH_QUERY_RE = new RegExp(`[/\\\\]${prefix}(_.*?)?\\.css(\\?.*)?$`)
-    const RESOLVED_ID_RE = new RegExp(`[/\\\\]${prefix}(?:_(.*?))?\.css$`)
+    const RESOLVED_ID_WITH_QUERY_RE = new RegExp(`(?:^|[/\\\\]|\\0)${prefix}(_.*?)?\\.css(\\?.*)?$`)
+    const RESOLVED_ID_RE = new RegExp(`(?:^|[/\\\\]|\\0)${prefix}(?:_(.*?))?\.css$`)
     const regexes = {
       prefix,
       RESOLVED_ID_WITH_QUERY_RE,

--- a/virtual-shared/integration/src/layers.ts
+++ b/virtual-shared/integration/src/layers.ts
@@ -6,6 +6,8 @@ export async function resolveId(ctx: UnocssPluginContext, id: string, importer?:
   const { RESOLVED_ID_WITH_QUERY_RE, prefix } = await ctx.getVMPRegexes()
 
   if (id.match(RESOLVED_ID_WITH_QUERY_RE)) {
+    if (id.startsWith(`/${prefix}`))
+      return `\0${id.slice(1)}`
     return id
   }
 
@@ -19,7 +21,7 @@ export async function resolveId(ctx: UnocssPluginContext, id: string, importer?:
       if (importer)
         virtual = resolve(importer, '..', virtual)
       else
-        virtual = `/${virtual}`
+        virtual = `\0${virtual}`
       return virtual
     }
   }


### PR DESCRIPTION
## Summary

Use `\0`-prefixed internal IDs for UnoCSS virtual stylesheets while keeping browser-facing module URLs unchanged. This lets Vite 8's SSR module runner load `virtual:uno.css?inline` instead of rejecting `/__uno.css?inline`, and applies the same handling to per-module CSS IDs.

## Validation

- official SolidStart reproduction: HTTP 500 before, HTTP 200 after
- virtual-module regression test
- Vite fixture test
- affected package builds and repository lint

Fixes #5271.