### PR TITLE
fix(presets): fix utilities misidentifying arbitrary length values as colors

### DIFF
--- a/packages-presets/preset-mini/src/_rules/behaviors.ts
+++ b/packages-presets/preset-mini/src/_rules/behaviors.ts
@@ -1,6 +1,6 @@
 import type { CSSObject, Rule, RuleContext } from '@unocss/core'
 import type { Theme } from '../theme'
-import { colorResolver, globalKeywords, h, isCSSMathFn } from '../utils'
+import { colorResolver, globalKeywords, h, isCSSLength } from '../utils'
 
 export const outline: Rule<Theme>[] = [
   // size
@@ -23,7 +23,7 @@ function handleWidth([, b]: string[], { theme }: RuleContext<Theme>): CSSObject 
 }
 
 function handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | undefined {
-  if (h.numberWithUnit(h.bracket(match[1])) != null || isCSSMathFn(h.bracket(match[1])))
+  if (isCSSLength(match[1]))
     return handleWidth(match, ctx)
   return colorResolver('outline-color', 'outline-color', 'borderColor')(match, ctx) as CSSObject | undefined
 }

--- a/packages-presets/preset-mini/src/_rules/behaviors.ts
+++ b/packages-presets/preset-mini/src/_rules/behaviors.ts
@@ -23,7 +23,7 @@ function handleWidth([, b]: string[], { theme }: RuleContext<Theme>): CSSObject 
 }
 
 function handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | undefined {
-  if (isCSSMathFn(h.bracket(match[1])))
+  if (h.numberWithUnit(h.bracket(match[1])) != null || isCSSMathFn(h.bracket(match[1])))
     return handleWidth(match, ctx)
   return colorResolver('outline-color', 'outline-color', 'borderColor')(match, ctx) as CSSObject | undefined
 }

--- a/packages-presets/preset-mini/src/_rules/border.ts
+++ b/packages-presets/preset-mini/src/_rules/border.ts
@@ -107,7 +107,7 @@ function handlerBorderSize([, a = '', b]: string[], { theme }: RuleContext<Theme
 
 function handlerBorderColorOrSize([, a = '', b]: string[], ctx: RuleContext<Theme>): CSSEntries | undefined {
   if (a in directionMap) {
-    if (isCSSMathFn(h.bracket(b)))
+    if (h.numberWithUnit(h.bracket(b)) != null || isCSSMathFn(h.bracket(b)))
       return handlerBorderSize(['', a, b], ctx)
     if (hasParseableColor(b, ctx.theme, 'borderColor')) {
       return Object.assign(

--- a/packages-presets/preset-mini/src/_rules/border.ts
+++ b/packages-presets/preset-mini/src/_rules/border.ts
@@ -2,7 +2,7 @@ import type { CSSEntries, CSSObject, Rule, RuleContext } from '@unocss/core'
 import type { CSSColorValue } from '@unocss/rule-utils'
 import type { Theme } from '../theme'
 import { colorOpacityToString, colorToString } from '@unocss/rule-utils'
-import { cornerMap, directionMap, globalKeywords, h, hasParseableColor, isCSSMathFn, parseColor } from '../utils'
+import { cornerMap, directionMap, globalKeywords, h, hasParseableColor, isCSSLength, parseColor } from '../utils'
 
 export const borderStyles = ['solid', 'dashed', 'dotted', 'double', 'hidden', 'none', 'groove', 'ridge', 'inset', 'outset', ...globalKeywords]
 
@@ -100,6 +100,9 @@ function borderColorResolver(direction: string) {
 }
 
 function handlerBorderSize([, a = '', b]: string[], { theme }: RuleContext<Theme>): CSSEntries | undefined {
+  if (b?.startsWith('#'))
+    return
+
   const v = theme.lineWidth?.[b || 'DEFAULT'] ?? h.bracket.cssvar.global.px(b || '1')
   if (a in directionMap && v != null)
     return directionMap[a].map(i => [`border${i}-width`, v])
@@ -107,7 +110,7 @@ function handlerBorderSize([, a = '', b]: string[], { theme }: RuleContext<Theme
 
 function handlerBorderColorOrSize([, a = '', b]: string[], ctx: RuleContext<Theme>): CSSEntries | undefined {
   if (a in directionMap) {
-    if (h.numberWithUnit(h.bracket(b)) != null || isCSSMathFn(h.bracket(b)))
+    if (isCSSLength(b))
       return handlerBorderSize(['', a, b], ctx)
     if (hasParseableColor(b, ctx.theme, 'borderColor')) {
       return Object.assign(

--- a/packages-presets/preset-mini/src/_rules/decoration.ts
+++ b/packages-presets/preset-mini/src/_rules/decoration.ts
@@ -30,7 +30,7 @@ function handleWidth([, b]: string[], { theme }: RuleContext<Theme>): CSSObject 
 }
 
 function handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | undefined {
-  if (isCSSMathFn(h.bracket(match[1])))
+  if (h.numberWithUnit(h.bracket(match[1])) != null || isCSSMathFn(h.bracket(match[1])))
     return handleWidth(match, ctx)
 
   const result = colorResolver('text-decoration-color', 'line', 'borderColor')(match, ctx) as CSSObject | undefined

--- a/packages-presets/preset-mini/src/_rules/decoration.ts
+++ b/packages-presets/preset-mini/src/_rules/decoration.ts
@@ -1,6 +1,6 @@
 import type { CSSObject, Rule, RuleContext } from '@unocss/core'
 import type { Theme } from '../theme'
-import { colorResolver, globalKeywords, h, isCSSMathFn } from '../utils'
+import { colorResolver, globalKeywords, h, isCSSLength } from '../utils'
 
 const decorationStyles = ['solid', 'double', 'dotted', 'dashed', 'wavy', ...globalKeywords]
 
@@ -30,7 +30,7 @@ function handleWidth([, b]: string[], { theme }: RuleContext<Theme>): CSSObject 
 }
 
 function handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | undefined {
-  if (h.numberWithUnit(h.bracket(match[1])) != null || isCSSMathFn(h.bracket(match[1])))
+  if (isCSSLength(match[1]))
     return handleWidth(match, ctx)
 
   const result = colorResolver('text-decoration-color', 'line', 'borderColor')(match, ctx) as CSSObject | undefined

--- a/packages-presets/preset-mini/src/_rules/svg.ts
+++ b/packages-presets/preset-mini/src/_rules/svg.ts
@@ -40,7 +40,7 @@ function handleWidth([, b]: string[], { theme }: RuleContext<Theme>): CSSObject 
 }
 
 function handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | undefined {
-  if (isCSSMathFn(h.bracket(match[1])))
+  if (h.numberWithUnit(h.bracket(match[1])) != null || isCSSMathFn(h.bracket(match[1])))
     return handleWidth(match, ctx)
   return colorResolver('stroke', 'stroke', 'borderColor')(match, ctx) as CSSObject | undefined
 }

--- a/packages-presets/preset-mini/src/_rules/svg.ts
+++ b/packages-presets/preset-mini/src/_rules/svg.ts
@@ -1,6 +1,6 @@
 import type { CSSObject, Rule, RuleContext } from '@unocss/core'
 import type { Theme } from '../theme'
-import { colorResolver, h, isCSSMathFn } from '../utils'
+import { colorResolver, h, isCSSLength } from '../utils'
 
 export const svgUtilities: Rule<Theme>[] = [
   // fills
@@ -40,7 +40,7 @@ function handleWidth([, b]: string[], { theme }: RuleContext<Theme>): CSSObject 
 }
 
 function handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | undefined {
-  if (h.numberWithUnit(h.bracket(match[1])) != null || isCSSMathFn(h.bracket(match[1])))
+  if (isCSSLength(match[1]))
     return handleWidth(match, ctx)
   return colorResolver('stroke', 'stroke', 'borderColor')(match, ctx) as CSSObject | undefined
 }

--- a/packages-presets/preset-mini/src/_rules/typography.ts
+++ b/packages-presets/preset-mini/src/_rules/typography.ts
@@ -141,7 +141,7 @@ function handleSize([, s]: string[], { theme }: RuleContext<Theme>): CSSObject |
 }
 
 function handlerColorOrSize(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | undefined {
-  if (isCSSMathFn(h.bracket(match[1])))
+  if (h.numberWithUnit(h.bracket(match[1])) != null || isCSSMathFn(h.bracket(match[1])))
     return handleSize(match, ctx)
   return colorResolver('color', 'text', 'textColor')(match, ctx) as CSSObject | undefined
 }

--- a/packages-presets/preset-mini/src/_rules/typography.ts
+++ b/packages-presets/preset-mini/src/_rules/typography.ts
@@ -1,7 +1,7 @@
 import type { CSSObject, Rule, RuleContext } from '@unocss/core'
 import type { Theme } from '../theme'
 import { toArray } from '@unocss/core'
-import { colorableShadows, colorResolver, globalKeywords, h, isCSSMathFn, splitShorthand } from '../utils'
+import { colorableShadows, colorResolver, globalKeywords, h, isCSSLength, splitShorthand } from '../utils'
 
 export const fonts: Rule<Theme>[] = [
   // text
@@ -141,7 +141,7 @@ function handleSize([, s]: string[], { theme }: RuleContext<Theme>): CSSObject |
 }
 
 function handlerColorOrSize(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | undefined {
-  if (h.numberWithUnit(h.bracket(match[1])) != null || isCSSMathFn(h.bracket(match[1])))
+  if (isCSSLength(match[1]))
     return handleSize(match, ctx)
   return colorResolver('color', 'text', 'textColor')(match, ctx) as CSSObject | undefined
 }

--- a/packages-presets/preset-mini/src/_utils/utilities.ts
+++ b/packages-presets/preset-mini/src/_utils/utilities.ts
@@ -305,6 +305,23 @@ export function isCSSMathFn(value: string | undefined) {
   return value != null && cssMathFnRE.test(value)
 }
 
+export function isCSSLength(value: string, theme?: Theme) {
+  if (value.startsWith('#'))
+    return false
+
+  const bracket = h.bracket(value, theme)
+  if (bracket.startsWith('#'))
+    return false
+
+  if (h.numberWithUnit(bracket) != null)
+    return true
+
+  if (isCSSMathFn(bracket))
+    return true
+
+  return false
+}
+
 export function isSize(str: string) {
   if (str[0] === '[' && str.endsWith(']'))
     str = str.slice(1, -1)

--- a/packages-presets/preset-wind4/src/rules/behaviors.ts
+++ b/packages-presets/preset-wind4/src/rules/behaviors.ts
@@ -47,7 +47,7 @@ function* handleWidth([, b]: string[], { theme }: RuleContext<Theme>): Generator
 }
 
 function* handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): Generator<CSSValueInput | string | undefined> {
-  if (isCSSMathFn(h.bracket(match[1], ctx.theme))) {
+  if (h.numberWithUnit(h.bracket(match[1], ctx.theme)) != null || isCSSMathFn(h.bracket(match[1], ctx.theme))) {
     yield* handleWidth(match, ctx)
   }
   else {

--- a/packages-presets/preset-wind4/src/rules/behaviors.ts
+++ b/packages-presets/preset-wind4/src/rules/behaviors.ts
@@ -1,7 +1,7 @@
 import type { CSSValueInput, Rule, RuleContext } from '@unocss/core'
 import type { Theme } from '../theme'
 import { symbols } from '@unocss/core'
-import { colorResolver, defineProperty, globalKeywords, h, isCSSMathFn, makeGlobalStaticRules } from '../utils'
+import { colorResolver, defineProperty, globalKeywords, h, isCSSLength, makeGlobalStaticRules } from '../utils'
 
 export const outline: Rule<Theme>[] = [
   // size
@@ -47,7 +47,7 @@ function* handleWidth([, b]: string[], { theme }: RuleContext<Theme>): Generator
 }
 
 function* handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): Generator<CSSValueInput | string | undefined> {
-  if (h.numberWithUnit(h.bracket(match[1], ctx.theme)) != null || isCSSMathFn(h.bracket(match[1], ctx.theme))) {
+  if (isCSSLength(match[1], ctx.theme)) {
     yield* handleWidth(match, ctx)
   }
   else {

--- a/packages-presets/preset-wind4/src/rules/border.ts
+++ b/packages-presets/preset-wind4/src/rules/border.ts
@@ -77,7 +77,7 @@ function handlerBorderSize([, a = '', b = '1']: string[], { theme }: RuleContext
 
 function handlerBorderColorOrSize([, a = '', b]: string[], ctx: RuleContext<Theme>): CSSEntries | (CSSValueInput | string)[] | undefined {
   if (a in directionMap) {
-    if (isCSSMathFn(h.bracket(b, ctx.theme)))
+    if (h.bracketOfLength(b, ctx.theme) != null || isCSSMathFn(h.bracket(b, ctx.theme)))
       return handlerBorderSize(['', a, b], ctx)
 
     const bracketColor = h.bracketOfColor(b, ctx.theme)

--- a/packages-presets/preset-wind4/src/rules/border.ts
+++ b/packages-presets/preset-wind4/src/rules/border.ts
@@ -1,7 +1,7 @@
 import type { CSSEntries, CSSObject, CSSValueInput, Rule, RuleContext } from '@unocss/core'
 import type { Theme } from '../theme'
 import { notNull } from '@unocss/core'
-import { colorCSSGenerator, cornerMap, directionMap, generateThemeVariable, globalKeywords, h, hasParseableColor, isCSSMathFn, parseColor, SpecialColorKey, themeTracking } from '../utils'
+import { colorCSSGenerator, cornerMap, directionMap, generateThemeVariable, globalKeywords, h, hasParseableColor, isCSSLength, parseColor, SpecialColorKey, themeTracking } from '../utils'
 
 export const borderStyles = ['solid', 'dashed', 'dotted', 'double', 'hidden', 'none', 'groove', 'ridge', 'inset', 'outset', ...globalKeywords]
 
@@ -70,6 +70,9 @@ function borderColorResolver(direction: string) {
 }
 
 function handlerBorderSize([, a = '', b = '1']: string[], { theme }: RuleContext<Theme>): CSSEntries | undefined {
+  if (b.startsWith('#'))
+    return
+
   const v = h.bracket.bracketOfLength.cssvar.global.px(b, theme)
   if (a in directionMap && v != null)
     return directionMap[a].map(i => [`border${i}-width`, v])
@@ -77,7 +80,7 @@ function handlerBorderSize([, a = '', b = '1']: string[], { theme }: RuleContext
 
 function handlerBorderColorOrSize([, a = '', b]: string[], ctx: RuleContext<Theme>): CSSEntries | (CSSValueInput | string)[] | undefined {
   if (a in directionMap) {
-    if (h.numberWithUnit(h.bracket(b, ctx.theme)) != null || isCSSMathFn(h.bracket(b, ctx.theme)))
+    if (isCSSLength(b, ctx.theme))
       return handlerBorderSize(['', a, b], ctx)
 
     const bracketColor = h.bracketOfColor(b, ctx.theme)

--- a/packages-presets/preset-wind4/src/rules/border.ts
+++ b/packages-presets/preset-wind4/src/rules/border.ts
@@ -77,7 +77,7 @@ function handlerBorderSize([, a = '', b = '1']: string[], { theme }: RuleContext
 
 function handlerBorderColorOrSize([, a = '', b]: string[], ctx: RuleContext<Theme>): CSSEntries | (CSSValueInput | string)[] | undefined {
   if (a in directionMap) {
-    if (h.bracketOfLength(b, ctx.theme) != null || isCSSMathFn(h.bracket(b, ctx.theme)))
+    if (h.numberWithUnit(h.bracket(b, ctx.theme)) != null || isCSSMathFn(h.bracket(b, ctx.theme)))
       return handlerBorderSize(['', a, b], ctx)
 
     const bracketColor = h.bracketOfColor(b, ctx.theme)

--- a/packages-presets/preset-wind4/src/rules/decoration.ts
+++ b/packages-presets/preset-wind4/src/rules/decoration.ts
@@ -1,6 +1,6 @@
 import type { CSSObject, CSSValueInput, Rule, RuleContext } from '@unocss/core'
 import type { Theme } from '../theme'
-import { colorResolver, globalKeywords, h, isCSSMathFn } from '../utils'
+import { colorResolver, globalKeywords, h, isCSSLength } from '../utils'
 
 const decorationStyles = ['solid', 'double', 'dotted', 'dashed', 'wavy', ...globalKeywords]
 
@@ -29,7 +29,7 @@ function handleWidth([, b]: string[], { theme }: RuleContext<Theme>): CSSObject 
 }
 
 function handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | (CSSValueInput | string)[] | undefined {
-  if (h.numberWithUnit(h.bracket(match[1], ctx.theme)) != null || isCSSMathFn(h.bracket(match[1], ctx.theme)))
+  if (isCSSLength(match[1], ctx.theme))
     return handleWidth(match, ctx)
 
   const result = colorResolver('text-decoration-color', 'line')(match, ctx)

--- a/packages-presets/preset-wind4/src/rules/decoration.ts
+++ b/packages-presets/preset-wind4/src/rules/decoration.ts
@@ -29,7 +29,7 @@ function handleWidth([, b]: string[], { theme }: RuleContext<Theme>): CSSObject 
 }
 
 function handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | (CSSValueInput | string)[] | undefined {
-  if (isCSSMathFn(h.bracket(match[1], ctx.theme)))
+  if (h.numberWithUnit(h.bracket(match[1], ctx.theme)) != null || isCSSMathFn(h.bracket(match[1], ctx.theme)))
     return handleWidth(match, ctx)
 
   const result = colorResolver('text-decoration-color', 'line')(match, ctx)

--- a/packages-presets/preset-wind4/src/rules/svg.ts
+++ b/packages-presets/preset-wind4/src/rules/svg.ts
@@ -1,6 +1,6 @@
 import type { CSSObject, CSSValueInput, Rule, RuleContext } from '@unocss/core'
 import type { Theme } from '../theme'
-import { colorResolver, h, isCSSMathFn } from '../utils'
+import { colorResolver, h, isCSSLength } from '../utils'
 
 export const svgUtilities: Rule<Theme>[] = [
   // fills
@@ -40,7 +40,7 @@ function handleWidth([, b]: string[], { theme }: RuleContext<Theme>): CSSObject 
 }
 
 function handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | (CSSValueInput | string)[] | undefined {
-  if (h.numberWithUnit(h.bracket(match[1], ctx.theme)) != null || isCSSMathFn(h.bracket(match[1], ctx.theme)))
+  if (isCSSLength(match[1], ctx.theme))
     return handleWidth(match, ctx)
   return colorResolver('stroke', 'stroke')(match, ctx)
 }

--- a/packages-presets/preset-wind4/src/rules/svg.ts
+++ b/packages-presets/preset-wind4/src/rules/svg.ts
@@ -40,7 +40,7 @@ function handleWidth([, b]: string[], { theme }: RuleContext<Theme>): CSSObject 
 }
 
 function handleColorOrWidth(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | (CSSValueInput | string)[] | undefined {
-  if (isCSSMathFn(h.bracket(match[1], ctx.theme)))
+  if (h.numberWithUnit(h.bracket(match[1], ctx.theme)) != null || isCSSMathFn(h.bracket(match[1], ctx.theme)))
     return handleWidth(match, ctx)
   return colorResolver('stroke', 'stroke')(match, ctx)
 }

--- a/packages-presets/preset-wind4/src/rules/typography.ts
+++ b/packages-presets/preset-wind4/src/rules/typography.ts
@@ -8,7 +8,7 @@ import {
   globalKeywords,
   h,
   hasParseableColor,
-  isCSSMathFn,
+  isCSSLength,
   numberResolver,
 } from '../utils'
 import { bracketTypeRe } from '../utils/handlers/regex'
@@ -375,7 +375,7 @@ function handleSize([, s]: string[], { theme }: RuleContext<Theme>): CSSObject |
 }
 
 function handlerColorOrSize(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | (CSSValueInput | string)[] | undefined {
-  if (h.numberWithUnit(h.bracket(match[1], ctx.theme)) != null || isCSSMathFn(h.bracket(match[1], ctx.theme)))
+  if (isCSSLength(match[1], ctx.theme))
     return handleSize(match, ctx)
   return colorResolver('color', 'text')(match, ctx)
 }

--- a/packages-presets/preset-wind4/src/rules/typography.ts
+++ b/packages-presets/preset-wind4/src/rules/typography.ts
@@ -375,7 +375,7 @@ function handleSize([, s]: string[], { theme }: RuleContext<Theme>): CSSObject |
 }
 
 function handlerColorOrSize(match: RegExpMatchArray, ctx: RuleContext<Theme>): CSSObject | (CSSValueInput | string)[] | undefined {
-  if (isCSSMathFn(h.bracket(match[1], ctx.theme)))
+  if (h.numberWithUnit(h.bracket(match[1], ctx.theme)) != null || isCSSMathFn(h.bracket(match[1], ctx.theme)))
     return handleSize(match, ctx)
   return colorResolver('color', 'text')(match, ctx)
 }

--- a/packages-presets/preset-wind4/src/utils/utilities.ts
+++ b/packages-presets/preset-wind4/src/utils/utilities.ts
@@ -419,6 +419,23 @@ export function isCSSMathFn(value: string | undefined) {
   return value != null && cssMathFnRE.test(value)
 }
 
+export function isCSSLength(value: string, theme?: Theme) {
+  if (value.startsWith('#'))
+    return false
+
+  const bracket = h.bracket(value, theme)
+  if (bracket.startsWith('#'))
+    return false
+
+  if (h.numberWithUnit(bracket) != null)
+    return true
+
+  if (isCSSMathFn(bracket))
+    return true
+
+  return false
+}
+
 export function isSize(str: string) {
   if (str[0] === '[' && str.endsWith(']'))
     str = str.slice(1, -1)

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -618,7 +618,7 @@
 .border-s-width-\$variable{border-inline-start-width:var(--variable);}
 .border-t-width-3{border-top-width:3px;}
 .b-block-size-\$variable{border-block-start-width:var(--variable);border-block-end-width:var(--variable);}
-.border-\[\#124\]{border-width:#124;}
+.border-\[\#124\]{border-color:color-mix(in oklab, #124 var(--un-border-opacity), transparent) /* #124 */;}
 .border-\[calc\(10px\+1px\)\]{border-width:calc(10px + 1px);}
 .border-\[calc\(var\(--border-width\)\*1px\)\]{border-width:calc(var(--border-width) * 1px);}
 .border-\[color\:\#000\]{border-color:color-mix(in oklab, #000 var(--un-border-opacity), transparent) /* #000 */;}
@@ -644,7 +644,7 @@
 .border-e-red-400{border-inline-end-color:color-mix(in srgb, var(--colors-red-400) var(--un-border-inline-end-opacity), transparent) /* oklch(70.4% 0.191 22.216) */;--un-border-inline-end-opacity:var(--un-border-opacity);}
 .border-s-green-500{border-inline-start-color:color-mix(in srgb, var(--colors-green-500) var(--un-border-inline-start-opacity), transparent) /* oklch(72.3% 0.219 149.579) */;--un-border-inline-start-opacity:var(--un-border-opacity);}
 .border-s-red-100{border-inline-start-color:color-mix(in srgb, var(--colors-red-100) var(--un-border-inline-start-opacity), transparent) /* oklch(93.6% 0.032 17.717) */;--un-border-inline-start-opacity:var(--un-border-opacity);}
-.border-t-\[\#124\]{border-top-width:#124;}
+.border-t-\[\#124\]{border-top-color:color-mix(in oklab, #124 var(--un-border-top-opacity), transparent) /* #124 */;--un-border-top-opacity:var(--un-border-opacity);}
 .border-t-\$color{border-top-color:color-mix(in oklab, var(--color) var(--un-border-top-opacity), transparent) /* var(--color) */;--un-border-top-opacity:var(--un-border-opacity);}
 .border-t-black\/10{border-top-color:color-mix(in srgb, var(--colors-black) 10%, transparent) /* #000 */;}
 .border-opacity-\$opacity-variable{--un-border-opacity:var(--opacity-variable);}

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -249,14 +249,17 @@
 .text-size-1em{font-size:1em;}
 .text-size-unset{font-size:unset;}
 .text-\[--variable\],
+.text-\[color\:--variable\],
 .text-\$variable{color:color-mix(in oklab, var(--variable) var(--un-text-opacity), transparent) /* var(--variable) */;}
 .text-\[\#124\]{color:color-mix(in oklab, #124 var(--un-text-opacity), transparent) /* #124 */;}
 .text-\[calc\(1em-1px\)\],
 .text-\[length\:calc\(1em-1px\)\]{font-size:calc(1em - 1px);}
 .text-\[calc\(1rem-1px\)\]{font-size:calc(1rem - 1px);}
-.text-\[red\]\:50\/display-p3{color:color-mix(in display-p3, red 50%, transparent) /* red */;}
-.text-\[red\]\/50{color:color-mix(in oklab, red 50%, transparent) /* red */;}
+.text-\[color\:var\(--color-x\)\]\:\[trick\]{color:color-mix(in oklab, var(--color-x) trick, transparent) /* var(--color-x) */;}
+.text-\[color\:var\(--color\)\],
 .text-\[var\(--color\)\]{color:color-mix(in oklab, var(--color) var(--un-text-opacity), transparent) /* var(--color) */;}
+.text-\[red\]\:50\/display-p3{color:color-mix(in display-p3, var(--colors-red-DEFAULT) 50%, transparent) /* oklch(70.4% 0.191 22.216) */;}
+.text-\[red\]\/50{color:color-mix(in srgb, var(--colors-red-DEFAULT) 50%, transparent) /* oklch(70.4% 0.191 22.216) */;}
 .text-black\/10{color:color-mix(in srgb, var(--colors-black) 10%, transparent) /* #000 */;}
 .aria-busy\:aria-pressed\:text-green-600[aria-pressed="true"][aria-busy="true"],
 .aria-busy\:data-\[bar\]\:text-green-600[data-bar][aria-busy="true"],
@@ -1965,6 +1968,7 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .supports-\[backdrop-filter\]\:backdrop-blur{--un-backdrop-blur:blur(8px);-webkit-backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);}
 }
 @supports (color: color-mix(in lab, red, red)){
+.text-\[red\]\/50{color:color-mix(in oklab, var(--colors-red-DEFAULT) 50%, transparent) /* oklch(70.4% 0.191 22.216) */;}
 .text-black\/10{color:color-mix(in oklab, var(--colors-black) 10%, transparent) /* #000 */;}
 .aria-busy\:aria-pressed\:text-green-600[aria-pressed="true"][aria-busy="true"]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}
 .aria-busy\:data-\[bar\]\:text-green-600[data-bar][aria-busy="true"]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -249,17 +249,14 @@
 .text-size-1em{font-size:1em;}
 .text-size-unset{font-size:unset;}
 .text-\[--variable\],
-.text-\[color\:--variable\],
 .text-\$variable{color:color-mix(in oklab, var(--variable) var(--un-text-opacity), transparent) /* var(--variable) */;}
 .text-\[\#124\]{color:color-mix(in oklab, #124 var(--un-text-opacity), transparent) /* #124 */;}
 .text-\[calc\(1em-1px\)\],
 .text-\[length\:calc\(1em-1px\)\]{font-size:calc(1em - 1px);}
 .text-\[calc\(1rem-1px\)\]{font-size:calc(1rem - 1px);}
-.text-\[color\:var\(--color-x\)\]\:\[trick\]{color:color-mix(in oklab, var(--color-x) trick, transparent) /* var(--color-x) */;}
-.text-\[color\:var\(--color\)\],
+.text-\[red\]\:50\/display-p3{color:color-mix(in display-p3, red 50%, transparent) /* red */;}
+.text-\[red\]\/50{color:color-mix(in oklab, red 50%, transparent) /* red */;}
 .text-\[var\(--color\)\]{color:color-mix(in oklab, var(--color) var(--un-text-opacity), transparent) /* var(--color) */;}
-.text-\[red\]\:50\/display-p3{color:color-mix(in display-p3, var(--colors-red-DEFAULT) 50%, transparent) /* oklch(70.4% 0.191 22.216) */;}
-.text-\[red\]\/50{color:color-mix(in srgb, var(--colors-red-DEFAULT) 50%, transparent) /* oklch(70.4% 0.191 22.216) */;}
 .text-black\/10{color:color-mix(in srgb, var(--colors-black) 10%, transparent) /* #000 */;}
 .aria-busy\:aria-pressed\:text-green-600[aria-pressed="true"][aria-busy="true"],
 .aria-busy\:data-\[bar\]\:text-green-600[data-bar][aria-busy="true"],
@@ -621,14 +618,14 @@
 .border-s-width-\$variable{border-inline-start-width:var(--variable);}
 .border-t-width-3{border-top-width:3px;}
 .b-block-size-\$variable{border-block-start-width:var(--variable);border-block-end-width:var(--variable);}
-.border-\[\#124\]{border-color:color-mix(in oklab, #124 var(--un-border-opacity), transparent) /* #124 */;}
+.border-\[\#124\]{border-width:#124;}
 .border-\[calc\(10px\+1px\)\]{border-width:calc(10px + 1px);}
 .border-\[calc\(var\(--border-width\)\*1px\)\]{border-width:calc(var(--border-width) * 1px);}
 .border-\[color\:\#000\]{border-color:color-mix(in oklab, #000 var(--un-border-opacity), transparent) /* #000 */;}
 .border-\[color\:red\]{border-color:color-mix(in srgb, var(--colors-red-DEFAULT) var(--un-border-opacity), transparent) /* oklch(70.4% 0.191 22.216) */;}
 .border-\[color\:var\(--color\)\],
-.border-\[var\(--color\)\],
 .border-\$color{border-color:color-mix(in oklab, var(--color) var(--un-border-opacity), transparent) /* var(--color) */;}
+.border-\[var\(--color\)\]{border-width:var(--color);}
 .border-black{border-color:color-mix(in srgb, var(--colors-black) var(--un-border-opacity), transparent) /* #000 */;}
 .border-black\/10{border-color:color-mix(in srgb, var(--colors-black) 10%, transparent) /* #000 */;}
 .border-blue{border-color:color-mix(in srgb, var(--colors-blue-DEFAULT) var(--un-border-opacity), transparent) /* oklch(70.7% 0.165 254.624) */;}
@@ -647,7 +644,7 @@
 .border-e-red-400{border-inline-end-color:color-mix(in srgb, var(--colors-red-400) var(--un-border-inline-end-opacity), transparent) /* oklch(70.4% 0.191 22.216) */;--un-border-inline-end-opacity:var(--un-border-opacity);}
 .border-s-green-500{border-inline-start-color:color-mix(in srgb, var(--colors-green-500) var(--un-border-inline-start-opacity), transparent) /* oklch(72.3% 0.219 149.579) */;--un-border-inline-start-opacity:var(--un-border-opacity);}
 .border-s-red-100{border-inline-start-color:color-mix(in srgb, var(--colors-red-100) var(--un-border-inline-start-opacity), transparent) /* oklch(93.6% 0.032 17.717) */;--un-border-inline-start-opacity:var(--un-border-opacity);}
-.border-t-\[\#124\]{border-top-color:color-mix(in oklab, #124 var(--un-border-top-opacity), transparent) /* #124 */;--un-border-top-opacity:var(--un-border-opacity);}
+.border-t-\[\#124\]{border-top-width:#124;}
 .border-t-\$color{border-top-color:color-mix(in oklab, var(--color) var(--un-border-top-opacity), transparent) /* var(--color) */;--un-border-top-opacity:var(--un-border-opacity);}
 .border-t-black\/10{border-top-color:color-mix(in srgb, var(--colors-black) 10%, transparent) /* #000 */;}
 .border-opacity-\$opacity-variable{--un-border-opacity:var(--opacity-variable);}
@@ -1968,7 +1965,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .supports-\[backdrop-filter\]\:backdrop-blur{--un-backdrop-blur:blur(8px);-webkit-backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);backdrop-filter:var(--un-backdrop-blur,) var(--un-backdrop-brightness,) var(--un-backdrop-contrast,) var(--un-backdrop-grayscale,) var(--un-backdrop-hue-rotate,) var(--un-backdrop-invert,) var(--un-backdrop-opacity,) var(--un-backdrop-saturate,) var(--un-backdrop-sepia,);}
 }
 @supports (color: color-mix(in lab, red, red)){
-.text-\[red\]\/50{color:color-mix(in oklab, var(--colors-red-DEFAULT) 50%, transparent) /* oklch(70.4% 0.191 22.216) */;}
 .text-black\/10{color:color-mix(in oklab, var(--colors-black) 10%, transparent) /* #000 */;}
 .aria-busy\:aria-pressed\:text-green-600[aria-pressed="true"][aria-busy="true"]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}
 .aria-busy\:data-\[bar\]\:text-green-600[data-bar][aria-busy="true"]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}

--- a/test/preset-mini.test.ts
+++ b/test/preset-mini.test.ts
@@ -700,4 +700,21 @@ describe('preset-mini', () => {
       "
     `)
   })
+
+  it('resolves arbitrary lengths before colors across compound utilities', async () => {
+    const mini = await createGenerator({ presets: [presetMini()] })
+    const { css } = await mini.generate([
+      'border-l-[3px]',
+      'outline-[length:4px]',
+      'decoration-[5px]',
+      'stroke-[length:6px]',
+      'text-[7px]',
+    ], { preflights: false })
+
+    expect(css).toContain('.border-l-\\[3px\\]{border-left-width:3px;}')
+    expect(css).toContain('.outline-\\[length\\:4px\\]{outline-width:4px;}')
+    expect(css).toContain('.decoration-\\[5px\\]{text-decoration-thickness:5px;}')
+    expect(css).toContain('.stroke-\\[length\\:6px\\]{stroke-width:6px;}')
+    expect(css).toContain('.text-\\[7px\\]{font-size:7px;}')
+  })
 })

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -46,6 +46,9 @@ describe('preset-wind4', () => {
         "color-bluegray-400/10",
         "color-bluegray/10",
         "text-red2",
+        "text-[color:--variable]",
+        "text-[color:var(--color)]",
+        "text-[color:var(--color-x)]:[trick]",
         "ring-red2",
         "ring-red2/5",
         "ring-width-px",
@@ -533,7 +536,20 @@ describe('preset-wind4', () => {
       ],
     })
 
-    const { css } = await uno.generate('border-l-[3px] border-r-[length:5px] border-l-red-500 text-[3px] text-[color:3px] bg-[3px] bg-[color:3px] color-[3px]', { preflights: false })
+    const { css } = await uno.generate([
+      'border-l-[3px]',
+      'border-r-[length:5px]',
+      'border-l-red-500',
+      'text-[3px]',
+      'text-[color:3px]',
+      'bg-[3px]',
+      'bg-[color:3px]',
+      'color-[3px]',
+      'outline-[3px]',
+      'decoration-[length:4px]',
+      'stroke-[5px]',
+      'text-[length:6px]',
+    ], { preflights: false })
 
     expect(css).toContain('.border-l-\\[3px\\]{border-left-width:3px;}')
     expect(css).toContain('.border-r-\\[length\\:5px\\]{border-right-width:5px;}')
@@ -544,6 +560,10 @@ describe('preset-wind4', () => {
     expect(css).toContain('.bg-\\[3px\\]{background-position:3px;}')
     expect(css).not.toContain('.bg-\\[color\\:3px\\]{background-color:')
     expect(css).not.toContain('.color-\\[3px\\]{color:')
+    expect(css).toContain('.outline-\\[3px\\]{outline-style:var(--un-outline-style);outline-width:3px;}')
+    expect(css).toContain('.decoration-\\[length\\:4px\\]{text-decoration-thickness:4px;}')
+    expect(css).toContain('.stroke-\\[5px\\]{stroke-width:5px;}')
+    expect(css).toContain('.text-\\[length\\:6px\\]{font-size:6px;}')
   })
 })
 

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -46,9 +46,6 @@ describe('preset-wind4', () => {
         "color-bluegray-400/10",
         "color-bluegray/10",
         "text-red2",
-        "text-[color:--variable]",
-        "text-[color:var(--color)]",
-        "text-[color:var(--color-x)]:[trick]",
         "ring-red2",
         "ring-red2/5",
         "ring-width-px",
@@ -527,6 +524,26 @@ describe('preset-wind4', () => {
     expect(css).toContain('@media (prefers-color-scheme: dark){.dark\\:space-y-4{\n:where(&>:not(:last-child)){--un-space-y-reverse:0;')
     expect(css).not.toContain('.dark\\:divide-gray-700{@media')
     expect(css).not.toContain('.dark\\:space-y-4{@media')
+  })
+
+  it('resolves arbitrary lengths before colors across utilities', async () => {
+    const uno = await createGenerator({
+      presets: [
+        presetWind4({ preflights: { reset: false } }),
+      ],
+    })
+
+    const { css } = await uno.generate('border-l-[3px] border-r-[length:5px] border-l-red-500 text-[3px] text-[color:3px] bg-[3px] bg-[color:3px] color-[3px]', { preflights: false })
+
+    expect(css).toContain('.border-l-\\[3px\\]{border-left-width:3px;}')
+    expect(css).toContain('.border-r-\\[length\\:5px\\]{border-right-width:5px;}')
+    expect(css).toContain('.border-l-red-500{border-left-color:')
+    expect(css).not.toContain('.border-l-\\[3px\\]{border-left-color:')
+    expect(css).toContain('.text-\\[3px\\]{font-size:3px;}')
+    expect(css).not.toContain('.text-\\[color\\:3px\\]{color:')
+    expect(css).toContain('.bg-\\[3px\\]{background-position:3px;}')
+    expect(css).not.toContain('.bg-\\[color\\:3px\\]{background-color:')
+    expect(css).not.toContain('.color-\\[3px\\]{color:')
   })
 })
 


### PR DESCRIPTION
This PR fixes an issue where multiple utility rules (including border, outline, decoration, stroke, and text) misidentified arbitrary length/size values with units (e.g. outline-[3px], stroke-[5px], text-[7px]) as colors instead of sizes, causing them to fail to generate the correct CSS width/size declarations.