### PR TITLE
fix(preset-typography): update cssExtend type to TypographyCSSObject

### DIFF
--- a/packages-presets/preset-typography/src/types.ts
+++ b/packages-presets/preset-typography/src/types.ts
@@ -52,7 +52,7 @@ export interface TypographyOptions<T extends TypographyTheme = TypographyTheme> 
    *
    * @default undefined
    */
-  cssExtend?: Record<string, CSSObject> | ((theme: T) => Record<string, CSSObject>)
+  cssExtend?: TypographyCSSObject | ((theme: T) => TypographyCSSObject)
 
   /**
    * Compatibility option. Notice that it will affect some features.


### PR DESCRIPTION
before:
```ts
presetTypography({
  cssExtend: {
    'max-width': '100%',
    //^ TS2322: Type string is not assignable to type CSSObject
  },
}),
```