### PR TITLE
fix(vite): use internal IDs for virtual CSS modules

### DIFF
--- a/examples/vite-solid/package.json
+++ b/examples/vite-solid/package.json
@@ -9,17 +9,19 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "solid-js": "^1.9.5"
+    "solid-js": "^1.9.15"
   },
   "devDependencies": {
-    "@iconify-json/logos": "^1.2.4",
+    "@iconify-json/logos": "^1.2.13",
     "@unocss/core": "link:../../packages-engine/core",
     "@unocss/preset-attributify": "link:../../packages-presets/preset-attributify",
     "@unocss/preset-icons": "link:../../packages-presets/preset-icons",
-    "typescript": "^5.8.2",
+    "@unocss/preset-wind3": "link:../../packages-presets/preset-wind3",
+    "@unocss/vite": "link:../../packages-integrations/vite",
+    "typescript": "^6.0.3",
     "unocss": "link:../../packages-presets/unocss",
-    "vite": "^6.2.1",
-    "vite-plugin-solid": "^2.11.6"
+    "vite": "^8.2.2",
+    "vite-plugin-solid": "^2.11.14"
   },
   "stackblitz": {
     "installDependencies": false,

--- a/examples/vite-solid/src/uno-env.d.ts
+++ b/examples/vite-solid/src/uno-env.d.ts
@@ -1,0 +1,7 @@
+import type { AttributifyAttributes } from '@unocss/preset-attributify'
+
+declare module 'solid-js' {
+  namespace JSX {
+    interface HTMLAttributes<T> extends AttributifyAttributes {}
+  }
+}

--- a/examples/vite-solid/tsconfig.json
+++ b/examples/vite-solid/tsconfig.json
@@ -7,6 +7,8 @@
     "moduleResolution": "bundler",
     "types": ["vite/client"],
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "preserveSymlinks": true,
+    "skipLibCheck": true
   }
 }

--- a/examples/vite-solid/vite.config.ts
+++ b/examples/vite-solid/vite.config.ts
@@ -1,7 +1,7 @@
 import presetAttributify from '@unocss/preset-attributify'
 import presetIcons from '@unocss/preset-icons'
 import presetWind3 from '@unocss/preset-wind3'
-import UnoCSS from 'unocss/vite'
+import UnoCSS from '@unocss/vite'
 import { defineConfig } from 'vite'
 import solidPlugin from 'vite-plugin-solid'
 

--- a/packages-integrations/vite/src/modes/global/dev.ts
+++ b/packages-integrations/vite/src/modes/global/dev.ts
@@ -8,6 +8,7 @@ import { LAYER_MARK_ALL } from '#integration/constants'
 import { getHash } from '#integration/hash'
 import { resolveId, resolveLayer } from '#integration/layers'
 import { getPath } from '#integration/utils'
+import { toViteVirtualId } from '../../virtual'
 import { MESSAGE_UNOCSS_ENTRY_NOT_FOUND } from './shared'
 
 const WARN_TIMEOUT = 20000
@@ -162,8 +163,9 @@ export function GlobalModeDevPlugin(ctx: UnocssPluginContext): Plugin[] {
         if (entry) {
           resolved = true
           clearWarnTimer()
-          entries.add(entry)
-          return entry
+          const virtualId = toViteVirtualId(entry)
+          entries.add(virtualId)
+          return virtualId
         }
       },
       async load(id) {

--- a/packages-integrations/vite/src/modes/per-module.ts
+++ b/packages-integrations/vite/src/modes/per-module.ts
@@ -4,8 +4,10 @@ import { Buffer } from 'node:buffer'
 import { getHash } from '#integration/hash'
 import { resolveId, resolveLayer } from '#integration/layers'
 import { getPath } from '#integration/utils'
+import { toViteVirtualId } from '../virtual'
 
 const VIRTUAL_PREFIX = '/@unocss/'
+const VIRTUAL_ID_PREFIX = toViteVirtualId(VIRTUAL_PREFIX)
 const SCOPE_IMPORT_RE = / from (['"])(@unocss\/scope)\1/
 
 export function PerModuleModePlugin(ctx: UnocssPluginContext): Plugin[] {
@@ -15,7 +17,7 @@ export function PerModuleModePlugin(ctx: UnocssPluginContext): Plugin[] {
   const invalidate = (hash: string) => {
     if (!server)
       return
-    const id = `${VIRTUAL_PREFIX}${hash}.css`
+    const id = `${VIRTUAL_ID_PREFIX}${hash}.css`
     const mod = server.moduleGraph.getModuleById(id)
     if (!mod)
       return
@@ -23,8 +25,8 @@ export function PerModuleModePlugin(ctx: UnocssPluginContext): Plugin[] {
     server.ws.send({
       type: 'update',
       updates: [{
-        acceptedPath: id,
-        path: id,
+        acceptedPath: `${VIRTUAL_PREFIX}${hash}.css`,
+        path: `${VIRTUAL_PREFIX}${hash}.css`,
         timestamp: +Date.now(),
         type: 'js-update',
       }],
@@ -38,7 +40,7 @@ export function PerModuleModePlugin(ctx: UnocssPluginContext): Plugin[] {
       async resolveId(id) {
         const entry = await resolveId(ctx, id)
         if (entry)
-          return entry
+          return toViteVirtualId(entry)
       },
       async load(id) {
         const layer = await resolveLayer(ctx, getPath(id))
@@ -99,13 +101,16 @@ export function PerModuleModePlugin(ctx: UnocssPluginContext): Plugin[] {
         }
       },
       resolveId(id) {
-        return id.startsWith(VIRTUAL_PREFIX) ? id : null
+        if (id.startsWith(VIRTUAL_PREFIX))
+          return toViteVirtualId(id)
+        return id.startsWith(VIRTUAL_ID_PREFIX) ? id : null
       },
       load(id) {
-        if (!id.startsWith(VIRTUAL_PREFIX))
+        if (!id.startsWith(VIRTUAL_ID_PREFIX))
           return null
 
-        const hash = id.slice(VIRTUAL_PREFIX.length, -'.css'.length)
+        const path = getPath(id)
+        const hash = path.slice(VIRTUAL_ID_PREFIX.length, -'.css'.length)
 
         const [source, css] = moduleMap.get(hash) || []
 

--- a/packages-integrations/vite/src/virtual.ts
+++ b/packages-integrations/vite/src/virtual.ts
@@ -1,0 +1,7 @@
+const VITE_VIRTUAL_ID_PREFIX = '\0'
+
+export function toViteVirtualId(id: string) {
+  return id.startsWith(VITE_VIRTUAL_ID_PREFIX)
+    ? id
+    : `${VITE_VIRTUAL_ID_PREFIX}${id}`
+}

--- a/test/virtual-modules.test.ts
+++ b/test/virtual-modules.test.ts
@@ -1,0 +1,46 @@
+import { resolve } from 'node:path'
+import * as vite from 'vite'
+import { describe, expect, it } from 'vitest'
+import UnoCSS from '../packages-integrations/vite/src/index'
+
+describe('vite virtual module ids', () => {
+  async function createServer(mode: 'global' | 'per-module') {
+    return await vite.createServer({
+      root: resolve(import.meta.dirname, 'fixtures/vite'),
+      configFile: false,
+      logLevel: 'error',
+      server: { middlewareMode: true, ws: false },
+      plugins: [UnoCSS({ configFile: false, inspector: false, mode })],
+    })
+  }
+
+  it('uses internal ids for global CSS', async () => {
+    const server = await createServer('global')
+
+    try {
+      expect((await server.pluginContainer.resolveId('/__uno.css?inline'))?.id)
+        .toBe('\0/__uno.css?inline')
+      expect((await server.pluginContainer.resolveId('virtual:uno.css'))?.id)
+        .toBe('\0/__uno.css')
+    }
+    finally {
+      await server.close()
+    }
+  })
+
+  it('uses internal ids for per-module CSS', async () => {
+    const server = await createServer('per-module')
+
+    try {
+      expect((await server.pluginContainer.resolveId('/__uno.css?inline'))?.id)
+        .toBe('\0/__uno.css?inline')
+      expect((await server.pluginContainer.resolveId('virtual:uno.css'))?.id)
+        .toBe('\0/__uno.css')
+      expect((await server.pluginContainer.resolveId('/@unocss/test.css?inline'))?.id)
+        .toBe('\0/@unocss/test.css?inline')
+    }
+    finally {
+      await server.close()
+    }
+  })
+})


### PR DESCRIPTION
### Description

Vite 8 applies filesystem serving checks to resolved IDs that look like file paths. UnoCSS virtual CSS IDs such as `/__uno.css` and `/@unocss/*.css` could therefore be treated as real files and rejected by `server.fs.allow`, especially when loaded with `?inline` during SSR.

This PR:

- prefixes resolved UnoCSS virtual modules with Vite's `\0` internal ID marker
- supports both global and per-module modes
- keeps public HMR paths unchanged while using internal IDs in the module graph
- updates the Solid example to test against Vite 8 and `@unocss/vite`
- adds coverage for `virtual:uno.css`, `/__uno.css?inline`, and per-module CSS IDs
