### PR TITLE
fix(preset-mini,preset-wind4): keep commas inside a css variable fallback

### DIFF
--- a/packages-presets/preset-mini/src/_utils/handlers/handlers.ts
+++ b/packages-presets/preset-mini/src/_utils/handlers/handlers.ts
@@ -236,7 +236,13 @@ export function bracketOfPosition(str: string) {
 
 export function cssvar(str: string) {
   if (/^\$[^\s'"`;{}]/.test(str)) {
-    const [name, defaultValue] = str.slice(1).split(',')
+    // Only the first comma separates the name from the fallback. Splitting on
+    // every comma dropped the rest of a fallback that contains its own, such
+    // as `$foo,rgba(0,0,0,.5)`, which emitted an unbalanced `var(--foo, rgba(0`.
+    const body = str.slice(1)
+    const separator = body.indexOf(',')
+    const name = separator === -1 ? body : body.slice(0, separator)
+    const defaultValue = separator === -1 ? '' : body.slice(separator + 1)
     return `var(--${escapeSelector(name)}${defaultValue ? `, ${defaultValue}` : ''})`
   }
 }

--- a/packages-presets/preset-mini/test/handler.test.ts
+++ b/packages-presets/preset-mini/test/handler.test.ts
@@ -15,6 +15,17 @@ describe('value handler', () => {
     expect(h.bracket('[calc(var(--min-width)_-_2_*_var(--col-gap))]')).eql('calc(var(--min-width) - 2 * var(--col-gap))')
   })
 
+  it('cssvar fallback keeps its own commas', () => {
+    expect(h.cssvar('$foo')).eql('var(--foo)')
+    expect(h.cssvar('$foo,blue')).eql('var(--foo, blue)')
+    // A fallback may itself contain commas, so only the first one separates
+    // the name from the fallback. Splitting on all of them truncated the
+    // value and left an unbalanced paren.
+    expect(h.cssvar('$foo,rgba(0,0,0,.5)')).eql('var(--foo, rgba(0,0,0,.5))')
+    expect(h.cssvar('$foo,var(--bar,blue)')).eql('var(--foo, var(--bar,blue))')
+    expect(h.cssvar('$a,b,c')).eql('var(--a, b,c)')
+  })
+
   it('bracket curly', () => {
     expect(h.bracket('[foo][bar]')).eql(undefined)
     expect(h.bracket('[[]]')).eql('[]')

--- a/packages-presets/preset-wind4/src/utils/handlers/handlers.ts
+++ b/packages-presets/preset-wind4/src/utils/handlers/handlers.ts
@@ -310,7 +310,13 @@ export function cssvar(str: string) {
 
   const match = str.match(/^(?:\$|--)([^\s'"`;{}]+)$/)
   if (match) {
-    const [name, defaultValue] = match[1].split(',')
+    // Only the first comma separates the name from the fallback. Splitting on
+    // every comma dropped the rest of a fallback that contains its own, such
+    // as `$foo,rgba(0,0,0,.5)`, which emitted an unbalanced `var(--foo, rgba(0`.
+    const body = match[1]
+    const separator = body.indexOf(',')
+    const name = separator === -1 ? body : body.slice(0, separator)
+    const defaultValue = separator === -1 ? '' : body.slice(separator + 1)
     return `var(--${escapeSelector(name)}${defaultValue ? `, ${defaultValue}` : ''})`
   }
 }


### PR DESCRIPTION
`cssvar` truncates a CSS variable fallback at the first comma, and the result is not just wrong but syntactically invalid CSS.

```js
h.cssvar('$foo,rgba(0,0,0,.5)')   // 'var(--foo, rgba(0'      <- unbalanced
h.cssvar('$foo,var(--bar,blue)')  // 'var(--foo, var(--bar'   <- unbalanced
h.cssvar('$a,b,c')                // 'var(--a, b)'            <- ',c' dropped
```

End to end, the unbalanced paren corrupts the whole declaration, and under `preset-wind4` it breaks the enclosing `color-mix()`:

```css
/* preset-mini */
.text-\$foo\,rgba\(0\,0\,0\,\.5\) { color: var(--foo, rgba(0); }

/* preset-wind4 */
color: color-mix(in oklab, var(--foo, rgba(0) var(--un-text-opacity), transparent);
```

### Cause

```js
const [name, defaultValue] = str.slice(1).split(',')
```

`split(',')` splits on every comma and the destructuring keeps only the first two parts, so everything after the second comma is discarded. A CSS variable fallback is allowed to contain commas, and commonly does: `rgba(...)`, a nested `var(--x, y)`, a font stack, a `calc()` with a comma-bearing function.

Only the first comma is a separator, so this now splits at `indexOf(',')` and keeps the remainder intact.

`preset-wind4` carries its own copy of the handler with the same bug, so both are fixed. Its regex differs slightly (it also accepts a `--name` form) but the split is identical.

### Tests

Added a `cssvar` case to `packages-presets/preset-mini/test/handler.test.ts` covering a plain variable, a simple fallback, a fallback with nested parens and commas, a nested `var()` fallback, and a bare multi-comma fallback. There was no existing coverage for a fallback containing commas, which is why this survived.

Mutation tested: reverting only `preset-mini`'s handler while keeping the test gives `expected 'var(--foo, rgba(0' to deeply equal 'var(--foo, rgba(0,0,0,.5))'`.

Full run of `test/`, `packages-presets/`, `packages-engine/` and `virtual-shared/`: 513 passed, 3 skipped. One unrelated failure, `cli > keeps cli logs off stdout when writing generated css to stdout`, times out at 30s identically on an unmodified checkout here, so it is not from this change.

### How it was found

Fuzzing generated utilities and asserting that every emitted declaration body has balanced parentheses. That check produced 40 hits, all reducing to this one handler.
