### PR TITLE
feat(transformer-attributify-jsx): support resolver-specific include patterns

### DIFF
--- a/packages-presets/transformer-attributify-jsx/README.md
+++ b/packages-presets/transformer-attributify-jsx/README.md
@@ -109,6 +109,22 @@ Will be compiled to:
 <div text-red text-center text-5xl animate-bounce="">unocss</div>
 ```
 
+## Resolver
+
+By default, the transformer uses the Oxc resolver and falls back to the regex resolver when Oxc cannot parse a file.
+You can select a resolver for individual files directly in `include`:
+
+```js
+transformerAttributifyJsx({
+  include: [
+    { pattern: /\.mdx$/, resolver: 'regex' },
+    { pattern: /\.[jt]sx$/, resolver: 'oxc' },
+  ],
+})
+```
+
+The first matching pattern is used. A rule with an explicit resolver does not fall back to another resolver when it fails.
+
 ## License
 
 MIT License &copy; 2022-PRESENT [Anthony Fu](https://github.com/antfu)

--- a/packages-presets/transformer-attributify-jsx/src/index.ts
+++ b/packages-presets/transformer-attributify-jsx/src/index.ts
@@ -6,17 +6,47 @@ import { attributifyJsxOxcResolver } from './resolver/oxc'
 import { attributifyJsxRegexResolver } from './resolver/regex'
 
 export type FilterPattern = Array<string | RegExp> | string | RegExp | null
+export type ResolverType = 'oxc' | 'regex'
+export interface ResolverFilterPattern {
+  pattern: string | RegExp
+  resolver: ResolverType
+}
+export type IncludePattern
+  = | Array<string | RegExp | ResolverFilterPattern>
+    | string
+    | RegExp
+    | ResolverFilterPattern
+    | null
 
 function createFilter(
-  include: FilterPattern,
+  include: IncludePattern,
   exclude: FilterPattern,
-): (id: string) => boolean {
+): {
+  idFilter: (id: string) => boolean
+  resolveResolver: (id: string) => ResolverType | undefined
+} {
   const includePattern = toArray(include || [])
   const excludePattern = toArray(exclude || [])
-  return (id: string) => {
+
+  const match = (id: string) => {
     if (excludePattern.some(p => id.match(p)))
-      return false
-    return includePattern.some(p => id.match(p))
+      return
+
+    return includePattern.find((item) => {
+      const pattern = item instanceof RegExp || typeof item === 'string'
+        ? item
+        : item.pattern
+      return id.match(pattern)
+    })
+  }
+
+  return {
+    idFilter: id => match(id) != null,
+    resolveResolver: (id) => {
+      const matched = match(id)
+      if (matched && !(matched instanceof RegExp) && typeof matched !== 'string')
+        return matched.resolver
+    },
   }
 }
 
@@ -28,10 +58,15 @@ export interface TransformerAttributifyJsxOptions {
   blocklist?: (string | RegExp)[]
 
   /**
-   * Regex of modules to be included from processing
+   * Patterns of modules to be included from processing.
+   *
+   * Use `{ pattern, resolver }` to select a resolver for matching files.
+   * The first matching pattern is used.
+   * Patterns without a resolver retain the default Oxc-to-regex fallback.
+   *
    * @default [/\.[jt]sx$/, /\.mdx$/]
    */
-  include?: FilterPattern
+  include?: IncludePattern
 
   /**
    * Regex of modules to exclude from processing
@@ -67,7 +102,7 @@ export default function transformerAttributifyJsx(options: TransformerAttributif
     return false
   }
 
-  const idFilter = createFilter(
+  const filter = createFilter(
     options.include || [/\.[jt]sx$/, /\.mdx$/],
     options.exclude || [],
   )
@@ -76,7 +111,7 @@ export default function transformerAttributifyJsx(options: TransformerAttributif
     name: '@unocss/transformer-attributify-jsx',
     docs: 'https://unocss.dev/transformers/attributify-jsx',
     enforce: 'pre',
-    idFilter,
+    idFilter: filter.idFilter,
     async transform(code, id, { uno }) {
       // Skip if running in VSCode extension context
       try {
@@ -92,6 +127,16 @@ export default function transformerAttributifyJsx(options: TransformerAttributif
         id,
         uno,
         isBlocked,
+      }
+
+      const resolver = filter.resolveResolver(id)
+      if (resolver === 'oxc') {
+        await attributifyJsxOxcResolver(params)
+        return
+      }
+      if (resolver === 'regex') {
+        await attributifyJsxRegexResolver(params)
+        return
       }
 
       try {

--- a/packages-presets/transformer-attributify-jsx/test/oxc.test.ts
+++ b/packages-presets/transformer-attributify-jsx/test/oxc.test.ts
@@ -1,10 +1,51 @@
 import { createGenerator } from '@unocss/core'
 import MagicString from 'magic-string'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import transformerAttributifyJsx from '../src'
 import { attributifyJsxOxcResolver } from '../src/resolver/oxc'
 
 describe('resolver-oxc', async () => {
   const uno = await createGenerator()
+
+  it('selects resolvers from include patterns', async () => {
+    const transformer = transformerAttributifyJsx({
+      include: [
+        { pattern: /\.mdx$/, resolver: 'regex' },
+        { pattern: /\.tsx$/, resolver: 'oxc' },
+      ],
+    })
+    const errorCode = '<d iv></div>'
+
+    expect(transformer.idFilter?.('app.mdx')).toBe(true)
+    expect(transformer.idFilter?.('app.tsx')).toBe(true)
+    expect(transformer.idFilter?.('app.vue')).toBe(false)
+    await expect(transformer.transform(new MagicString(errorCode), 'app.mdx', { uno } as any)).resolves.toBeUndefined()
+    await expect(transformer.transform(new MagicString(errorCode), 'app.tsx', { uno } as any)).rejects.toThrow('Oxc parse errors')
+  })
+
+  it('retains fallback for include patterns without a resolver', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const transformer = transformerAttributifyJsx({ include: /\.tsx$/ })
+
+    await expect(transformer.transform(new MagicString('<d iv></div>'), 'app.tsx', { uno } as any)).resolves.toBeUndefined()
+    expect(warn).toHaveBeenCalledOnce()
+
+    warn.mockRestore()
+  })
+
+  it('uses the first matching include pattern and respects exclude', async () => {
+    const transformer = transformerAttributifyJsx({
+      include: [
+        { pattern: /\.tsx$/, resolver: 'regex' },
+        { pattern: /^app\./, resolver: 'oxc' },
+      ],
+      exclude: /excluded/,
+    })
+
+    expect(transformer.idFilter?.('app.tsx')).toBe(true)
+    expect(transformer.idFilter?.('excluded.tsx')).toBe(false)
+    await expect(transformer.transform(new MagicString('<d iv></div>'), 'app.tsx', { uno } as any)).resolves.toBeUndefined()
+  })
 
   it('error', async () => {
     const errorCode = '<d iv></div>'


### PR DESCRIPTION
### Description

Allow users to select the resolver for different files directly through the transformer's `include` patterns.

```ts
transformerAttributifyJsx({
  include: [
    { pattern: /\.mdx$/, resolver: 'regex' },
    { pattern: /\.[jt]sx$/, resolver: 'oxc' },
  ],
})
```

The `idFilter` and resolver selection now share the same matching rules, avoiding duplicated file patterns across multiple options.

### Behavior

- `exclude` patterns take precedence over `include`.
- The first matching `include` pattern determines the resolver.
- Patterns without an explicit resolver preserve the existing Oxc-to-regex fallback.
- Patterns with an explicit resolver only use the selected resolver and propagate its errors.
- Existing `include` configurations remain backward compatible.

### Motivation

Some supported files, such as MDX files, may not be parsed directly by Oxc and currently rely on the regex fallback. Allowing the resolver to be selected from the matching `include` rule avoids unnecessary parser failures and gives users explicit per-file control.

### Tests

- Added coverage for resolver-specific include patterns.
- Added coverage for first-match precedence and `exclude`.
- Added coverage for the legacy Oxc-to-regex fallback.
- Verified ESLint, unit tests, and package build.

close #5254, close #5288