### PR TITLE
feat(core): extract unquoted class attributes

### DIFF
--- a/packages-engine/core/src/extractors/split.ts
+++ b/packages-engine/core/src/extractors/split.ts
@@ -2,16 +2,26 @@ import type { Extractor } from '../types'
 
 export const defaultSplitRE = /[\\:]?[\s'"`;{}]+/g
 export const splitWithVariantGroupRE = /([\\:]?[\s"'`;<>]|:\(|\)"|\)\s)/g
+const htmlClassAttributeRE = /<[a-z](?:[^"'<>]|"[^"]*"|'[^']*')*\sclass\s*=\s*([^\s"'`=<>{}]+)/gi
 
 export function splitCode(code: string): string[] {
   return code.split(defaultSplitRE)
+}
+
+function extractUnquotedClasses(code: string) {
+  return [...code.matchAll(htmlClassAttributeRE)]
+    .map(([, value]) => value.endsWith('/') ? value.slice(0, -1) : value)
 }
 
 export const extractorSplit: Extractor = {
   name: '@unocss/core/extractor-split',
   order: 0,
   extract({ code }) {
-    return splitCode(code)
+    const classes = extractUnquotedClasses(code)
+    return [
+      ...splitCode(code).filter(token => !classes.some(value => token === `class=${value}` || token === `class=${value}>` || token === `class=${value}/>`)),
+      ...classes,
+    ]
   },
 }
 

--- a/packages-engine/core/src/extractors/split.ts
+++ b/packages-engine/core/src/extractors/split.ts
@@ -2,7 +2,7 @@ import type { Extractor } from '../types'
 
 export const defaultSplitRE = /[\\:]?[\s'"`;{}]+/g
 export const splitWithVariantGroupRE = /([\\:]?[\s"'`;<>]|:\(|\)"|\)\s)/g
-const htmlClassAttributeRE = /<[a-z](?:[^"'<>]|"[^"]*"|'[^']*')*\sclass\s*=\s*([^\s"'`=<>{}]+)/gi
+const htmlClassAttributeRE = /(<[a-z](?:[^"'<>]|"[^"]*"|'[^']*')*?)\sclass\s*=\s*([^\s"'`=<>{}]+)(?=[\s/>]|$)/gi
 
 export function splitCode(code: string): string[] {
   return code.split(defaultSplitRE)
@@ -10,7 +10,11 @@ export function splitCode(code: string): string[] {
 
 function extractUnquotedClasses(code: string) {
   return [...code.matchAll(htmlClassAttributeRE)]
-    .map(([, value]) => value.endsWith('/') ? value.slice(0, -1) : value)
+    .map(([, , value]) => value.endsWith('/') ? value.slice(0, -1) : value)
+}
+
+function removeUnquotedClassAttributes(code: string) {
+  return code.replace(htmlClassAttributeRE, '$1')
 }
 
 export const extractorSplit: Extractor = {
@@ -19,7 +23,7 @@ export const extractorSplit: Extractor = {
   extract({ code }) {
     const classes = extractUnquotedClasses(code)
     return [
-      ...splitCode(code).filter(token => !classes.some(value => token === `class=${value}` || token === `class=${value}>` || token === `class=${value}/>`)),
+      ...splitCode(removeUnquotedClassAttributes(code)),
       ...classes,
     ]
   },

--- a/packages-engine/core/test/extractor.test.ts
+++ b/packages-engine/core/test/extractor.test.ts
@@ -14,6 +14,25 @@ it('extractorSplit', async () => {
   expect(await extract('<div :class="{ fixed: isMobile }">')).toContain('fixed')
 })
 
+it('extractorSplit extracts unquoted HTML class attributes', async () => {
+  async function extract(code: string) {
+    return [...await extractorSplit.extract?.({ code, original: code } as any) || []]
+  }
+
+  const classAttribute = await extract('<div class=foo id=ignored>')
+  expect(classAttribute).toContain('foo')
+  expect(classAttribute).not.toContain('class=foo')
+
+  const selfClosingClassAttribute = await extract('<div class=hover:bg-red-500/>')
+  expect(selfClosingClassAttribute).toContain('hover:bg-red-500')
+  expect(selfClosingClassAttribute).not.toContain('class=hover:bg-red-500/>')
+
+  const unquotedAttributes = await extract('<div id=ignored data-class=ignored className=ignored :class=ignored title="class=ignored">')
+  expect(unquotedAttributes).not.toContain('ignored')
+
+  expect(await extract('<div class={active}>')).eql(['<div', 'class=', 'active', '>'])
+})
+
 it('extractorSplitArbitrary', async () => {
   async function extract(code: string) {
     return [...await extractorArbitraryVariants().extract!({ code, original: code } as any) || []]

--- a/packages-engine/core/test/extractor.test.ts
+++ b/packages-engine/core/test/extractor.test.ts
@@ -27,6 +27,15 @@ it('extractorSplit extracts unquoted HTML class attributes', async () => {
   expect(selfClosingClassAttribute).toContain('hover:bg-red-500')
   expect(selfClosingClassAttribute).not.toContain('class=hover:bg-red-500/>')
 
+  for (const code of ['<div class = text-red-500>', '<div class= text-red-500>']) {
+    const whitespaceClassAttribute = await extract(code)
+    expect(whitespaceClassAttribute).toContain('text-red-500')
+    expect(whitespaceClassAttribute).not.toContain('text-red-500>')
+  }
+
+  for (const code of ['<div class=foo=bar>', '<div class=foo"bar>', '<div class=foo{bar}>', '<div class=foo<bar>'])
+    expect(await extract(code)).not.toContain('foo')
+
   const unquotedAttributes = await extract('<div id=ignored data-class=ignored className=ignored :class=ignored title="class=ignored">')
   expect(unquotedAttributes).not.toContain('ignored')
 


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

- extract values from valid unquoted HTML `class` attributes
- reject malformed values without producing partial utilities
- cover valid spacing forms and existing quoted/framework behavior

## Validation

- focused extractor tests
- full core unit suite
- ESLint and package build/typecheck

Closes #5258