### PR TITLE
fix(preset-wind4): add font fallbacks without theme preflight

### DIFF
--- a/packages-presets/preset-wind4/src/rules/typography.ts
+++ b/packages-presets/preset-wind4/src/rules/typography.ts
@@ -159,7 +159,7 @@ export const fonts: Rule<Theme>[] = [
       // Prefer theme font family
       if (theme.font?.[d]) {
         themeTracking('font', d)
-        v = generateThemeVariable('font', d)
+        v = `var(--font-${d}, ${theme.font[d]})`
         return { 'font-family': v }
       }
 

--- a/test/__snapshots__/preset-web-fonts.test.ts.snap
+++ b/test/__snapshots__/preset-web-fonts.test.ts.snap
@@ -1470,5 +1470,5 @@ exports[`with presetWind4 1`] = `
 /* layer: theme */
 :root, :host { --font-custom: "Fira Code"; }
 /* layer: default */
-.font-custom{font-family:var(--font-custom);}"
+.font-custom{font-family:var(--font-custom, "Fira Code");}"
 `;

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -387,8 +387,8 @@
 .font-\$font-name{font-family:var(--font-name);}
 .font-550{--un-font-weight:550;font-weight:550;}
 .font-inherit{font-family:inherit;}
-.font-mono{font-family:var(--font-mono);}
-.font-sans{font-family:var(--font-sans);}
+.font-mono{font-family:var(--font-mono, ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace);}
+.font-sans{font-family:var(--font-sans, ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji");}
 .font-thin{--un-font-weight:var(--fontWeight-thin);font-weight:var(--fontWeight-thin);}
 .group:hover .group-hover\:font-10{--un-font-weight:10;font-weight:10;}
 .group\/label:hover .group-hover\/label\:font-15{--un-font-weight:15;font-weight:15;}

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -166,6 +166,41 @@ describe('preset-wind4', () => {
     await expect(css).toMatchFileSnapshot('./assets/output/preset-wind4-theme.css')
   })
 
+  it('font families fall back to the theme value without theme preflight', async () => {
+    const uno = await createGenerator({
+      presets: [
+        presetWind4({ preflights: { reset: false, theme: false } }),
+      ],
+    })
+
+    const { css } = await uno.generate('font-sans font-serif font-mono')
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .font-mono{font-family:var(--font-mono, ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace);}
+      .font-sans{font-family:var(--font-sans, ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji");}
+      .font-serif{font-family:var(--font-serif, ui-serif,Georgia,Cambria,"Times New Roman",Times,serif);}"
+    `,
+    )
+  })
+
+  it('font families use custom theme values with theme preflight', async () => {
+    const uno = await createGenerator({
+      presets: [presetWind4({ preflights: { reset: false } })],
+      theme: {
+        font: { sans: 'Custom Sans' },
+      },
+    })
+
+    const { css } = await uno.generate('font-sans')
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: theme */
+      :root, :host { --font-sans: Custom Sans; }
+      /* layer: default */
+      .font-sans{font-family:var(--font-sans, Custom Sans);}"
+    `,
+    )
+  })
+
   it('custom theme values with variable', async () => {
     const uno = await createGenerator({
       envMode: 'dev',

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -201,6 +201,24 @@ describe('preset-wind4', () => {
     )
   })
 
+  it('font families fall back to custom theme values without theme preflight', async () => {
+    const uno = await createGenerator({
+      presets: [
+        presetWind4({ preflights: { reset: false, theme: false } }),
+      ],
+      theme: {
+        font: { sans: 'Custom Sans' },
+      },
+    })
+
+    const { css } = await uno.generate('font-sans')
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .font-sans{font-family:var(--font-sans, Custom Sans);}"
+    `,
+    )
+  })
+
   it('custom theme values with variable', async () => {
     const uno = await createGenerator({
       envMode: 'dev',

--- a/test/transformer-directives.test.ts
+++ b/test/transformer-directives.test.ts
@@ -1497,7 +1497,17 @@ describe('wind4', () => {
             font-size: var(--text-lg-fontSize);
             line-height: var(--un-leading, var(--text-lg-lineHeight));
             border-radius: var(--radius-DEFAULT);
-            font-family: var(--font-mono);
+            font-family: var(
+              --font-mono,
+              ui-monospace,
+              SFMono-Regular,
+              Menlo,
+              Monaco,
+              Consolas,
+              "Liberation Mono",
+              "Courier New",
+              monospace
+            );
           }
           "
         `)


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

- add resolved font-family fallbacks for Wind4 font utilities
- preserve theme-variable overrides and normal preflight behavior
- cover default/custom themes with enabled and disabled theme preflight

## Validation

- full test suite
- ESLint and typecheck
- parallel spec and standards reviews

Closes #5253