### PR TITLE
feat: add Rollup and Rolldown integration

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -43,6 +43,7 @@ const Integrations = [
   { text: 'Astro', link: '/integrations/astro' },
   { text: 'Svelte Scoped', link: '/integrations/svelte-scoped' },
   { text: 'Webpack', link: '/integrations/webpack' },
+  { text: 'Rollup and Rolldown', link: '/integrations/rollup' },
   { text: 'Runtime', link: '/integrations/runtime' },
   { text: 'CLI', link: '/integrations/cli' },
   { text: 'PostCSS', link: '/integrations/postcss' },

--- a/docs/integrations/rollup.md
+++ b/docs/integrations/rollup.md
@@ -1,0 +1,89 @@
+---
+title: UnoCSS Rollup and Rolldown Plugin
+description: Use UnoCSS with Rollup or Rolldown.
+outline: deep
+---
+
+# Rollup and Rolldown Plugin
+
+Use UnoCSS with Rollup or Rolldown without Vite. The plugin supports the `global` mode and emits a CSS asset when you import `uno.css` from an entry module.
+
+## Installation
+
+::: code-group
+
+```bash [pnpm]
+pnpm add -D unocss rollup
+```
+
+```bash [yarn]
+yarn add -D unocss rollup
+```
+
+```bash [npm]
+npm install -D unocss rollup
+```
+
+```bash [bun]
+bun add -D unocss rollup
+```
+
+:::
+
+Replace `rollup` with `rolldown` when you use Rolldown.
+
+## Rollup
+
+```ts [rollup.config.ts]
+import UnoCSS from 'unocss/rollup'
+
+export default {
+  input: 'src/main.ts',
+  plugins: [
+    UnoCSS(),
+  ],
+}
+```
+
+## Rolldown
+
+```ts [rolldown.config.ts]
+import UnoCSS from 'unocss/rolldown'
+
+export default {
+  input: 'src/main.ts',
+  plugins: [
+    UnoCSS(),
+  ],
+}
+```
+
+Import `uno.css` from an entry module:
+
+```ts [src/main.ts]
+import 'uno.css'
+```
+
+The plugin emits generated CSS as an output asset. Include that asset in your application with your deployment or HTML pipeline.
+
+## Configuration
+
+Create a `uno.config.ts` file:
+
+```ts [uno.config.ts]
+import { defineConfig } from 'unocss'
+
+export default defineConfig({
+  // ...UnoCSS options
+})
+```
+
+You can also pass the configuration to the plugin directly:
+
+```ts
+import UnoCSS from 'unocss/rollup'
+
+UnoCSS({
+  // ...UnoCSS options
+})
+```

--- a/packages-integrations/README.md
+++ b/packages-integrations/README.md
@@ -2,16 +2,17 @@
 
 Packages that integrate UnoCSS with other tools, they should be aimed for agnostic on presets.
 
-| Package                                  | Description                  | Included in `unocss` |
-| ---------------------------------------- | ---------------------------- | -------------------- |
-| [@unocss/vite](./vite)                   | The Vite plugins             | ✅                   |
-| [@unocss/astro](./astro)                 | The Astro integration        | ✅                   |
-| [@unocss/webpack](./webpack)             | The Webpack plugin           | No                   |
-| [@unocss/postcss](./postcss)             | The PostCSS plugin           | No                   |
-| [@unocss/inspector](./postcss)           | Embedded Inspector UI        | ✅                   |
-| [@unocss/nuxt](./nuxt)                   | The Nuxt Module              | No                   |
-| [@unocss/runtime](./runtime)             | CSS-in-JS Runtime for UnoCSS | No                   |
-| [@unocss/svelte-scoped](./svelte-scoped) | Scoped UnoCSS for Svelte     | No                   |
-| [@unocss/eslint-plugin](./eslint-plugin) | ESLint plugin                | No                   |
-| [@unocss/eslint-config](./eslint-config) | ESLint config                | No                   |
-| [VS Code Extension](./vscode)            | UnoCSS for VS Code           | -                    |
+| Package                                  | Description                    | Included in `unocss` |
+| ---------------------------------------- | ------------------------------ | -------------------- |
+| [@unocss/vite](./vite)                   | The Vite plugins               | ✅                   |
+| [@unocss/astro](./astro)                 | The Astro integration          | ✅                   |
+| [@unocss/webpack](./webpack)             | The Webpack plugin             | No                   |
+| [@unocss/rollup](./rollup)               | The Rollup and Rolldown plugin | ✅                   |
+| [@unocss/postcss](./postcss)             | The PostCSS plugin             | No                   |
+| [@unocss/inspector](./postcss)           | Embedded Inspector UI          | ✅                   |
+| [@unocss/nuxt](./nuxt)                   | The Nuxt Module                | No                   |
+| [@unocss/runtime](./runtime)             | CSS-in-JS Runtime for UnoCSS   | No                   |
+| [@unocss/svelte-scoped](./svelte-scoped) | Scoped UnoCSS for Svelte       | No                   |
+| [@unocss/eslint-plugin](./eslint-plugin) | ESLint plugin                  | No                   |
+| [@unocss/eslint-config](./eslint-config) | ESLint config                  | No                   |
+| [VS Code Extension](./vscode)            | UnoCSS for VS Code             | -                    |

--- a/packages-integrations/rollup/package.json
+++ b/packages-integrations/rollup/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/rollup",
   "type": "module",
-  "version": "66.8.1",
+  "version": "66.9.2",
   "description": "The Rollup and Rolldown plugin for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages-integrations/rollup/package.json
+++ b/packages-integrations/rollup/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@unocss/rollup",
+  "type": "module",
+  "version": "66.8.1",
+  "description": "The Rollup and Rolldown plugin for UnoCSS",
+  "author": "Anthony Fu <anthonyfu117@hotmail.com>",
+  "license": "MIT",
+  "funding": "https://github.com/sponsors/antfu",
+  "homepage": "https://unocss.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unocss/unocss.git",
+    "directory": "packages-integrations/rollup"
+  },
+  "bugs": {
+    "url": "https://github.com/unocss/unocss/issues"
+  },
+  "keywords": [
+    "unocss",
+    "rollup-plugin",
+    "rolldown-plugin"
+  ],
+  "sideEffects": false,
+  "exports": {
+    ".": "./dist/index.mjs",
+    "./package.json": "./package.json"
+  },
+  "types": "dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*.d.mts",
+        "./*"
+      ]
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown --config-loader unrun",
+    "prepack": "turbo build --filter=.",
+    "dev": "tsdown --config-loader unrun --watch"
+  },
+  "peerDependencies": {
+    "rolldown": "^1.0.0",
+    "rollup": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "rolldown": {
+      "optional": true
+    },
+    "rollup": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@jridgewell/remapping": "catalog:build",
+    "@unocss/config": "workspace:*",
+    "@unocss/core": "workspace:*",
+    "chokidar": "catalog:utils",
+    "magic-string": "catalog:utils",
+    "pathe": "catalog:utils",
+    "tinyglobby": "catalog:utils",
+    "unplugin-utils": "catalog:utils"
+  },
+  "devDependencies": {
+    "rolldown": "catalog:build",
+    "rollup": "catalog:build"
+  }
+}

--- a/packages-integrations/rollup/src/index.ts
+++ b/packages-integrations/rollup/src/index.ts
@@ -1,0 +1,113 @@
+import type { UserConfigDefaults } from '@unocss/core'
+import type { RollupPluginConfig, UnoCSSRollupPlugin } from './types'
+import process from 'node:process'
+import { LAYER_IMPORTS } from '@unocss/core'
+import { setupContentExtractor } from '#integration/content'
+import { createContext } from '#integration/context'
+import { resolveId, resolveLayer } from '#integration/layers'
+import { applyTransformers } from '#integration/transformers'
+
+export * from './types'
+
+export function defineConfig<Theme extends object>(config: RollupPluginConfig<Theme>) {
+  return config
+}
+
+export default function RollupPlugin<Theme extends object>(
+  configOrPath?: RollupPluginConfig<Theme> | string,
+  defaults: UserConfigDefaults = {},
+): UnoCSSRollupPlugin {
+  const ctx = createContext<RollupPluginConfig>(configOrPath as any, {
+    envMode: process.env.NODE_ENV === 'development' ? 'dev' : 'build',
+    ...defaults,
+  })
+  const { extract, filter, flushTasks, getConfig, tasks, tokens } = ctx
+  const vfsLayers = new Map<string, string>()
+  const unocssImporters = new Set<string>()
+  let lastTokenSize = 0
+  let css = ''
+
+  async function generateCss() {
+    await flushTasks()
+    if (lastTokenSize === tokens.size)
+      return css
+
+    const result = await ctx.uno.generate(tokens, { minify: true })
+    css = result.getLayers(undefined, [LAYER_IMPORTS, ...vfsLayers.keys()])
+    lastTokenSize = tokens.size
+    return css
+  }
+
+  return {
+    name: 'unocss:rollup',
+    async buildStart() {
+      await ctx.ready
+      vfsLayers.clear()
+      tasks.length = 0
+      lastTokenSize = 0
+      css = ''
+      tasks.push(setupContentExtractor(ctx))
+    },
+    async transform(code, id) {
+      if (!filter(code, id))
+        return null
+
+      const preTransform = await applyTransformers(ctx, code, id, 'pre')
+      const defaultTransform = await applyTransformers(ctx, preTransform?.code || code, id)
+      const postTransform = await applyTransformers(ctx, defaultTransform?.code || preTransform?.code || code, id, 'post')
+      const transformedCode = postTransform?.code || defaultTransform?.code || preTransform?.code || code
+
+      tasks.push(extract(transformedCode, id))
+      return postTransform || defaultTransform || preTransform || null
+    },
+    async resolveId(id, importer) {
+      const entry = await resolveId(ctx, id, importer)
+      if (!entry)
+        return
+
+      const layer = await resolveLayer(ctx, entry)
+      if (!layer)
+        return entry
+
+      if (importer)
+        unocssImporters.add(importer)
+
+      if (vfsLayers.has(layer)) {
+        this.warn(`[unocss] ${JSON.stringify(id)} is being imported multiple times in different files, using the first occurrence: ${JSON.stringify(vfsLayers.get(layer))}`)
+        return vfsLayers.get(layer)
+      }
+
+      const virtualEntry = `\0unocss:${layer}`
+      vfsLayers.set(layer, virtualEntry)
+      return virtualEntry
+    },
+    load(id) {
+      const layer = Array.from(vfsLayers).find(([, entry]) => entry === id)?.[0]
+      if (!layer)
+        return
+
+      return {
+        code: '',
+        map: null,
+        moduleSideEffects: true,
+      }
+    },
+    shouldTransformCachedModule({ id }) {
+      return unocssImporters.delete(id)
+    },
+    async generateBundle() {
+      if (!vfsLayers.size) {
+        if ((await getConfig()).checkImport) {
+          this.warn('[unocss] Entry module not found. Did you add `import \'uno.css\'` in your main entry?')
+        }
+        return
+      }
+
+      this.emitFile({
+        type: 'asset',
+        name: 'uno.css',
+        source: await generateCss(),
+      })
+    },
+  }
+}

--- a/packages-integrations/rollup/src/types.ts
+++ b/packages-integrations/rollup/src/types.ts
@@ -1,0 +1,13 @@
+import type { UserConfig } from '@unocss/core'
+import type { Plugin } from 'rollup'
+
+export interface RollupPluginConfig<Theme extends object = object> extends UserConfig<Theme> {
+  /**
+   * Disable the warning when no UnoCSS virtual CSS entry is imported.
+   *
+   * @default false
+   */
+  checkImport?: boolean
+}
+
+export type UnoCSSRollupPlugin = Plugin

--- a/packages-integrations/rollup/src/types.ts
+++ b/packages-integrations/rollup/src/types.ts
@@ -3,7 +3,7 @@ import type { Plugin } from 'rollup'
 
 export interface RollupPluginConfig<Theme extends object = object> extends UserConfig<Theme> {
   /**
-   * Disable the warning when no UnoCSS virtual CSS entry is imported.
+   * Warn when no UnoCSS virtual CSS entry is imported.
    *
    * @default false
    */

--- a/packages-integrations/rollup/tsdown.config.ts
+++ b/packages-integrations/rollup/tsdown.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'tsdown'
+import { aliasVirtual } from '../../alias'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  clean: true,
+  dts: true,
+  alias: aliasVirtual,
+  deps: {
+    neverBundle: [
+      'rolldown',
+      'rollup',
+    ],
+  },
+  exports: true,
+  failOnWarn: true,
+  publint: 'ci-only',
+  attw: {
+    enabled: 'ci-only',
+    ignoreRules: ['cjs-resolves-to-esm'],
+  },
+})

--- a/packages-presets/unocss/package.json
+++ b/packages-presets/unocss/package.json
@@ -44,6 +44,8 @@
     "./preset-wind": "./dist/preset-wind.mjs",
     "./preset-wind3": "./dist/preset-wind3.mjs",
     "./preset-wind4": "./dist/preset-wind4.mjs",
+    "./rolldown": "./dist/rolldown.mjs",
+    "./rollup": "./dist/rollup.mjs",
     "./vite": "./dist/vite.mjs",
     "./webpack": {
       "import": "./dist/webpack.mjs",
@@ -100,6 +102,7 @@
     "@unocss/preset-wind": "workspace:*",
     "@unocss/preset-wind3": "workspace:*",
     "@unocss/preset-wind4": "workspace:*",
+    "@unocss/rollup": "workspace:*",
     "@unocss/transformer-attributify-jsx": "workspace:*",
     "@unocss/transformer-compile-class": "workspace:*",
     "@unocss/transformer-directives": "workspace:*",

--- a/packages-presets/unocss/src/rolldown.ts
+++ b/packages-presets/unocss/src/rolldown.ts
@@ -1,0 +1,2 @@
+export * from './rollup'
+export { default } from './rollup'

--- a/packages-presets/unocss/src/rollup.ts
+++ b/packages-presets/unocss/src/rollup.ts
@@ -1,0 +1,19 @@
+import type { RollupPluginConfig } from '@unocss/rollup'
+import type { Plugin } from 'rollup'
+import presetWind3 from '@unocss/preset-wind3'
+import RollupPlugin from '@unocss/rollup'
+
+export * from '@unocss/rollup'
+
+export default function UnocssRollupPlugin<Theme extends object>(
+  configOrPath?: RollupPluginConfig<Theme> | string,
+): Plugin {
+  return RollupPlugin(
+    configOrPath,
+    {
+      presets: [
+        presetWind3(),
+      ],
+    },
+  )
+}

--- a/packages-presets/unocss/tsdown.config.ts
+++ b/packages-presets/unocss/tsdown.config.ts
@@ -33,12 +33,16 @@ export default defineConfig([
       'src/preset-mini.ts',
       'src/preset-wind3.ts',
       'src/preset-wind4.ts',
+      'src/rolldown.ts',
+      'src/rollup.ts',
     ],
     clean: false,
     dts: true,
     deps: {
       neverBundle: [
         'astro',
+        'rolldown',
+        'rollup',
         'vite',
       ],
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,7 +496,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: catalog:eslint
-        version: 9.3.0(@typescript-eslint/typescript-estree@8.69.0)(@typescript-eslint/utils@8.69.0)(@unocss/eslint-plugin@66.8.1)(@vue/compiler-sfc@3.5.42)(eslint-plugin-format@2.0.1)(eslint@10.9.1)(supports-color@10.2.2)(svelte-eslint-parser@1.8.1)(typescript@6.0.3)(vitest@4.1.11)
+        version: 9.3.0(@typescript-eslint/typescript-estree@8.69.0)(@typescript-eslint/utils@8.69.0)(@unocss/eslint-plugin@66.9.1)(@vue/compiler-sfc@3.5.42)(eslint-plugin-format@2.0.1)(eslint@10.9.1)(supports-color@10.2.2)(svelte-eslint-parser@1.8.1)(typescript@6.0.3)(vitest@4.1.11)
       '@antfu/ni':
         specifier: catalog:utils
         version: 30.5.0
@@ -1231,7 +1231,7 @@ importers:
         version: 1.2.6
       rollup:
         specifier: catalog:build
-        version: 4.63.0
+        version: 4.63.1
 
   packages-integrations/runtime:
     dependencies:
@@ -4691,17 +4691,17 @@ packages:
       webpack:
         optional: true
 
-  '@unocss/config@66.8.1':
-    resolution: {integrity: sha512-2MhijaV6a4OWSH5zJeo2QLIUr7gtjxdA3x1D4CIDCWQnrEqmPstOBRQOhWDl3HbLW6/0jHOFSMExbeeFvCvnsA==}
+  '@unocss/config@66.9.1':
+    resolution: {integrity: sha512-1Re36+AGU6c3OXIq/lOhsEe6yGVsNy0DBFscKiA7GTl/ZS6ofADitSKkd9+FFx2QbztAJi2mbcuMnW+gtY76yw==}
 
-  '@unocss/core@66.8.1':
-    resolution: {integrity: sha512-ze/3qTloXZtFn6TXiNjL6ai1vgMvTCXIm8nqTzoU/Dt5d5MRxA86ERfUmgTX70rEBam5l6vnsaEVZO6WnHhdRA==}
+  '@unocss/core@66.9.1':
+    resolution: {integrity: sha512-x4ckZij1dV8mdLx9dpLPH5Aw5bUvGQM58p7pj6HYpeufxxE+qQeEOGuMZkmWSjilfZ039Zj9/KPf+e/V7sqMdQ==}
 
-  '@unocss/eslint-plugin@66.8.1':
-    resolution: {integrity: sha512-MC2zoxGq9LRa1Ix3DujBNAkhLXkv3y0R1CuAFvLujvxjuXls4wv29O2NdwNNazuAL8smXDs5LceRZvIijdP7+g==}
+  '@unocss/eslint-plugin@66.9.1':
+    resolution: {integrity: sha512-2NVwDXQ6HsK+2juROpn+qai1vklVXAEduN9rzwd83oj1aKowUG2ATY6/YZK28e2uNpNkXqskHUtag5vJMv/7aA==}
 
-  '@unocss/rule-utils@66.8.1':
-    resolution: {integrity: sha512-EQ9bhifqIodIsl7+eOmkCVWXkZ7dnwkmTURFyAosVpUc8j4WYsfnQC+3SjKnJfT44s1rIqHJtoBBaG9X97opdA==}
+  '@unocss/rule-utils@66.9.1':
+    resolution: {integrity: sha512-4Du8AAauGzLoMBfic0C7S1oo2PFuDYeM8etiE8ZBR66T+utIWUrP6JZWE1h5ti6DNrhf7OFWRM/EuOFus1AjjQ==}
 
   '@vercel/nft@1.11.0':
     resolution: {integrity: sha512-m1QFg+U+3yPOnP1xSYJ73UIRxLOXdts1JOhiOiyPYqEsALgrXFFINvgUaD6R6iNvaBFAjHllBCbkfx4FuOdpaA==}
@@ -9949,7 +9949,7 @@ snapshots:
 
   '@andrewbranch/untar.js@1.0.4': {}
 
-  '@antfu/eslint-config@9.3.0(@typescript-eslint/typescript-estree@8.69.0)(@typescript-eslint/utils@8.69.0)(@unocss/eslint-plugin@66.8.1)(@vue/compiler-sfc@3.5.42)(eslint-plugin-format@2.0.1)(eslint@10.9.1)(supports-color@10.2.2)(svelte-eslint-parser@1.8.1)(typescript@6.0.3)(vitest@4.1.11)':
+  '@antfu/eslint-config@9.3.0(@typescript-eslint/typescript-estree@8.69.0)(@typescript-eslint/utils@8.69.0)(@unocss/eslint-plugin@66.9.1)(@vue/compiler-sfc@3.5.42)(eslint-plugin-format@2.0.1)(eslint@10.9.1)(supports-color@10.2.2)(svelte-eslint-parser@1.8.1)(typescript@6.0.3)(vitest@4.1.11)':
     dependencies:
       '@antfu/install-pkg': 2.0.1
       '@clack/prompts': 1.7.0
@@ -9989,7 +9989,7 @@ snapshots:
       vue-eslint-parser: 10.4.1(eslint@10.9.1)(supports-color@10.2.2)
       yaml-eslint-parser: 2.1.0
     optionalDependencies:
-      '@unocss/eslint-plugin': 66.8.1(eslint@10.9.1)(supports-color@10.2.2)(typescript@6.0.3)
+      '@unocss/eslint-plugin': 66.9.1(eslint@10.9.1)(supports-color@10.2.2)(typescript@6.0.3)
       eslint-plugin-format: 2.0.1(eslint@10.9.1)
       svelte-eslint-parser: 1.8.1(svelte@5.57.0)
     transitivePeerDependencies:
@@ -12965,23 +12965,23 @@ snapshots:
       - rollup
       - unloader
 
-  '@unocss/config@66.8.1':
+  '@unocss/config@66.9.1':
     dependencies:
-      '@unocss/core': 66.8.1
+      '@unocss/core': 66.9.1
       colorette: 2.0.20
       consola: 3.4.2
       unconfig: 7.5.0
     optional: true
 
-  '@unocss/core@66.8.1':
+  '@unocss/core@66.9.1':
     optional: true
 
-  '@unocss/eslint-plugin@66.8.1(eslint@10.9.1)(supports-color@10.2.2)(typescript@6.0.3)':
+  '@unocss/eslint-plugin@66.9.1(eslint@10.9.1)(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/utils': 8.69.0(eslint@10.9.1)(supports-color@10.2.2)(typescript@6.0.3)
-      '@unocss/config': 66.8.1
-      '@unocss/core': 66.8.1
-      '@unocss/rule-utils': 66.8.1
+      '@unocss/config': 66.9.1
+      '@unocss/core': 66.9.1
+      '@unocss/rule-utils': 66.9.1
       magic-string: 1.2.3
       synckit: 0.11.13
     transitivePeerDependencies:
@@ -12990,9 +12990,9 @@ snapshots:
       - typescript
     optional: true
 
-  '@unocss/rule-utils@66.8.1':
+  '@unocss/rule-utils@66.9.1':
     dependencies:
-      '@unocss/core': 66.8.1
+      '@unocss/core': 66.9.1
       magic-string: 1.2.3
     optional: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ catalogs:
     gzip-size:
       specifier: ^6.0.0
       version: 6.0.0
+    rolldown:
+      specifier: ^1.0.0
+      version: 1.2.6
     rollup:
       specifier: ^4.63.0
       version: 4.63.1
@@ -1196,6 +1199,40 @@ importers:
         specifier: catalog:utils
         version: 0.2.17
 
+  packages-integrations/rollup:
+    dependencies:
+      '@jridgewell/remapping':
+        specifier: catalog:build
+        version: 2.3.5
+      '@unocss/config':
+        specifier: workspace:*
+        version: link:../../packages-engine/config
+      '@unocss/core':
+        specifier: workspace:*
+        version: link:../../packages-engine/core
+      chokidar:
+        specifier: catalog:utils
+        version: 5.0.0
+      magic-string:
+        specifier: catalog:utils
+        version: 1.2.3
+      pathe:
+        specifier: catalog:utils
+        version: 2.0.3
+      tinyglobby:
+        specifier: catalog:utils
+        version: 0.2.17
+      unplugin-utils:
+        specifier: catalog:utils
+        version: 0.3.2
+    devDependencies:
+      rolldown:
+        specifier: catalog:build
+        version: 1.2.6
+      rollup:
+        specifier: catalog:build
+        version: 4.63.0
+
   packages-integrations/runtime:
     dependencies:
       '@iconify/utils':
@@ -1604,6 +1641,9 @@ importers:
       '@unocss/preset-wind4':
         specifier: workspace:*
         version: link:../preset-wind4
+      '@unocss/rollup':
+        specifier: workspace:*
+        version: link:../../packages-integrations/rollup
       '@unocss/transformer-attributify-jsx':
         specifier: workspace:*
         version: link:../transformer-attributify-jsx

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,7 @@ catalogs:
     brotli-size: ^4.0.0
     bumpp: ^12.2.1
     gzip-size: ^6.0.0
+    rolldown: ^1.0.0
     rollup: ^4.63.0
     terser: ^5.50.0
     tsdown: ^0.22.14

--- a/scripts/prepare.ts
+++ b/scripts/prepare.ts
@@ -38,6 +38,7 @@ async function preparePackagesBundle() {
     'reset',
     'svelte',
     'runtime',
+    'rollup',
     'shared',
     'scope',
     'babel',

--- a/test/rollup-assets.test.ts
+++ b/test/rollup-assets.test.ts
@@ -1,0 +1,52 @@
+import type { Plugin } from 'rollup'
+import UnoCSS from '@unocss/rollup'
+import { rolldown } from 'rolldown'
+import { rollup } from 'rollup'
+import { describe, expect, it } from 'vitest'
+
+function entryPlugin(): Plugin {
+  return {
+    name: 'entry',
+    resolveId(id) {
+      if (id === 'entry')
+        return '/entry.tsx'
+    },
+    load(id) {
+      if (id === '/entry.tsx')
+        return 'import \'uno.css\'\nexport const className = \'text-red-500\''
+    },
+  }
+}
+
+async function getUnoCss(bundle: { generate: (options: { format: 'es' }) => Promise<{ output: Array<{ type: string, source?: unknown }> }> }) {
+  const output = await bundle.generate({ format: 'es' })
+  const asset = output.output.find(item => item.type === 'asset')
+
+  expect(asset?.source).toContain('.text-red-500')
+}
+
+describe('rollup-compatible plugin', () => {
+  it('emits UnoCSS with Rollup', async () => {
+    const bundle = await rollup({
+      input: 'entry',
+      plugins: [
+        entryPlugin(),
+        UnoCSS({ rules: [['text-red-500', { color: 'red' }]] }),
+      ],
+    })
+
+    await getUnoCss(bundle)
+  })
+
+  it('emits UnoCSS with Rolldown', async () => {
+    const bundle = await rolldown({
+      input: 'entry',
+      plugins: [
+        entryPlugin(),
+        UnoCSS({ rules: [['text-red-500', { color: 'red' }]] }),
+      ],
+    })
+
+    await getUnoCss(bundle)
+  })
+})

--- a/test/rollup-check-import.test.ts
+++ b/test/rollup-check-import.test.ts
@@ -1,0 +1,72 @@
+import type { Plugin } from 'rollup'
+import UnoCSS from '@unocss/rollup'
+import { rolldown } from 'rolldown'
+import { rollup } from 'rollup'
+import { describe, expect, it } from 'vitest'
+
+function entryPlugin(withUnoCssImport: boolean): Plugin {
+  return {
+    name: 'entry',
+    resolveId(id) {
+      if (id === 'entry')
+        return '/entry.tsx'
+    },
+    load(id) {
+      if (id === '/entry.tsx')
+        return `${withUnoCssImport ? 'import \'uno.css\'' : ''}\nexport const className = 'text-red-500'`
+    },
+  }
+}
+
+interface Warning { message: string }
+interface BuildOutput { generate: (options: { format: 'es' }) => Promise<{ output: Array<{ type: string, source?: unknown }> }> }
+type BuildFn = (options: { onwarn: (warning: Warning) => void }) => Promise<BuildOutput>
+
+function withRollup(withUnoCssImport: boolean, checkImport: boolean | undefined): BuildFn {
+  return ({ onwarn }) => rollup({
+    input: 'entry',
+    onwarn,
+    plugins: [
+      entryPlugin(withUnoCssImport),
+      UnoCSS({ checkImport, rules: [['text-red-500', { color: 'red' }]] }),
+    ],
+  })
+}
+
+function withRolldown(withUnoCssImport: boolean, checkImport: boolean | undefined): BuildFn {
+  return ({ onwarn }) => rolldown({
+    input: 'entry',
+    onwarn,
+    plugins: [
+      entryPlugin(withUnoCssImport),
+      UnoCSS({ checkImport, rules: [['text-red-500', { color: 'red' }]] }),
+    ],
+  })
+}
+
+async function getWarnings(build: BuildFn) {
+  const warnings: string[] = []
+  const bundle = await build({ onwarn: warning => warnings.push(warning.message) })
+  await bundle.generate({ format: 'es' })
+  return warnings
+}
+
+describe.each([
+  ['rollup', withRollup],
+  ['rolldown', withRolldown],
+])('checkImport (%s)', (_, createBuild) => {
+  it('warns when no UnoCSS virtual CSS entry is imported and checkImport is true', async () => {
+    const warnings = await getWarnings(createBuild(false, true))
+    expect(warnings.some(w => w.includes('import \'uno.css\''))).toBe(true)
+  })
+
+  it('does not warn when no UnoCSS virtual CSS entry is imported and checkImport is unset', async () => {
+    const warnings = await getWarnings(createBuild(false, undefined))
+    expect(warnings.some(w => w.includes('import \'uno.css\''))).toBe(false)
+  })
+
+  it('does not warn when the UnoCSS virtual CSS entry is imported and checkImport is true', async () => {
+    const warnings = await getWarnings(createBuild(true, true))
+    expect(warnings.some(w => w.includes('import \'uno.css\''))).toBe(false)
+  })
+})

--- a/virtual-shared/docs/src/packages.ts
+++ b/virtual-shared/docs/src/packages.ts
@@ -16,6 +16,7 @@ export const allPackages = [
   "@unocss/language-server",
   "@unocss/nuxt",
   "@unocss/postcss",
+  "@unocss/rollup",
   "@unocss/runtime",
   "@unocss/scope",
   "@unocss/svelte-scoped",


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

- add `@unocss/rollup` with Rollup and Rolldown support
- expose `unocss/rollup` and `unocss/rolldown` public entry points
- document integration and cover both bundlers

## Validation

- Rollup and Rolldown integration tests
- typecheck, lint, and workspace build
- parallel spec and standards reviews

Closes #5162