### PR TITLE
fix(vite): encode virtual IDs in global HMR updates

### DIFF
--- a/packages-integrations/vite/src/modes/global/dev.ts
+++ b/packages-integrations/vite/src/modes/global/dev.ts
@@ -8,7 +8,7 @@ import { LAYER_MARK_ALL } from '#integration/constants'
 import { getHash } from '#integration/hash'
 import { resolveId, resolveLayer } from '#integration/layers'
 import { getPath } from '#integration/utils'
-import { toViteVirtualId } from '../../virtual'
+import { toViteClientPath, toViteVirtualId } from '../../virtual'
 import { MESSAGE_UNOCSS_ENTRY_NOT_FOUND } from './shared'
 
 const WARN_TIMEOUT = 20000
@@ -75,9 +75,10 @@ export function GlobalModeDevPlugin(ctx: UnocssPluginContext): Plugin[] {
             const mod = server.moduleGraph.getModuleById(id)
             if (!mod)
               return null
+            const path = toViteClientPath(mod.url)
             return {
-              acceptedPath: mod.url,
-              path: mod.url,
+              acceptedPath: path,
+              path,
               timestamp: lastServedTime,
               type: 'js-update',
             } as Update

--- a/packages-integrations/vite/src/virtual.ts
+++ b/packages-integrations/vite/src/virtual.ts
@@ -1,7 +1,15 @@
 const VITE_VIRTUAL_ID_PREFIX = '\0'
+const VITE_CLIENT_ID_PREFIX = '/@id/'
+const VITE_NULL_BYTE_PLACEHOLDER = '__x00__'
 
 export function toViteVirtualId(id: string) {
   return id.startsWith(VITE_VIRTUAL_ID_PREFIX)
     ? id
     : `${VITE_VIRTUAL_ID_PREFIX}${id}`
+}
+
+export function toViteClientPath(id: string) {
+  return id.startsWith(VITE_VIRTUAL_ID_PREFIX)
+    ? `${VITE_CLIENT_ID_PREFIX}${id.replace(VITE_VIRTUAL_ID_PREFIX, VITE_NULL_BYTE_PLACEHOLDER)}`
+    : id
 }

--- a/test/virtual-modules.test.ts
+++ b/test/virtual-modules.test.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path'
 import * as vite from 'vite'
 import { describe, expect, it } from 'vitest'
 import UnoCSS from '../packages-integrations/vite/src/index'
+import { toViteClientPath } from '../packages-integrations/vite/src/virtual'
 
 describe('vite virtual module ids', () => {
   async function createServer(mode: 'global' | 'per-module') {
@@ -26,6 +27,13 @@ describe('vite virtual module ids', () => {
     finally {
       await server.close()
     }
+  })
+
+  it('converts internal ids to public client paths', () => {
+    expect(toViteClientPath('\0/__uno.css'))
+      .toBe('/@id/__x00__/__uno.css')
+    expect(toViteClientPath('/src/main.ts'))
+      .toBe('/src/main.ts')
   })
 
   it('uses internal ids for per-module CSS', async () => {


### PR DESCRIPTION
### Description

Global mode stores UnoCSS entries as Vite internal virtual module IDs after #5284, but its HMR payload still sent the internal `\0`-prefixed URL directly to the browser.

Keep the internal ID for `moduleGraph.getModuleById()` and invalidation, then encode null-byte IDs as Vite's public `/@id/__x00__/...` client path when sending the HMR update. Normal module URLs are preserved.

This is a follow-up to #5284.

Fixes #5293

### Validation

- `vitest run test/virtual-modules.test.ts`
- ESLint on the changed files
- `tsgo --noEmit`
- Manual Vite 8.2.2 browser reproduction with a dynamically imported TSX module; utilities applied without a page reload
