### PR TITLE
fix(preset-mini,preset-wind4): key the breakpoint cache by kind

### DIFF
--- a/packages-presets/preset-mini/src/_utils/utilities.ts
+++ b/packages-presets/preset-mini/src/_utils/utilities.ts
@@ -274,7 +274,7 @@ export function hasParseableColor(color: string | undefined, theme: Theme, key: 
 }
 
 const reLetters = /[a-z]+/gi
-const resolvedBreakpoints = new WeakMap<any, { point: string, size: string }[]>()
+const resolvedBreakpoints = new WeakMap<any, Map<string, { point: string, size: string }[]>>()
 
 export function resolveBreakpoints({ theme, generator }: Readonly<VariantContext<Theme>>, key: 'breakpoints' | 'verticalBreakpoints' = 'breakpoints') {
   const breakpoints: Record<string, string> | undefined = (generator?.userConfig?.theme as any)?.[key] || theme[key]
@@ -282,14 +282,20 @@ export function resolveBreakpoints({ theme, generator }: Readonly<VariantContext
   if (!breakpoints)
     return undefined
 
-  if (resolvedBreakpoints.has(theme))
-    return resolvedBreakpoints.get(theme)
+  let cache = resolvedBreakpoints.get(theme)
+  if (!cache) {
+    cache = new Map()
+    resolvedBreakpoints.set(theme, cache)
+  }
+  // horizontal and vertical breakpoints share the same theme, so the cache has to be keyed by both
+  if (cache.has(key))
+    return cache.get(key)
 
   const resolved = Object.entries(breakpoints)
     .sort((a, b) => Number.parseInt(a[1].replace(reLetters, '')) - Number.parseInt(b[1].replace(reLetters, '')))
     .map(([point, size]) => ({ point, size }))
 
-  resolvedBreakpoints.set(theme, resolved)
+  cache.set(key, resolved)
   return resolved
 }
 

--- a/packages-presets/preset-wind4/src/utils/utilities.ts
+++ b/packages-presets/preset-wind4/src/utils/utilities.ts
@@ -353,7 +353,7 @@ export function hasParseableColor(color: string | undefined, theme: Theme) {
 
 // #region resolve breakpoints
 const reLetters = /[a-z]+/gi
-const resolvedBreakpoints = new WeakMap<any, { point: string, size: string }[]>()
+const resolvedBreakpoints = new WeakMap<any, Map<string, { point: string, size: string }[]>>()
 
 export function resolveBreakpoints({ theme, generator }: Readonly<VariantContext<Theme>>, key: 'breakpoint' | 'verticalBreakpoint' = 'breakpoint') {
   const breakpoints: Record<string, string> | undefined = (generator?.userConfig?.theme as any)?.[key] || theme[key]
@@ -361,14 +361,20 @@ export function resolveBreakpoints({ theme, generator }: Readonly<VariantContext
   if (!breakpoints)
     return undefined
 
-  if (resolvedBreakpoints.has(theme))
-    return resolvedBreakpoints.get(theme)
+  let cache = resolvedBreakpoints.get(theme)
+  if (!cache) {
+    cache = new Map()
+    resolvedBreakpoints.set(theme, cache)
+  }
+  // horizontal and vertical breakpoints share the same theme, so the cache has to be keyed by both
+  if (cache.has(key))
+    return cache.get(key)
 
   const resolved = Object.entries(breakpoints)
     .sort((a, b) => Number.parseInt(a[1].replace(reLetters, '')) - Number.parseInt(b[1].replace(reLetters, '')))
     .map(([point, size]) => ({ point, size }))
 
-  resolvedBreakpoints.set(theme, resolved)
+  cache.set(key, resolved)
   return resolved
 }
 

--- a/test/preset-mini.test.ts
+++ b/test/preset-mini.test.ts
@@ -360,6 +360,37 @@ describe('preset-mini', () => {
     `)
   })
 
+  it('h-screen-* uses verticalBreakpoints', async () => {
+    const uno = await createGenerator({
+      presets: [
+        presetMini(),
+      ],
+      theme: {
+        breakpoints: {
+          sm: '640px',
+          md: '768px',
+        },
+        verticalBreakpoints: {
+          sm: '400px',
+          md: '500px',
+        },
+      },
+    })
+
+    const { css } = await uno.generate([
+      'h-screen-sm',
+      'h-screen-md',
+      'w-screen-sm',
+    ], { preflights: false })
+
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .h-screen-md{height:500px;}
+      .h-screen-sm{height:400px;}
+      .w-screen-sm{width:640px;}"
+    `)
+  })
+
   it('theme for zIndex', async () => {
     const uno = await createGenerator({
       presets: [

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -544,6 +544,39 @@ describe('preset-wind4', () => {
     expect(css).not.toContain('.dark\\:divide-gray-700{@media')
     expect(css).not.toContain('.dark\\:space-y-4{@media')
   })
+
+  it('h-screen-* uses verticalBreakpoint', async () => {
+    const uno = await createGenerator({
+      presets: [
+        presetWind4({
+          preflights: { reset: false, theme: false },
+        }),
+      ],
+      theme: {
+        breakpoint: {
+          sm: '640px',
+          md: '768px',
+        },
+        verticalBreakpoint: {
+          sm: '400px',
+          md: '500px',
+        },
+      },
+    })
+
+    const { getLayer } = await uno.generate([
+      'h-screen-sm',
+      'h-screen-md',
+      'w-screen-sm',
+    ])
+
+    expect(getLayer('default')).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .h-screen-md{height:500px;}
+      .h-screen-sm{height:400px;}
+      .w-screen-sm{width:640px;}"
+    `)
+  })
 })
 
 describe('important', () => {


### PR DESCRIPTION
### Description

`resolveBreakpoints` takes a `key` selecting `breakpoints` or `verticalBreakpoints`, but memoizes into a `WeakMap` keyed only on the theme object:

```ts
if (resolvedBreakpoints.has(theme))
  return resolvedBreakpoints.get(theme)
```

The `breakpoints` variant calls it with the default horizontal key for every token during variant matching, and variant matching always runs before rule matching. So by the time `h-screen-<point>` asks for the vertical set, the entry is already populated with the horizontal one and the vertical values are silently ignored.

Isolated, on one theme:

```
call 1 (horizontal, as the variant does first): [ sm: 640px, md: 768px ]
call 2 (vertical,   as h-screen-* asks):        [ sm: 640px, md: 768px ]   <- should be 400px / 500px
```

End to end, with `verticalBreakpoints: { sm: '400px', md: '500px' }`:

```
- .h-screen-md{height:500px;}     expected
+ .h-screen-md{height:768px;}     actual
- .h-screen-sm{height:400px;}     expected
+ .h-screen-sm{height:640px;}     actual
```

This is deterministic rather than order-dependent, and it stays hidden with the shipped defaults because `verticalBreakpoints` starts as a copy of `breakpoints`. It only surfaces once a user customizes them differently, which the `h-screen-$verticalBreakpoints` autocomplete and the typed theme key both invite.

### Change

The cache becomes a `Map` keyed by the breakpoint kind, so the two sets no longer share an entry. Applied identically to `preset-mini` and `preset-wind4`, which carry the same function.

### Tests

One test per preset, asserting `h-screen-sm/md` follow the vertical set while `w-screen-sm` still follows the horizontal one, so an over-correction that swapped both would also fail.

Reverting only the two source files and rebuilding the presets fails both with `.h-screen-md{height:768px;}` against the expected `500px`; restoring passes. Full `preset-mini` and `preset-wind4` suites pass 46/46, and eslint is clean on the changed files.