### PR TITLE
fix(core): keep variant selectors intact when expanding nested shortcuts

### DIFF
--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -1006,7 +1006,12 @@ class UnoGeneratorInternal<Theme extends object = object> {
         if (raw !== inputWithoutVariant) {
           const expanded = await this.expandShortcut(inputWithoutVariant, context, depth - 1)
           if (expanded) {
-            stringResult = expanded[0].filter(isString).map(item => raw.replace(inputWithoutVariant, item))
+            // the matcher is always the last occurrence, the variants may contain
+            // it as well (e.g. `[&_.btn]:btn`), so the earlier ones have to be kept
+            const matcherIndex = raw.lastIndexOf(inputWithoutVariant)
+            stringResult = expanded[0].filter(isString).map(item => matcherIndex === -1
+              ? raw
+              : raw.slice(0, matcherIndex) + item + raw.slice(matcherIndex + inputWithoutVariant.length))
             inlineResult = (expanded[0].filter(i => !isString(i)) as ShortcutInlineValue[]).map((item) => {
               return { handles: [...item.handles, ...handles], value: item.value }
             })

--- a/packages-engine/core/test/shortcuts.test.ts
+++ b/packages-engine/core/test/shortcuts.test.ts
@@ -228,6 +228,24 @@ describe('shortcuts', async () => {
     `)
   })
 
+  it('nested shortcut keeps the class name used by an arbitrary variant', async () => {
+    const uno = await createGenerator({
+      presets: [
+        presetWind3(),
+      ],
+      shortcuts: {
+        btn: 'mr-10',
+        card: '[&_.btn]:btn',
+      },
+    })
+
+    const { css } = await uno.generate(['card'], { preflights: false })
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: shortcuts */
+      .card .btn{margin-right:2.5rem;}"
+    `)
+  })
+
   it('inline only body with variants', async () => {
     const { css } = await uno.generate('test-inline-body-with-variant', { preflights: false })
     expect(css).toMatchInlineSnapshot(`


### PR DESCRIPTION
### Description

In `expandShortcut`, the nested-with-variants branch does:

```ts
stringResult = expanded[0].filter(isString).map(item => raw.replace(inputWithoutVariant, item))
```

`String.prototype.replace` with a string needle replaces the **first** occurrence. `raw` is the whole token including its variant prefix, while `inputWithoutVariant` is only the trailing matcher. When the variant prefix itself contains the matcher text, which is exactly what an arbitrary variant targeting a shortcut class looks like, the substitution lands inside the selector:

```
raw = '[&_.btn]:btn', matcher = 'btn'
replace()   -> '[&_.px-2]:btn'     the selector was rewritten
intended    -> '[&_.btn]:px-2'
```

With `shortcuts: { btn: 'px-2 py-1', card: '[&_.btn]:btn text-red' }`, generating `card` produces:

```css
/* before */
.card .px-2,
.card .py-1{padding-left:0.5rem;padding-right:0.5rem;padding-top:0.25rem;padding-bottom:0.25rem;}

/* after */
.card .btn{padding-left:0.5rem;padding-right:0.5rem;padding-top:0.25rem;padding-bottom:0.25rem;}
```

The generated rule targets `.px-2` and `.py-1`, classes that appear nowhere in the user's markup, and never matches the `.btn` they asked for.

A bare `[&_.btn]:btn` written directly in markup is unaffected, because the top level calls `expandShortcut` with `skipVariantMatch = true`. The depth-1 recursion does not skip variant matching, so it reproduces through any shortcut that references such a token.

### Change

Splice at the last occurrence of the matcher rather than replacing the first. The matcher is always the trailing part of the token, so `lastIndexOf` is the correct anchor, and suffix or prefix style variants such as `text-red!` and `-mt-2` keep working. When the matcher is absent the behaviour is identical to before.

Using slicing rather than `replace` also removes the latent replacement-pattern hazard, where an expanded utility containing `$&` or `$1` would have been interpreted by `String.replace`.

### Tests

One test in `packages-engine/core/test/shortcuts.test.ts`, using a local generator so no existing snapshot shifts. Reverting only `generator.ts` and rebuilding `@unocss/core` fails it with `.card .mr-10` where `.card .btn` is expected; restoring passes. The shortcuts suite passes 20/20 and eslint is clean on both files.

I checked #4630 since it is the nearest open issue, but that one is about whether `[&>h1]:hover:x` should scope `:hover` to the child, which a maintainer confirmed matches Tailwind 3. This is a different symptom, a corrupted class name, and reproduces with no pseudo-class involved.