### PR TITLE
fix(transformer-directives): honor the deprecated varStyle option

### DIFF
--- a/packages-presets/transformer-directives/src/transform.ts
+++ b/packages-presets/transformer-directives/src/transform.ts
@@ -15,7 +15,8 @@ export function resolveApplyVariables(options: TransformerDirectivesOptions) {
   if (applyVariable === undefined) {
     if (varStyle !== undefined)
       applyVariable = varStyle ? [`${varStyle}apply`] : []
-    applyVariable = ['--at-apply', '--uno-apply', '--uno']
+    else
+      applyVariable = ['--at-apply', '--uno-apply', '--uno']
   }
   return toArray(applyVariable || [])
 }

--- a/test/transformer-directives.test.ts
+++ b/test/transformer-directives.test.ts
@@ -10,7 +10,7 @@ import MagicString from 'magic-string'
 import parserCSS from 'prettier/parser-postcss'
 import prettier from 'prettier/standalone'
 import { describe, expect, it } from 'vitest'
-import { transformDirectives } from '../packages-presets/transformer-directives/src/transform'
+import { resolveApplyVariables, transformDirectives } from '../packages-presets/transformer-directives/src/transform'
 
 describe('source filter', () => {
   it('detects supported directives', () => {
@@ -23,6 +23,21 @@ describe('source filter', () => {
   it('detects custom apply variables', () => {
     const transformer = transformerDirectives({ applyVariable: '--custom-apply' })
     expect(transformer.codeFilter?.('.button { --custom-apply: text-red; }', 'fixture.css')).toBe(true)
+  })
+})
+
+describe('apply variables', () => {
+  it('defaults', () => {
+    expect(resolveApplyVariables({})).toEqual(['--at-apply', '--uno-apply', '--uno'])
+  })
+
+  it('respects the deprecated varStyle option', () => {
+    expect(resolveApplyVariables({ varStyle: '--my-' })).toEqual(['--my-apply'])
+    expect(resolveApplyVariables({ varStyle: false })).toEqual([])
+  })
+
+  it('applyVariable takes precedence over varStyle', () => {
+    expect(resolveApplyVariables({ applyVariable: '--custom-apply', varStyle: '--my-' })).toEqual(['--custom-apply'])
   })
 })
 


### PR DESCRIPTION
### Description

`resolveApplyVariables` computes `applyVariable` from `varStyle` and then overwrites it unconditionally on the very next line:

```ts
if (applyVariable === undefined) {
  if (varStyle !== undefined)
    applyVariable = varStyle ? [`${varStyle}apply`] : []
  applyVariable = ['--at-apply', '--uno-apply', '--uno']   // always wins
}
```

So the `varStyle` option has no effect at all. It is deprecated but still public and typed `false | string`:

```
varStyle: '--my-'  ->  ["--at-apply","--uno-apply","--uno"]   expected ["--my-apply"]
varStyle: false    ->  ["--at-apply","--uno-apply","--uno"]   expected []
```

`varStyle: false` is documented as the way to turn off custom-property `@apply` entirely, and it currently leaves all three defaults active.

### Change

The default assignment moves into an `else`, so it only applies when `varStyle` is not provided. `applyVariable` still takes precedence over `varStyle`, which is the documented order.

### Tests

A new `apply variables` block covering the defaults, `varStyle` as a string, `varStyle: false`, and `applyVariable` winning over `varStyle`. Reverting only the source and keeping the tests fails with `expected [ Array(3) ] to deeply equal [ '--my-apply' ]`; restored, the transformer-directives suite passes 78/78 and eslint is clean.