### PR TITLE
fix(preset-attributify): apply ignoreAttributes after stripping binding prefixes

### DIFF
--- a/packages-presets/preset-attributify/src/extractor.ts
+++ b/packages-presets/preset-attributify/src/extractor.ts
@@ -27,15 +27,15 @@ export function extractorAttributify(options?: AttributifyOptions): Extractor {
         .flatMap(([, name, ...contents]) => {
           const content = contents.filter(Boolean).join('')
 
-          if (ignoreAttributes.includes(name))
-            return []
-
           for (const prefix of strippedPrefixes) {
             if (name.startsWith(prefix)) {
               name = name.slice(prefix.length)
               break
             }
           }
+
+          if (ignoreAttributes.includes(name))
+            return []
 
           if (!content) {
             if (isValidSelector(name) && nonValuedAttribute !== false) {

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -244,6 +244,19 @@ describe('attributify', async () => {
     expect(css3).toMatchSnapshot()
   })
 
+  it('ignores attributes bound with `:` or `v-bind:`', async () => {
+    const code = `
+      <input placeholder="msg" :placeholder="msg" v-bind:placeholder="msg" />
+      <path fill="c" :fill="c" v-bind:fill="c" />
+    `
+    const extracted = await extractorAttributify().extract!({ code } as any)
+    expect(Array.from(extracted ?? [])).toEqual([])
+
+    const custom = await extractorAttributify({ ignoreAttributes: ['text'] })
+      .extract!({ code: '<a text="red" :text="red" v-bind:text="red" />' } as any)
+    expect(Array.from(custom ?? [])).toEqual([])
+  })
+
   it('#4818: extracts an attribute when a nearby line has an unbalanced backtick', async () => {
     // The JSX template-literal lines and the stray quote in `>"something"` used
     // to make the backtick alternative in `elementRE` span multiple lines,


### PR DESCRIPTION
### Description

In `extractorAttributify`, the `ignoreAttributes` guard runs before the `v-bind:` and `:` prefixes are stripped, so an ignored attribute is still extracted when it is written as a dynamic binding:

```
<input placeholder="msg" />        ->  []                        ignored, correct
<input :placeholder="msg" />       ->  [ '[placeholder~="msg"]' ]  extracted anyway
<path v-bind:fill="c" />           ->  [ '[fill~="c"]' ]           extracted anyway

ignoreAttributes: ['text']
<a text="red" />                   ->  []
<a :text="red" />                  ->  [ '[text~="red"]' ]
```

The docs present `ignoreAttributes` as the way to stop an attribute such as `text` colliding with a real component prop, and `placeholder`, `fill` and `opacity` are in the defaults for exactly that reason. The dynamic form defeats it, and in Vue templates the bound form is common.

### Change

The guard moves below the prefix-stripping loop, so it sees the resolved attribute name. No other change.

### Tests

One test asserting that both `:placeholder` and `v-bind:fill` are ignored, alongside the plain forms. Reverting only the source and rebuilding the preset fails it with `expected [ '[placeholder~="msg"]', …(3) ] to deeply equal []`; restored, the attributify suite passes 18/18 and eslint is clean.

Related but distinct: #2110 added `fill` and `opacity` to the default ignore list for the same underlying complaint, but did not touch the ordering, so bound attributes still bypassed it.