### PR TITLE
fix(cli): propagate transformer errors in transformFiles

### DIFF
--- a/packages-engine/cli/src/index.ts
+++ b/packages-engine/cli/src/index.ts
@@ -270,15 +270,13 @@ async function transformFiles(
     sources: FileEntryItem[],
     enforce: SourceCodeTransformerEnforce,
   ) => Promise.all(
-    sources.map(source => new Promise<FileEntryItem>((resolve) => {
-      applyTransformers(ctx, source.transformedCode ?? source.code, source.id, enforce)
-        .then((transformsRes) => {
-          resolve({
-            ...source,
-            transformedCode: transformsRes?.code ?? source.transformedCode,
-          })
-        })
-    })),
+    sources.map(async (source) => {
+      const transformsRes = await applyTransformers(ctx, source.transformedCode ?? source.code, source.id, enforce)
+      return {
+        ...source,
+        transformedCode: transformsRes?.code ?? source.transformedCode,
+      }
+    }),
   )
 
   const preTrans = await run(sources, 'pre')

--- a/packages-engine/cli/test/cli.test.ts
+++ b/packages-engine/cli/test/cli.test.ts
@@ -99,6 +99,63 @@ describe('cli', () => {
     expect(transform).toMatchSnapshot()
   })
 
+  it('applies pre, default, and post transformers', async () => {
+    const { output, transform } = await runCli({
+      'views/index.html': '<div></div>',
+      'unocss.config.js': `
+  import { defineConfig, presetWind3 } from 'unocss'
+  export default defineConfig({
+    presets: [presetWind3()],
+    transformers: [
+      {
+        name: 'pre',
+        enforce: 'pre',
+        transform(code) {
+          code.prepend('<div class="bg-red"></div>')
+        },
+      },
+      {
+        name: 'default',
+        transform(code) {
+          code.append('<div class="bg-blue"></div>')
+        },
+      },
+      {
+        name: 'post',
+        enforce: 'post',
+        transform(code) {
+          code.append('<div class="p-4"></div>')
+        },
+      },
+    ],
+  })
+      `.trim(),
+    }, { args: ['--rewrite'], transformFile: 'views/index.html' })
+
+    expect(output).toContain('.bg-red')
+    expect(output).toContain('.bg-blue')
+    expect(output).toContain('.p-4')
+    expect(transform).toBe('<div class="bg-red"></div><div></div><div class="bg-blue"></div><div class="p-4"></div>')
+  })
+
+  it('rejects the build when a transformer rejects', async () => {
+    await expect(runCli({
+      'views/index.html': '<div class="bg-red"></div>',
+      'unocss.config.js': `
+  import { defineConfig, presetWind3 } from 'unocss'
+  export default defineConfig({
+    presets: [presetWind3()],
+    transformers: [{
+      name: 'rejecting-transformer',
+      async transform() {
+        throw new Error('intentional transformer failure')
+      },
+    }],
+  })
+      `.trim(),
+    })).rejects.toThrow('intentional transformer failure')
+  })
+
   it('supports unocss.config.js cli options', async () => {
     const testDir = getTestDir()
     const outFiles = ['./uno1.css', './test/uno2.css']


### PR DESCRIPTION
## Bug

`transformFiles` in the CLI wrapped each `applyTransformers` call in a `new Promise` that only ever called `resolve`. When a transformer rejected, the rejection was never routed to the wrapping promise: it became an unhandled rejection (potentially crashing Node) while the outer build promise stayed pending forever.

## Fix

Replace the manual `new Promise` wrapper with an `async` function that awaits `applyTransformers`. Transformer rejections now propagate through `transformFiles` and the CLI build, while pre/default/post stage ordering and the `transformedCode` semantics (`transformsRes?.code ?? source.transformedCode`) stay unchanged.

## Tests

Added regression tests in `packages-engine/cli/test/cli.test.ts`:

- a rejecting transformer rejects the whole CLI build
- pre/default/post transformers apply in order with the expected transformed source

Test run: `pnpm exec vitest run packages-engine/cli/test --project unit` — 14/14 passed (12 existing + 2 new). ESLint passes on the changed files.