### PR TITLE
fix(postcss): propagate screen directive errors

### DIFF
--- a/packages-integrations/postcss/src/esm.ts
+++ b/packages-integrations/postcss/src/esm.ts
@@ -115,7 +115,7 @@ export function createPlugin(options: UnoPostcssPluginOptions) {
 
     await parseApply(root, uno, directiveMap.apply)
     await parseTheme(root, uno)
-    await parseScreen(root, uno, directiveMap.screen)
+    parseScreen(root, uno, directiveMap.screen)
 
     promises.push(
       ...plainContent.map(async (c, idx) => {

--- a/packages-integrations/postcss/src/screen.ts
+++ b/packages-integrations/postcss/src/screen.ts
@@ -2,9 +2,8 @@ import type { UnoGenerator } from '@unocss/core'
 import type { Root } from 'postcss'
 import { calcMaxWidthBySize } from '@unocss/rule-utils'
 
-export async function parseScreen(root: Root, uno: UnoGenerator, directiveName: string) {
-  // @ts-expect-error types
-  root.walkAtRules(directiveName, async (rule) => {
+export function parseScreen(root: Root, uno: UnoGenerator, directiveName: string) {
+  root.walkAtRules(directiveName, (rule) => {
     let breakpointName = ''
     let prefix = ''
 

--- a/test/postcss.test.ts
+++ b/test/postcss.test.ts
@@ -2,6 +2,7 @@ import type { UserConfig } from '@unocss/core'
 import { escapeSelector } from '@unocss/core'
 import postcssPlugin from '@unocss/postcss'
 import presetWind from '@unocss/preset-wind'
+import presetWind4 from '@unocss/preset-wind4'
 import postcss from 'postcss'
 import { describe, expect, it } from 'vitest'
 import { targets } from './assets/preset-wind3-targets'
@@ -88,6 +89,18 @@ function pcssLite() {
   )
 }
 
+function pcssScreen(config: UserConfig, directiveName = 'screen') {
+  return postcss(
+    postcssPlugin({
+      directiveMap: { screen: directiveName },
+      configOrPath: {
+        content: { filesystem: [], inline: [] },
+        ...config,
+      },
+    }),
+  )
+}
+
 const file = 'style.css'
 const processOptions = { from: file, to: file }
 
@@ -153,6 +166,36 @@ describe('postcss', () => {
     }`, processOptions)
 
     expect(css).toMatchSnapshot()
+  })
+
+  it('@screen rejects unknown breakpoints', async () => {
+    await expect(
+      pcssScreen({ presets: [presetWind()] }).process('@screen missing { .test { color: red } }', processOptions),
+    ).rejects.toThrow('breakpoint missing not found')
+  })
+
+  it('@screen preserves Wind3 breakpoint variants', async () => {
+    const { css } = await pcssScreen({ presets: [presetWind()] }).process(`
+      @screen sm { .sm { color: red } }
+      @screen lt-md { .lt { color: red } }
+      @screen at-md { .at { color: red } }
+    `, processOptions)
+
+    expect(css).toContain('@media (min-width: 640px)')
+    expect(css).toContain('@media (max-width: 767.9px)')
+    expect(css).toContain('@media (min-width: 768px) and (max-width: 1023.9px)')
+  })
+
+  it('@screen preserves configured directives and Wind4 breakpoints', async () => {
+    const { css } = await pcssScreen({ presets: [presetWind4()] }, 'custom-screen').process(`
+      @custom-screen sm { .sm { color: red } }
+      @custom-screen lt-md { .lt { color: red } }
+      @custom-screen at-md { .at { color: red } }
+    `, processOptions)
+
+    expect(css).toContain('@media (min-width: 40rem)')
+    expect(css).toContain('@media (max-width: calc(48rem - 0.1px))')
+    expect(css).toContain('@media (min-width: 48rem) and (max-width: calc(64rem - 0.1px))')
   })
 
   it('inline media node type', async () => {


### PR DESCRIPTION
### Description

An unknown breakpoint in `@screen` did not fail the PostCSS build. `parseScreen` passed an `async` callback to `root.walkAtRules` although it does no async work, so the thrown `breakpoint X not found` error became an unhandled rejection while the PostCSS processing promise fulfilled with the `@screen` rule left untouched in the output.

The visitor is now synchronous (and `parseScreen` itself is no longer `async`), the masking `@ts-expect-error` is removed, and errors propagate as rejections of the PostCSS process promise. Valid `sm` / `lt-` / `at-` breakpoints keep producing the same media queries, including Wind4 `rem` breakpoints and a customized directive name via `directiveMap`.

### Tests

- `@screen` with an unknown breakpoint rejects with `breakpoint missing not found` (through real `postcss().process`).
- Wind3 `sm`, `lt-md`, `at-md` still resolve to the correct `@media` queries.
- Wind4 breakpoints with a custom `@custom-screen` directive name resolve to the correct `rem`-based `@media` queries.

Evidence from the fixed build:

- Before: `process()` fulfilled and printed `UNHANDLED REJECTION: breakpoint foo not found`.
- After: `process()` rejects with `Error: breakpoint foo not found`.

`npx vitest run test/postcss.test.ts --project unit`: 13 passed.