### PR TITLE
fix(scripts): close default-export bypass in dist verification

### DIFF
--- a/scripts/dist-verify.ts
+++ b/scripts/dist-verify.ts
@@ -1,42 +1,31 @@
 import fs from 'node:fs/promises'
+import { join } from 'node:path'
 import process from 'node:process'
 import { glob } from 'tinyglobby'
 
-export async function verifyDist() {
-  const cjsFiles = await glob([
-    'packages-*/*/dist/**/*.d.ts',
+// UnoCSS packages are ESM-only, so CJS output must not require them
+const forbiddenCjsImport = /\brequire\(\s*['"]@?unocss(?:\/core)?['"]\s*\)/
+
+export async function verifyDist(root = process.cwd()) {
+  const cjsOutputFiles = await glob([
+    'packages-*/*/dist/**/*.cjs',
     'packages-*/*/dist/**/*.d.cts',
   ], {
+    cwd: root,
     ignore: ['**/node_modules/**'],
     expandDirectories: false,
   })
-  // const cjsFiles = await fg('packages-*/*/dist/**/*.cjs', {
-  //   ignore: ['**/node_modules/**'],
-  // })
 
-  console.log(`${cjsFiles.length} dts files found`)
-  // console.log(`${cjsFiles.length} cjs files found`)
-  console.log(cjsFiles.map(i => ` - ${i}`).join('\n'))
-
-  const forbidden = [
-    // Make sure no CJS is importing UnoCSS packages as they are ESM only
-    /require\(['"]@?unocss(\/core)?['"]\)/,
-    // Use `exports.default` instead, should be patched by postbuild.ts
-    // 'module.exports',
-  ]
-
-  const exportsDefault = 'as default'
-  // const exportsDefault = 'exports.default'
+  console.log(`${cjsOutputFiles.length} CJS output files found`)
+  console.log(cjsOutputFiles.map(i => ` - ${i}`).join('\n'))
 
   let error = false
-  await Promise.all(cjsFiles.map(async (file) => {
-    const code = await fs.readFile(file, 'utf-8')
-    const matches = forbidden.map(r => code.match(r)).filter(Boolean)
-    // the CJS module can have exports.default and another module.exports
-    // preset-legacy-compat is an example, exporting presetLegacyCompat as default and named
-    if (matches.length && !code.match(exportsDefault)) {
+  await Promise.all(cjsOutputFiles.map(async (file) => {
+    const code = await fs.readFile(join(root, file), 'utf-8')
+    const match = code.match(forbiddenCjsImport)
+    if (match) {
       console.error(`\nFound forbidden code in ${file}`)
-      console.error(matches.map(i => ` - ${i![0]}`).join('\n'))
+      console.error(` - ${match[0]}`)
       error = true
     }
   }))
@@ -48,4 +37,4 @@ export async function verifyDist() {
 }
 
 if (process.argv[1] === new URL(import.meta.url).pathname)
-  await verifyDist()
+  await verifyDist(process.argv[2])

--- a/scripts/dist-verify.ts
+++ b/scripts/dist-verify.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import { join } from 'node:path'
 import process from 'node:process'
+import { pathToFileURL } from 'node:url'
 import { glob } from 'tinyglobby'
 
 // UnoCSS packages ship no CJS types, so declaration output must not use
@@ -38,5 +39,5 @@ export async function verifyDist(root = process.cwd()) {
     console.log('\nDist files verify passed')
 }
 
-if (process.argv[1] === new URL(import.meta.url).pathname)
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
   await verifyDist(process.argv[2])

--- a/scripts/dist-verify.ts
+++ b/scripts/dist-verify.ts
@@ -3,12 +3,14 @@ import { join } from 'node:path'
 import process from 'node:process'
 import { glob } from 'tinyglobby'
 
-// UnoCSS packages are ESM-only, so CJS output must not require them
+// UnoCSS packages ship no CJS types, so declaration output must not use
+// `import x = require()` against them. Runtime `require()` of ESM is valid
+// on Node >= 22.12 (the minimum engine), so runtime .cjs is not checked.
 const forbiddenCjsImport = /\brequire\(\s*['"]@?unocss(?:\/core)?['"]\s*\)/
 
 export async function verifyDist(root = process.cwd()) {
-  const cjsOutputFiles = await glob([
-    'packages-*/*/dist/**/*.cjs',
+  const cjsDeclarationFiles = await glob([
+    'packages-*/*/dist/**/*.d.ts',
     'packages-*/*/dist/**/*.d.cts',
   ], {
     cwd: root,
@@ -16,11 +18,11 @@ export async function verifyDist(root = process.cwd()) {
     expandDirectories: false,
   })
 
-  console.log(`${cjsOutputFiles.length} CJS output files found`)
-  console.log(cjsOutputFiles.map(i => ` - ${i}`).join('\n'))
+  console.log(`${cjsDeclarationFiles.length} CJS declaration files found`)
+  console.log(cjsDeclarationFiles.map(i => ` - ${i}`).join('\n'))
 
   let error = false
-  await Promise.all(cjsOutputFiles.map(async (file) => {
+  await Promise.all(cjsDeclarationFiles.map(async (file) => {
     const code = await fs.readFile(join(root, file), 'utf-8')
     const match = code.match(forbiddenCjsImport)
     if (match) {

--- a/test/dist-verify.test.ts
+++ b/test/dist-verify.test.ts
@@ -37,9 +37,10 @@ afterEach(async () => {
 })
 
 describe('dist verification', () => {
-  it('accepts valid CJS runtime and declaration outputs', async () => {
+  it('accepts runtime CJS requiring ESM-only packages and valid declarations', async () => {
     const root = await createFixture({
-      'index.cjs': 'module.exports = { value: 1 }',
+      // require() of an ESM-only package is valid at runtime on Node >= 22.12
+      'index.cjs': 'const uno = require("@unocss/core")\nmodule.exports = { value: uno }',
       'index.d.cts': 'declare const value: number\nexport = value',
       'index.d.ts': 'import type { UnoGenerator } from \'@unocss/core\'',
     })
@@ -47,12 +48,11 @@ describe('dist verification', () => {
     const result = await runChecker(root)
 
     expect(result.code).toBe(0)
-    expect(result.output).toContain('2 CJS output files found')
+    expect(result.output).toContain('2 CJS declaration files found')
   })
 
   it.each([
-    ['runtime CJS', 'index.cjs', 'const uno = require("@unocss/core")\nmodule.exports = uno'],
-    ['runtime CJS with default export', 'index.cjs', 'const uno = require("@unocss/core")\nmodule.exports.default = uno'],
+    ['CJS declaration', 'index.d.cts', 'import uno = require("@unocss/core")\nexport = uno'],
     ['CJS declaration with default export', 'index.d.cts', 'import uno = require("@unocss/core")\nexport { uno as default }'],
   ])('rejects a forbidden import in %s even with a default export', async (_, file, content) => {
     const root = await createFixture({ [file]: content })

--- a/test/dist-verify.test.ts
+++ b/test/dist-verify.test.ts
@@ -1,0 +1,66 @@
+import { spawn } from 'node:child_process'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const roots: string[] = []
+const script = resolve(import.meta.dirname, '../scripts/dist-verify.ts')
+
+async function createFixture(files: Record<string, string>) {
+  const root = await mkdtemp(join(tmpdir(), 'unocss-dist-verify-'))
+  roots.push(root)
+  await Promise.all(Object.entries(files).map(async ([file, content]) => {
+    const path = join(root, 'packages-test/fixture/dist', file)
+    await mkdir(resolve(path, '..'), { recursive: true })
+    await writeFile(path, content)
+  }))
+  return root
+}
+
+async function runChecker(root: string) {
+  return await new Promise<{ code: number | null, output: string }>((resolve, reject) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', script, root], {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let output = ''
+    child.stdout.on('data', data => output += data)
+    child.stderr.on('data', data => output += data)
+    child.on('error', reject)
+    child.on('close', code => resolve({ code, output }))
+  })
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })))
+})
+
+describe('dist verification', () => {
+  it('accepts valid CJS runtime and declaration outputs', async () => {
+    const root = await createFixture({
+      'index.cjs': 'module.exports = { value: 1 }',
+      'index.d.cts': 'declare const value: number\nexport = value',
+      'index.d.ts': 'import type { UnoGenerator } from \'@unocss/core\'',
+    })
+
+    const result = await runChecker(root)
+
+    expect(result.code).toBe(0)
+    expect(result.output).toContain('2 CJS output files found')
+  })
+
+  it.each([
+    ['runtime CJS', 'index.cjs', 'const uno = require("@unocss/core")\nmodule.exports = uno'],
+    ['runtime CJS with default export', 'index.cjs', 'const uno = require("@unocss/core")\nmodule.exports.default = uno'],
+    ['CJS declaration with default export', 'index.d.cts', 'import uno = require("@unocss/core")\nexport { uno as default }'],
+  ])('rejects a forbidden import in %s even with a default export', async (_, file, content) => {
+    const root = await createFixture({ [file]: content })
+
+    const result = await runChecker(root)
+
+    expect(result.code).toBe(1)
+    expect(result.output).toContain(`Found forbidden code in packages-test/fixture/dist/${file}`)
+    expect(result.output).toContain('require("@unocss/core")')
+  })
+})


### PR DESCRIPTION
## Problem

The postbuild dist checker (`scripts/dist-verify.ts`) could report success while a forbidden import was present. Its forbidden-`require()` rule was skipped for any file containing `as default`, so a declaration like:

```ts
import uno = require("@unocss/core")
export { uno as default }
```

passed validation. The script also carried obsolete commented-out checks, misleading `cjsFiles` naming, and had no test coverage.

## Changes

- Forbidden `require()` of `@unocss/*` in CJS declaration output (`.d.ts` / `.d.cts`) now always fails the build — the `as default` exemption is removed.
- Scope intentionally limited to **declaration outputs**: runtime `.cjs` may `require()` ESM-only packages because Node ≥ 22.12 (the minimum engine) supports `require(esm)`. The nuxt and webpack integrations rely on this; an earlier draft that scanned runtime output produced false positives in CI.
- Removed obsolete commented-out implementation; renamed `cjsFiles` → `cjsDeclarationFiles` so logs match what is scanned.
- Direct-execution guard now compares via `pathToFileURL()`, fixing a silent no-op on Windows (`argv[1]` is `C:\...`, never equal to a `/C:/` URL pathname).
- Added `test/dist-verify.test.ts`: spawns the real checker against temporary fixtures and asserts pass/fail exit codes, including the default-export case.

## Validation

- `pnpm exec vitest run test/dist-verify.test.ts` — 3/3 passed
- Full checker run against a complete local build: `Dist files verify passed`
- CI green across ubuntu/macos/windows matrices