### PR TITLE
fix(rule-utils): anchor the part- variant regex

### DIFF
--- a/packages-presets/rule-utils/src/pseudo.ts
+++ b/packages-presets/rule-utils/src/pseudo.ts
@@ -388,7 +388,8 @@ export function createTaggedPseudoClasses<T extends object = object>(
   ]
 }
 
-const PartClassesRE = /(part-\[(.+)\]:)(.+)/
+// Must stay anchored: the matcher below slices from index 0, so a mid-string match would corrupt it.
+const PartClassesRE = /^(part-\[(.+)\]:)(.+)/
 
 export function createPartClasses<T extends object = object>(): VariantObject<T> {
   return {

--- a/packages-presets/rule-utils/test/pseudo.test.ts
+++ b/packages-presets/rule-utils/test/pseudo.test.ts
@@ -8,7 +8,7 @@ import {
   createPseudoClassFunctions,
   createTaggedPseudoClasses,
 } from '../src/pseudo'
-import { variantGetBracket } from '../src/variants'
+import { variantGetBracket, variantMatcher } from '../src/variants'
 
 // Create utilities similar to what presets use
 const utils: PseudoVariantUtilities = {
@@ -237,6 +237,35 @@ it('part classes', async () => {
       "/* layer: default */
       .part-\\[button\\]\\:foo-1::part(button){color:foo-1;}
       .part-\\[slider-thumb\\]\\:foo-2::part(slider-thumb){color:foo-2;}"
+    `)
+})
+
+it('part classes after another variant', async () => {
+  const uno = await createGenerator({
+    variants: [
+      createPartClasses(),
+      variantMatcher('dark', input => ({ prefix: `.dark $$ ${input.prefix}` })),
+    ],
+    rules: [
+      [/^foo-(\d)$/, ([_, a]) => ({ color: `foo-${a}` })],
+    ],
+  })
+
+  const result = await uno.generate([
+    'dark:part-[button]:foo-1',
+  ])
+
+  expect(result.matched)
+    .toMatchInlineSnapshot(`
+      Set {
+        "dark:part-[button]:foo-1",
+      }
+    `)
+
+  expect(result.css)
+    .toMatchInlineSnapshot(`
+      "/* layer: default */
+      .dark .dark\\:part-\\[button\\]\\:foo-1::part(button){color:foo-1;}"
     `)
 })
 


### PR DESCRIPTION
### The bug

`part-[...]` stops working as soon as it is combined with a variant that UnoCSS resolves after it. `hover:part-[button]:text-red` works, but `dark:part-[button]:text-red` produces no CSS at all. The utility is silently dropped, with no warning.

Also affected: `rtl:`, `*:`, `scope-[...]:`, `group-data-[...]:`, `@container`, and the `[&...]:` variables variant.

### Reproduce

```ts
const uno = await createGenerator({ presets: [presetMini({ dark: 'class' })] })

await uno.generate(['hover:part-[button]:text-red'])
// .hover\:part-\[button\]\:text-red::part(button):hover{ ... }

await uno.generate(['dark:part-[button]:text-red'])
// "" (nothing)
```

### Root cause

`PartClassesRE` in `packages-presets/rule-utils/src/pseudo.ts` is not anchored, but its handler builds the next matcher with `input.slice(match[1].length)`, which assumes the match starts at index 0. For `dark:part-[button]:text-red` the regex matches at index 5 and the slice yields `ton]:text-red`, so no rule ever matches it. The variants that do work only work because they are ordered before `variantPartClasses` and get consumed first.

Anchoring the regex lets those later variants take their turn, after which `part-` matches at index 0 as it already does today.

### Test

`packages-presets/rule-utils/test/pseudo.test.ts` gains `part classes after another variant`: it registers `createPartClasses()` followed by a `dark` variant and asserts that `dark:part-[button]:foo-1` is matched and emits `.dark .dark\:part-\[button\]\:foo-1::part(button){color:foo-1;}`. Without the anchor `result.matched` is an empty set and no CSS is produced.

The existing `part classes` test is unchanged and still passes, as does the rest of the suite.
