### PR TITLE
fix(eslint-plugin): sort `unoVariables` class strings wrapped in `satisfies`

### DIFF
--- a/packages-integrations/eslint-plugin/src/rules/order.test.ts
+++ b/packages-integrations/eslint-plugin/src/rules/order.test.ts
@@ -467,3 +467,100 @@ run({
     },
   ],
 })
+
+run({
+  name: 'order-unoVariables-satisfies',
+  rule,
+  languageOptions: {
+    parser: vueParser,
+    parserOptions: {
+      parser: '@typescript-eslint/parser',
+    },
+  },
+  settings: {
+    unocss: {
+      configPath: fileURLToPath(new URL('./uno.config.ts', import.meta.url)),
+    },
+  },
+  valid: [
+    html`
+      <script lang="ts">
+      const clsButton = 'ml-1 mr-1' satisfies string
+      </script>
+    `,
+    html`
+      <script lang="ts">
+      const buttonClassNames = { default: 'pl1 pr1' } satisfies object
+      </script>
+    `,
+    html`
+      <script lang="ts">
+      const notSorted = 'mr-1 ml-1' satisfies string
+      </script>
+    `,
+  ],
+  invalid: [
+    {
+      code: html`
+        <script lang="ts">
+        const clsButton = 'mr-1 ml-1' satisfies string
+        </script>
+      `,
+      output: output => expect(output).toMatchInlineSnapshot(`
+        "<script lang="ts">
+        const clsButton = 'ml-1 mr-1' satisfies string
+        </script>"
+      `),
+      errors: [
+        { messageId: 'invalid-order' },
+      ],
+    },
+    {
+      code: html`
+        <script lang="ts">
+        const clsButton = 'mr-1 ml-1' as const satisfies string
+        </script>
+      `,
+      output: output => expect(output).toMatchInlineSnapshot(`
+        "<script lang="ts">
+        const clsButton = 'ml-1 mr-1' as const satisfies string
+        </script>"
+      `),
+      errors: [
+        { messageId: 'invalid-order' },
+      ],
+    },
+    {
+      code: html`
+        <script lang="ts">
+        const buttonClassNames = { default: 'pr1 pl1', variants: { light: 'mr-1 ml-1' } } satisfies object
+        </script>
+      `,
+      output: output => expect(output).toMatchInlineSnapshot(`
+        "<script lang="ts">
+        const buttonClassNames = { default: 'pl1 pr1', variants: { light: 'ml-1 mr-1' } } satisfies object
+        </script>"
+      `),
+      errors: [
+        { messageId: 'invalid-order' },
+        { messageId: 'invalid-order' },
+      ],
+    },
+    {
+      options: [{ unoVariables: ['^theme'] }],
+      code: html`
+        <script lang="ts">
+        const themeDashboard = { slots: { root: 'mr-1 ml-1' } } satisfies object
+        </script>
+      `,
+      output: output => expect(output).toMatchInlineSnapshot(`
+        "<script lang="ts">
+        const themeDashboard = { slots: { root: 'ml-1 mr-1' } } satisfies object
+        </script>"
+      `),
+      errors: [
+        { messageId: 'invalid-order' },
+      ],
+    },
+  ],
+})

--- a/packages-integrations/eslint-plugin/src/rules/order.ts
+++ b/packages-integrations/eslint-plugin/src/rules/order.ts
@@ -52,6 +52,13 @@ export default createRule({
       return unoVariablesRegexes.some(reg => reg.test(name))
     }
 
+    function unwrapTsExpression(node: TSESTree.Expression): TSESTree.Expression {
+      let current = node
+      while (current.type === 'TSAsExpression' || current.type === 'TSSatisfiesExpression')
+        current = current.expression
+      return current
+    }
+
     function checkLiteral(node: TSESTree.Literal | SvelteLiteral, addSpace?: 'before' | 'after' | undefined) {
       if (typeof node.value !== 'string' || !node.value.trim())
         return
@@ -275,12 +282,10 @@ export default createRule({
         if (node.id.type !== 'Identifier' || !node.init || !isUnoVariable(node.id.name))
           return
 
-        if (isPossibleLiteral(node.init)) {
-          return checkPossibleLiteral(node.init)
-        }
+        const init = unwrapTsExpression(node.init)
 
-        if (node.init.type === 'TSAsExpression' && isPossibleLiteral(node.init.expression)) {
-          return checkPossibleLiteral(node.init.expression)
+        if (isPossibleLiteral(init)) {
+          return checkPossibleLiteral(init)
         }
 
         function handleObjectExpression(node: TSESTree.ObjectExpression) {
@@ -297,11 +302,8 @@ export default createRule({
             }
           })
         }
-        if (node.init.type === 'ObjectExpression') {
-          return handleObjectExpression(node.init)
-        }
-        if (node.init.type === 'TSAsExpression' && node.init.expression.type === 'ObjectExpression') {
-          return handleObjectExpression(node.init.expression)
+        if (init.type === 'ObjectExpression') {
+          return handleObjectExpression(init)
         }
       },
     }


### PR DESCRIPTION
The order rule already walked object values on matching identifiers, but skipped the initializer when it was a `TSSatisfiesExpression`, so theme-style `const clsX = { base: '...' } satisfies T` never got reordered.

Resolves #5315