### PR TITLE
fix(preset-wind4): prevent arbitrary border length from being parsed as color

### DIFF
--- a/packages-presets/preset-wind4/src/rules/border.ts
+++ b/packages-presets/preset-wind4/src/rules/border.ts
@@ -2,6 +2,7 @@ import type { CSSEntries, CSSObject, CSSValueInput, Rule, RuleContext } from '@u
 import type { Theme } from '../theme'
 import { notNull } from '@unocss/core'
 import { colorCSSGenerator, cornerMap, directionMap, generateThemeVariable, globalKeywords, h, hasParseableColor, isCSSMathFn, parseColor, SpecialColorKey, themeTracking } from '../utils'
+import { bracketTypeRe } from '../utils/handlers/regex'
 
 export const borderStyles = ['solid', 'dashed', 'dotted', 'double', 'hidden', 'none', 'groove', 'ridge', 'inset', 'outset', ...globalKeywords]
 
@@ -80,9 +81,10 @@ function handlerBorderColorOrSize([, a = '', b]: string[], ctx: RuleContext<Them
     if (isCSSMathFn(h.bracket(b, ctx.theme)))
       return handlerBorderSize(['', a, b], ctx)
 
-    const bracketColor = h.bracketOfColor(b, ctx.theme)
+    const hasColorHint = b.match(bracketTypeRe)?.[1] === 'color'
+    const bracketColor = hasColorHint ? h.bracketOfColor(b, ctx.theme) : undefined
     b = bracketColor ?? b
-    if (bracketColor != null || hasParseableColor(b, ctx.theme)) {
+    if (hasColorHint || hasParseableColor(b, ctx.theme)) {
       const directions = directionMap[a].map(i =>
         borderColorResolver(i)(['', b], ctx)
         ?? colorCSSGenerator({ color: b, name: '_' } as unknown as ReturnType<typeof parseColor>, `border${i}-color`, `border${i}`, ctx))

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -597,6 +597,7 @@
 .scroll-auto{scroll-behavior:auto;}
 .scroll-unset{scroll-behavior:unset;}
 .b-2,
+.border-\[2px\],
 .border-\[length\:2px\],
 .border-\[width\:2px\],
 .border-size-2{border-width:2px;}
@@ -604,8 +605,10 @@
 .border-4{border-width:4px;}
 .border-x{border-inline-width:1px;}
 .border-b{border-bottom-width:1px;}
+.border-b-\[2px\]{border-bottom-width:2px;}
 .border-e-4{border-inline-end-width:4px;}
 .border-s-0{border-inline-start-width:0px;}
+.border-t-\[2px\],
 .border-t-2,
 .border-t-size-2{border-top-width:2px;}
 .border-inline{border-inline-start-width:1px;border-inline-end-width:1px;}

--- a/test/assets/preset-wind4-targets.ts
+++ b/test/assets/preset-wind4-targets.ts
@@ -671,6 +671,11 @@ export const presetWind4Targets: string[] = [
   'border-[length:2px]',
   'border-[width:2px]',
 
+  // #5322
+  'border-[2px]',
+  'border-b-[2px]',
+  'border-t-[2px]',
+
   // zoom
   'zoom-50',
   'zoom-[1.1]',


### PR DESCRIPTION
`handlerBorderColorOrSize` in `preset-wind4` matched arbitrary bracketed lengths like `border-b-[2px]` because `bracketOfColor` returns bracket content when no type hint is present. As a result, non-color arbitrary values were being handled as colors instead of falling through to `handlerBorderSize`.

This checks that bracketed values have an explicit `[color:...]` type hint or match `hasParseableColor` before resolving as border color.

close #5322
