### PR TITLE
fix(preset-wind4): apply stacked variants left to right like Tailwind v4

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -156,6 +156,20 @@ Postprocess the generate utils object.
 
 Variant separator.
 
+### variantApplyOrder
+
+- **Type:** `'right-to-left' | 'left-to-right'`
+- **Default:** `'right-to-left'`
+
+The order in which stacked variants are applied to a utility.
+
+- `'right-to-left'`: the rightmost variant is applied to the selector first, e.g. `hover:*:p-2` generates `.hover\:\*\:p-2 > *:hover`.
+- `'left-to-right'`: variants are applied in the order they are written, like Tailwind CSS v4, e.g. `hover:*:p-2` generates `.hover\:\*\:p-2:hover > *`.
+
+The handlers injected by the rules (`symbols.parent`, `symbols.variants`, ...) are applied before the variants of the utility in both orders. The presets are built around their default order: `presetWind4` sets `'left-to-right'`, `presetMini` and `presetWind3` expect `'right-to-left'`.
+
+It may be set by a preset or the user config, the user config takes precedence. [`@unocss/preset-wind4`](/presets/wind4#variant-stacking-order) sets it to `'left-to-right'`.
+
 ### extractorDefault
 
 - **Type:** `Extractor | null | false`

--- a/docs/presets/wind4.md
+++ b/docs/presets/wind4.md
@@ -51,6 +51,27 @@ export default defineConfig({
 
 Refer to [Tailwind Compatibility](https://tailwindcss.com/docs/compatibility) to learn about browser support and compatibility.
 
+## Variant stacking order
+
+Like Tailwind CSS v4, `presetWind4` applies stacked variants from left to right: the leftmost variant is the outermost one.
+
+```html
+<div class="*:last:p-2 last:*:p-2"></div>
+```
+
+```css
+.\*\:last\:p-2 > *:last-child {
+  padding: calc(var(--spacing) * 2);
+}
+.last\:\*\:p-2:last-child > * {
+  padding: calc(var(--spacing) * 2);
+}
+```
+
+This is controlled by the [`variantApplyOrder`](/config/#variantapplyorder) option, which `presetWind4` sets to `'left-to-right'`. Set it to `'right-to-left'` in your config to restore the order used by `presetWind3` and `presetMini`, where the rightmost variant is applied first.
+
+The variants adding a prefix to the selector (`dark:`, `rtl:`, `group-*`, `peer-*`, ...) and the pseudo elements (`before:`, `after:`, ...) apply to the whole selector wherever they are written, as they did before.
+
 ## Theme
 
 `PresetWind4`'s theme is almost identical to `PresetWind3`'s theme, but some theme keys have been adjusted.

--- a/packages-engine/core/src/config.ts
+++ b/packages-engine/core/src/config.ts
@@ -187,6 +187,10 @@ export async function resolveConfig<Theme extends object = object>(
 
   extractors.sort((a, b) => (a.order || 0) - (b.order || 0))
 
+  const variantApplyOrder = sourcesReversed
+    .find(i => i.variantApplyOrder !== undefined)
+    ?.variantApplyOrder ?? 'right-to-left'
+
   const rules = getMerged('rules')
   const rulesSize = rules.length
   const rulesStaticMap: ResolvedConfig<Theme>['rulesStaticMap'] = {}
@@ -248,6 +252,7 @@ export async function resolveConfig<Theme extends object = object>(
     extractors,
     safelist: getMerged('safelist'),
     separators,
+    variantApplyOrder,
     details: config.details ?? (config.envMode === 'dev'),
     content,
     transformers: uniqueBy(getMerged('transformers'), (a, b) => a.name === b.name),

--- a/packages-engine/core/src/generator.ts
+++ b/packages-engine/core/src/generator.ts
@@ -1,4 +1,4 @@
-import type { BlocklistMeta, BlocklistRule, BlocklistValue, ControlSymbols, ControlSymbolsEntry, CSSEntries, CSSEntriesInput, CSSEntry, CSSObject, CSSProcessorContext, CSSValueInput, ExtendedTokenInfo, ExtractorContext, GenerateOptions, GenerateResult, ParsedUtil, PreflightContext, PreparedRule, RawUtil, ResolvedConfig, Rule, RuleContext, RuleMeta, SafeListContext, Shortcut, ShortcutInlineValue, ShortcutValue, StringifiedUtil, UserConfig, UserConfigDefaults, UtilObject, Variant, VariantContext, VariantHandlerContext, VariantMatchedResult } from './types'
+import type { BlocklistMeta, BlocklistRule, BlocklistValue, ControlSymbols, ControlSymbolsEntry, CSSEntries, CSSEntriesInput, CSSEntry, CSSObject, CSSProcessorContext, CSSValueInput, ExtendedTokenInfo, ExtractorContext, GenerateOptions, GenerateResult, ParsedUtil, PreflightContext, PreparedRule, RawUtil, ResolvedConfig, Rule, RuleContext, RuleMeta, SafeListContext, Shortcut, ShortcutInlineValue, ShortcutValue, StringifiedUtil, UserConfig, UserConfigDefaults, UtilObject, Variant, VariantContext, VariantHandler, VariantHandlerContext, VariantMatchedResult } from './types'
 import { version } from '../package.json'
 import { resolveConfig } from './config'
 import { LAYER_DEFAULT, LAYER_PREFLIGHTS } from './constants'
@@ -136,6 +136,34 @@ class TokenProcessor<Theme extends object> {
     this.cache.delete(token)
     this.blocked.delete(token)
   }
+}
+
+/**
+ * Marks the handlers of the variants of a utility, as opposed to the ones injected by its rule
+ * (`symbols.parent`, `symbols.variants`, ...). Set on a copy owned by the generator, so the objects
+ * of the variants are never mutated, and as an own property so that it survives cloning.
+ */
+const SymbolUtilityVariant: unique symbol = Symbol('unocss-utility-variant')
+
+interface UtilityVariantHandler extends VariantHandler {
+  [SymbolUtilityVariant]?: true
+}
+
+function markUtilityVariant(handler: VariantHandler): VariantHandler {
+  return isUtilityVariant(handler)
+    ? handler
+    : { ...handler, [SymbolUtilityVariant]: true } as UtilityVariantHandler
+}
+
+function isUtilityVariant(handler: VariantHandler) {
+  return (handler as UtilityVariantHandler)[SymbolUtilityVariant] === true
+}
+
+function unmarkUtilityVariant(handler: VariantHandler): VariantHandler {
+  if (!isUtilityVariant(handler))
+    return handler
+  const { [SymbolUtilityVariant]: _, ...rest } = handler as UtilityVariantHandler
+  return rest
 }
 
 class UnoGeneratorInternal<Theme extends object = object> {
@@ -409,12 +437,20 @@ class UnoGeneratorInternal<Theme extends object = object> {
       return alias === null ? null : alias ?? layer
     }
 
+    // in `left-to-right` mode the at-rules are nested in the written order, so the blocks with more
+    // conditions are placed after the ones with fewer (`@dark:contrast-more:` after `contrast-more:`)
+    // to keep the cascade instead of relying on the alphabetical order of the parents
+    const leftToRight = this.config.variantApplyOrder === 'left-to-right'
+    const parentDepth = (parent: string | undefined) => parent ? parent.split(' $$ ').length : 0
+
     const getRawLayer = (layer: string = LAYER_DEFAULT) => {
       if (rawLayerCache[layer] != null)
         return rawLayerCache[layer]
 
       let css = Array.from(sheet)
-        .sort((a, b) => ((this.tokenProcessor.getParentOrder(a[0]) ?? 0) - (this.tokenProcessor.getParentOrder(b[0]) ?? 0)) || a[0]?.localeCompare(b[0] || '') || 0)
+        .sort((a, b) => ((this.tokenProcessor.getParentOrder(a[0]) ?? 0) - (this.tokenProcessor.getParentOrder(b[0]) ?? 0))
+          || (leftToRight ? parentDepth(a[0]) - parentDepth(b[0]) : 0)
+          || a[0]?.localeCompare(b[0] || '') || 0)
         .map(([parent, items]) => {
           const sorted: PreparedRule[] = items
             .filter(i => (i[4]?.layer || LAYER_DEFAULT) === layer)
@@ -580,6 +616,9 @@ class UnoGeneratorInternal<Theme extends object = object> {
       theme: this.config.theme,
       generator: this,
     }
+    // the handlers are stored in the order they are applied to the selector:
+    // from the rightmost variant by default, or from the leftmost one
+    const leftToRight = this.config.variantApplyOrder === 'left-to-right'
 
     const match = async (result: VariantMatchedResult<Theme>): Promise<VariantMatchedResult<Theme>[]> => {
       let applied = true
@@ -598,6 +637,7 @@ class UnoGeneratorInternal<Theme extends object = object> {
               continue
             handler = { matcher: handler }
           }
+          handler = Array.isArray(handler) ? handler.map(markUtilityVariant) : markUtilityVariant(handler)
 
           // If variant return an array of handlers,
           // we clone the matched result and branch the matching items
@@ -613,7 +653,7 @@ class UnoGeneratorInternal<Theme extends object = object> {
 
               const clones = handler.map((h): VariantMatchedResult<Theme> => {
                 const _processed = h.matcher ?? processed
-                const _handlers = [h, ...handlers]
+                const _handlers = leftToRight ? [...handlers, h] : [h, ...handlers]
                 const _variants = new Set(variants)
                 _variants.add(v)
                 return [result[0], _processed, _handlers, _variants]
@@ -623,7 +663,10 @@ class UnoGeneratorInternal<Theme extends object = object> {
           }
 
           result[1] = handler.matcher ?? processed
-          handlers.unshift(handler)
+          if (leftToRight)
+            handlers.push(handler)
+          else
+            handlers.unshift(handler)
           variants.add(v)
           applied = true
           break
@@ -651,7 +694,25 @@ class UnoGeneratorInternal<Theme extends object = object> {
     variantHandlers = parsed[4],
     raw = parsed[1],
   ): UtilObject[] {
-    const handler = variantHandlers.slice()
+    const leftToRight = this.config.variantApplyOrder === 'left-to-right'
+    const handlers = variantHandlers.slice()
+
+    // identifies this application of the variants for the handlers, see `VariantHandlerContext.application`
+    const application = {}
+    // in `left-to-right` mode the `parentOrder`, `sort` and `layer` set by the handlers injected
+    // by the rule are defaults, the first variant of the utility setting them decides
+    const defaults: Partial<Pick<VariantHandlerContext, 'parentOrder' | 'sort' | 'layer'>> = {}
+    const decided = { parentOrder: false, sort: false, layer: false }
+    const seed = (input: VariantHandlerContext): VariantHandlerContext => leftToRight
+      ? {
+          ...input,
+          parentOrder: input.parentOrder ?? defaults.parentOrder,
+          sort: input.sort ?? defaults.sort,
+          layer: input.layer ?? defaults.layer,
+        }
+      : input
+
+    const handler = handlers
       .sort((a, b) => (a.order || 0) - (b.order || 0))
       .reduceRight(
         (previous, v) => (input: VariantHandlerContext) => {
@@ -662,6 +723,27 @@ class UnoGeneratorInternal<Theme extends object = object> {
 
           const selector = v.selector?.(input.selector, entries)
 
+          // the leftmost variant decides the position of the rule (`sort`), of its block (`parentOrder`)
+          // and its layer: it is applied last by default, in `left-to-right` mode it is applied first
+          // so its values are kept over the ones set by the following variants
+          const next = (output: VariantHandlerContext) => {
+            if (!leftToRight)
+              return previous({ ...output, application })
+            const keep = <K extends keyof typeof defaults>(key: K): VariantHandlerContext[K] => {
+              if (!isUtilityVariant(v)) {
+                if (output[key] !== input[key])
+                  defaults[key] = output[key]
+                return input[key]
+              }
+              if (decided[key])
+                return input[key]
+              if (output[key] !== input[key])
+                decided[key] = true
+              return output[key]
+            }
+            return previous({ ...output, application, parentOrder: keep('parentOrder'), sort: keep('sort'), layer: keep('layer') })
+          }
+
           return (v.handle ?? defaultVariantHandler)({
             ...input,
             entries,
@@ -670,9 +752,9 @@ class UnoGeneratorInternal<Theme extends object = object> {
             parentOrder: parents[1] || input.parentOrder,
             layer: v.layer || input.layer,
             sort: v.sort || input.sort,
-          }, previous)
+          }, next)
         },
-        (input: VariantHandlerContext) => input,
+        seed,
       )
 
     const variantContextResult = handler({
@@ -680,6 +762,7 @@ class UnoGeneratorInternal<Theme extends object = object> {
       selector: toEscapedSelector(raw),
       pseudo: '',
       entries: parsed[2],
+      application,
     })
 
     const { parent, parentOrder } = variantContextResult
@@ -854,6 +937,7 @@ class UnoGeneratorInternal<Theme extends object = object> {
           return [meta!.__index!, css, meta]
 
         // Extract variants from special symbols
+        const utilityVariants = [...context.variantHandlers]
         let variants = context.variantHandlers
         let entryMeta = meta
         const setVariant = (variant: (typeof variants)[number]) => {
@@ -901,6 +985,17 @@ class UnoGeneratorInternal<Theme extends object = object> {
               break
           }
         }
+
+        // the variants of the utility are the handlers matched for it and the ones a callback may
+        // have cloned or rebuilt from them (a missing property and `undefined` being the same),
+        // the other handlers are injected by the rule
+        const sameHandler = (a: VariantHandler, b: VariantHandler) => {
+          const keys = new Set([...Object.keys(a), ...Object.keys(b)])
+          return keys.size > 0 && [...keys].every(key => (a as Record<string, unknown>)[key] === (b as Record<string, unknown>)[key])
+        }
+        const isDerived = (handler: VariantHandler) => utilityVariants.some(utility => utility === handler || sameHandler(handler, utility))
+        // a copy of a variant modified by a callback keeps its mark, drop it
+        variants = variants.map(handler => isDerived(handler) ? markUtilityVariant(handler) : unmarkUtilityVariant(handler))
 
         return [meta!.__index!, raw, css as CSSEntries, entryMeta, variants]
       })
@@ -1013,7 +1108,9 @@ class UnoGeneratorInternal<Theme extends object = object> {
               ? raw
               : raw.slice(0, matcherIndex) + item + raw.slice(matcherIndex + inputWithoutVariant.length))
             inlineResult = (expanded[0].filter(i => !isString(i)) as ShortcutInlineValue[]).map((item) => {
-              return { handles: [...item.handles, ...handles], value: item.value }
+              // the variants of the shortcut wrap the ones of its utilities
+              const shortcutFirst = this.config.variantApplyOrder === 'left-to-right'
+              return { handles: shortcutFirst ? [...handles, ...item.handles] : [...item.handles, ...handles], value: item.value }
             })
           }
         }
@@ -1066,7 +1163,12 @@ class UnoGeneratorInternal<Theme extends object = object> {
       }
 
       const isNoMerge = Object.fromEntries(item[2])[symbols.shortcutsNoMerge]
-      const variants = [...item[4], ...(!isNoMerge ? parentVariants : [])]
+      const shortcutVariants = isNoMerge ? [] : parentVariants
+      // the variants of the shortcut wrap the ones of its utilities, the handlers injected by
+      // the rules keep being applied before all of them
+      const variants = this.config.variantApplyOrder === 'left-to-right' && shortcutVariants.length
+        ? [...item[4].filter(h => !isUtilityVariant(h)), ...shortcutVariants, ...item[4].filter(isUtilityVariant)]
+        : [...item[4], ...shortcutVariants]
       for (const { selector, entries, parent, sort, noMerge, layer } of this.applyVariants(item, variants, raw)) {
         // find existing layer and merge
         const selectorMap = layerMap.getFallback(layer ?? meta.layer, new TwoKeyMap())

--- a/packages-engine/core/src/types.ts
+++ b/packages-engine/core/src/types.ts
@@ -333,6 +333,12 @@ export interface VariantHandlerContext {
    * @default false
    */
   noMerge?: boolean
+  /**
+   * Identifies the application of the variants to a utility. It is unique for each utility and
+   * kept across the handlers, so a variant can use it as a `WeakMap` key to share state with
+   * the handlers applied after it.
+   */
+  application?: object
 }
 
 export interface VariantHandler {
@@ -419,6 +425,22 @@ export interface ConfigBase<Theme extends object = object> {
    * @default [':', '-']
    */
   separators?: Arrayable<string>
+
+  /**
+   * The order in which stacked variants are applied to a utility.
+   *
+   * - `right-to-left`: the rightmost variant is applied to the selector first,
+   *   e.g. `hover:*:p-2` generates `.hover\:\*\:p-2 > *:hover`.
+   * - `left-to-right`: variants are applied in the order they are written, like Tailwind CSS v4,
+   *   e.g. `hover:*:p-2` generates `.hover\:\*\:p-2:hover > *`.
+   *
+   * The handlers injected by the rules (`symbols.parent`, `symbols.variants`, ...) are applied
+   * before the variants of the utility in both orders.
+   * Presets can set this option, the user config takes precedence.
+   *
+   * @default 'right-to-left'
+   */
+  variantApplyOrder?: 'right-to-left' | 'left-to-right'
 
   /**
    * Variants that preprocess the selectors,
@@ -948,7 +970,7 @@ export interface UserConfig<Theme extends object = object> extends ConfigBase<Th
 export interface UserConfigDefaults<Theme extends object = object> extends ConfigBase<Theme>, UserOnlyOptions<Theme> { }
 
 export interface ResolvedConfig<Theme extends object = object> extends Omit<
-  RequiredByKey<UserConfig<Theme>, 'mergeSelectors' | 'theme' | 'rules' | 'variants' | 'layers' | 'extractors' | 'blocklist' | 'safelist' | 'preflights' | 'sortLayers'>,
+  RequiredByKey<UserConfig<Theme>, 'mergeSelectors' | 'theme' | 'rules' | 'variants' | 'layers' | 'extractors' | 'blocklist' | 'safelist' | 'preflights' | 'sortLayers' | 'variantApplyOrder'>,
   'rules' | 'shortcuts' | 'autocomplete' | 'presets'
 > {
   presets: Preset<Theme>[]

--- a/packages-engine/core/test/variant-apply-order.test.ts
+++ b/packages-engine/core/test/variant-apply-order.test.ts
@@ -1,0 +1,224 @@
+import type { Rule, UserConfig, Variant, VariantHandler } from '@unocss/core'
+import { createGenerator, symbols } from '@unocss/core'
+import { variantMatcher } from '@unocss/rule-utils'
+import { describe, expect, it } from 'vitest'
+
+const shared: VariantHandler = { matcher: 'foo', selector: () => '.target' }
+
+const rules: Rule[] = [
+  ['foo', { name: 'bar' }],
+  [/^sup$/, () => ({ name: 'sup', [symbols.parent]: '@supports (x)' })],
+  [/^grid$/, () => ({ name: 'grid', [symbols.variants]: [{ parent: '@supports (display: grid)' }] })],
+  [/^target$/, () => ({ name: 'target', [symbols.selector]: () => '.target' })],
+  // a callback mutating the handlers in place
+  [/^mut$/, () => ({ name: 'mut', [symbols.variants]: (variants: VariantHandler[]) => {
+    variants.unshift({ selector: () => '.target' })
+    return variants
+  } })],
+  // a callback cloning the handlers
+  [/^copied$/, () => ({ name: 'copied', [symbols.variants]: (variants: VariantHandler[]) => variants.map(v => ({ ...v })) })],
+  // a callback rebuilding the handlers
+  [/^rebuilt$/, () => ({ name: 'rebuilt', [symbols.variants]: (variants: VariantHandler[]) => variants.map(({ matcher, handle, selector, order }) => ({ matcher, handle, selector, order })) })],
+  // a parent with an order provided by the rule
+  [/^gridp$/, () => ({ name: 'gridp', [symbols.parent]: ['@supports (display: grid)', -1] })],
+  // an order provided by the rule equal to the one of the leftmost variant
+  [/^gridp2$/, () => ({ name: 'gridp2', [symbols.parent]: ['@supports (display: grid)', 3] })],
+  [/^sorted$/, () => ({ name: 'sorted', [symbols.variants]: [{ sort: 2 }] })],
+  // a rule injecting the handler object of a variant
+  [/^inj$/, () => ({ name: 'inj', [symbols.variants]: [shared] })],
+  // a callback replacing the handlers with as many new ones
+  [/^replaced$/, () => ({ name: 'replaced', [symbols.variants]: () => [{ selector: () => '.target' }] })],
+  // a callback appending a handler
+  [/^icon$/, () => ({ name: 'icon', [symbols.variants]: (variants: VariantHandler[]) => [...variants, { selector: (s: string) => `${s} > .icon` }] })],
+  // a callback appending a modified copy of a handler
+  [/^mixed$/, () => ({ name: 'mixed', [symbols.variants]: (variants: VariantHandler[]) => [...variants, { ...variants[0], handle: undefined, selector: (s: string) => `${s} > .icon` }] })],
+  // a layer provided by the rule
+  [/^layered$/, () => ({ name: 'layered', [symbols.layer]: 'rule' })],
+  // a callback appending a copy of a handler with a property removed
+  [/^dropped$/, () => ({ name: 'dropped', [symbols.variants]: (variants: VariantHandler[]) => {
+    const { handle: _, ...rest } = variants[0]
+    return [...variants, { ...rest, selector: (s: string) => `${s} > .icon` }]
+  } })],
+]
+
+const variants: Variant[] = [
+  variantMatcher('a', input => ({ selector: `${input.selector}:a` })),
+  variantMatcher('b', input => ({ selector: `${input.selector}:b` })),
+  variantMatcher('first', input => ({ selector: `${input.selector}:first` }), { order: -1 }),
+  variantMatcher('pa', input => ({ parent: `${input.parent ? `${input.parent} $$ ` : ''}@media a`, parentOrder: 3 })),
+  variantMatcher('pb', input => ({ parent: `${input.parent ? `${input.parent} $$ ` : ''}@media b`, parentOrder: 2 })),
+  variantMatcher('pc', input => ({ parent: `${input.parent ? `${input.parent} $$ ` : ''}@media c`, parentOrder: 1 })),
+  variantMatcher('pd', input => ({ parent: `${input.parent ? `${input.parent} $$ ` : ''}@media d` })),
+  variantMatcher('pe', input => ({ parent: `${input.parent ? `${input.parent} $$ ` : ''}@media e` })),
+  variantMatcher('sa', input => ({ selector: `${input.selector}:sa`, sort: 2 })),
+  variantMatcher('sb', input => ({ selector: `${input.selector}:sb`, sort: 1 })),
+  // a variant leaving the selector alone
+  variantMatcher('bo', () => ({})),
+  variantMatcher('la', () => ({ layer: 'la' })),
+  variantMatcher('lb', () => ({ layer: 'lb' })),
+  // handlers that cannot be mutated
+  { name: 'sealed', match: (matcher: string) => matcher.startsWith('sealed:') ? Object.seal({ matcher: matcher.slice(7), selector: (s: string) => `${s}:sealed` }) : undefined },
+  { name: 'frozen', match: (matcher: string) => matcher.startsWith('frozen:') ? Object.freeze({ matcher: matcher.slice(7), selector: (s: string) => `${s}:frozen` }) : undefined },
+  { name: 'sharedv', match: (matcher: string) => matcher === 'sharedv:foo' ? shared : undefined },
+]
+
+async function generate(code: string, config: UserConfig = {}) {
+  const uno = await createGenerator({
+    presets: [],
+    rules,
+    variants,
+    shortcuts: [['sc', 'b:foo'], ['sc2', 'sup'], ['sc3', 'mut'], ['sc4', 'b:copied'], ['sc5', 'b:rebuilt'], ['sc6', 'a:replaced'], ['plain', 'icon'], ['strong', 'bo:icon'], ['sc7', 'b:mixed'], ['sc8', 'b:dropped'], ['alias', 'a:icon']],
+    ...config,
+  })
+  const { css } = await uno.generate(code, { preflights: false })
+  return css
+}
+
+describe('variantApplyOrder', () => {
+  it('defaults to applying the rightmost variant first', async () => {
+    expect(await generate('a:b:foo')).toContain('.a\\:b\\:foo:b:a{')
+    expect(await generate('b:first:foo')).toContain('.b\\:first\\:foo:first:b{')
+    expect(await generate('pa:pb:foo')).toContain('@media b{@media a{')
+    expect(await generate('a:sc')).toContain('.a\\:sc:b:a{')
+    // the handlers injected by the rules are applied first
+    expect(await generate('pa:sup')).toContain('@supports (x){@media a{')
+    expect(await generate('pa:grid')).toContain('@supports (display: grid){@media a{')
+    expect(await generate('a:target')).toContain('.target:a{')
+    expect(await generate('pa:sc2')).toContain('@supports (x){@media a{')
+    expect(await generate('a:mut')).toContain('.target:a{')
+    expect(await generate('a:sc3')).toContain('.target:a{')
+    expect(await generate('a:sc4')).toContain('.a\\:sc4:b:a{')
+    expect(await generate('a:sc5')).toContain('.a\\:sc5:b:a{')
+    expect(await generate('a:sealed:foo')).toContain('.a\\:sealed\\:foo:sealed:a{')
+    expect(await generate('a:frozen:foo')).toContain('.a\\:frozen\\:foo:frozen:a{')
+    // the `parentOrder` of the rule is a default, the variants of the utility decide
+    const css = await generate('foo pa:gridp')
+    expect(css.indexOf('.foo{')).toBeLessThan(css.indexOf('.pa\\:gridp'))
+    // the handler object of a variant used by a rule is still injected by the rule
+    await generate('sharedv:foo')
+    expect(await generate('a:inj')).toContain('.target:a{')
+    // handlers replacing or appended to the ones of the utility are injected by the rule
+    expect(await generate('b:sc6')).toContain('.target:b{')
+    expect(await generate('a:icon')).toContain('.a\\:icon:a > .icon{')
+    expect(await generate('a:plain')).toContain('.a\\:plain > .icon:a{')
+    expect(await generate('a:strong')).toContain('.a\\:strong > .icon:a{')
+    // a modified copy of a variant is injected by the rule
+    expect(await generate('a:mixed')).toContain('.a\\:mixed:a > .icon{')
+    expect(await generate('a:sc7')).toContain('.a\\:sc7:b > .icon:a{')
+    expect(await generate('a:dropped')).toContain('.a\\:dropped:a > .icon{')
+    expect(await generate('a:sc8')).toContain('.a\\:sc8:b > .icon:a{')
+    // a shortcut without variants keeps the order of the utility
+    expect(await generate('alias')).toContain('.alias:a > .icon{')
+  })
+
+  it('applies variants in the written order with `left-to-right`', async () => {
+    const config: UserConfig = { variantApplyOrder: 'left-to-right' }
+    expect(await generate('a:b:foo', config)).toContain('.a\\:b\\:foo:a:b{')
+    // `order` on a handler still wins over the position
+    expect(await generate('b:first:foo', config)).toContain('.b\\:first\\:foo:first:b{')
+    expect(await generate('pa:pb:foo', config)).toContain('@media a{@media b{')
+    // variants of a shortcut wrap the variants of its utilities
+    expect(await generate('a:sc', config)).toContain('.a\\:sc:a:b{')
+    // the handlers injected by the rules are still applied first
+    expect(await generate('pa:sup', config)).toContain('@supports (x){@media a{')
+    expect(await generate('pa:grid', config)).toContain('@supports (display: grid){@media a{')
+    expect(await generate('a:target', config)).toContain('.target:a{')
+    expect(await generate('pa:sc2', config)).toContain('@supports (x){@media a{')
+    expect(await generate('a:mut', config)).toContain('.target:a{')
+    expect(await generate('a:sc3', config)).toContain('.target:a{')
+    // cloned or rebuilt handlers keep being the variants of the utility
+    expect(await generate('a:sc4', config)).toContain('.a\\:sc4:a:b{')
+    expect(await generate('a:sc5', config)).toContain('.a\\:sc5:a:b{')
+    // the handlers of the variants are never mutated
+    expect(await generate('a:sealed:foo', config)).toContain('.a\\:sealed\\:foo:a:sealed{')
+    expect(await generate('a:frozen:foo', config)).toContain('.a\\:frozen\\:foo:a:frozen{')
+    // the `parentOrder` of the rule is a default, the variants of the utility decide
+    const css = await generate('foo pa:gridp', config)
+    expect(css.indexOf('.foo{')).toBeLessThan(css.indexOf('.pa\\:gridp'))
+    // the handler object of a variant used by a rule is still injected by the rule
+    await generate('sharedv:foo', config)
+    expect(await generate('a:inj', config)).toContain('.target:a{')
+    // handlers replacing or appended to the ones of the utility are injected by the rule
+    expect(await generate('b:sc6', config)).toContain('.target:b{')
+    expect(await generate('a:icon', config)).toContain('.a\\:icon:a > .icon{')
+    expect(await generate('a:plain', config)).toContain('.a\\:plain > .icon:a{')
+    expect(await generate('a:strong', config)).toContain('.a\\:strong > .icon:a{')
+    // a modified copy of a variant is injected by the rule
+    expect(await generate('a:mixed', config)).toContain('.a\\:mixed:a > .icon{')
+    expect(await generate('a:sc7', config)).toContain('.a\\:sc7 > .icon:a:b{')
+    expect(await generate('a:dropped', config)).toContain('.a\\:dropped:a > .icon{')
+    expect(await generate('a:sc8', config)).toContain('.a\\:sc8 > .icon:a:b{')
+    // a shortcut without variants keeps the order of the utility
+    expect(await generate('alias', config)).toContain('.alias:a > .icon{')
+  })
+
+  it('places the blocks with more conditions after the ones with fewer in `left-to-right`', async () => {
+    // `@media d $$ @media e` sorts before `@media e` alphabetically, but has more conditions
+    const css = await generate('pe:foo pd:pe:foo', { variantApplyOrder: 'left-to-right' })
+    expect(css.indexOf('.pe\\:foo')).toBeLessThan(css.indexOf('.pd\\:pe\\:foo'))
+  })
+
+  it('lets the leftmost variant decide the position of the rule and of its block in both orders', async () => {
+    for (const config of [{}, { variantApplyOrder: 'left-to-right' as const }]) {
+      // `pa:pc:foo` takes the `parentOrder` of `pa` (3), `pc:pa:foo` the one of `pc` (1)
+      const blocks = await generate('pb:foo pa:pc:foo pc:pa:foo', config)
+      expect(blocks.indexOf('.pc\\:pa\\:foo')).toBeLessThan(blocks.indexOf('.pb\\:foo'))
+      expect(blocks.indexOf('.pb\\:foo')).toBeLessThan(blocks.indexOf('.pa\\:pc\\:foo'))
+
+      // also when the rule provides the same value as the leftmost variant
+      const equal = await generate('pb:foo pa:pc:gridp2 sb:foo sa:sb:sorted', config)
+      expect(equal.indexOf('.pb\\:foo')).toBeLessThan(equal.indexOf('.pa\\:pc\\:gridp2'))
+      expect(equal.indexOf('.sb\\:foo{')).toBeLessThan(equal.indexOf('.sa\\:sb\\:sorted'))
+
+      // `sa:sb:foo` takes the `sort` of `sa` (2), `sb:sa:foo` the one of `sb` (1)
+      const rules = await generate('sa:sb:foo sb:sa:foo sa:foo', config)
+      expect(rules.indexOf('.sb\\:sa\\:foo')).toBeLessThan(rules.indexOf('.sa\\:foo'))
+      expect(rules.indexOf('.sb\\:sa\\:foo')).toBeLessThan(rules.indexOf('.sa\\:sb\\:foo'))
+    }
+  })
+
+  it('lets the leftmost variant decide the layer in both orders', async () => {
+    for (const config of [{}, { variantApplyOrder: 'left-to-right' as const }]) {
+      const uno = await createGenerator({ presets: [], rules, variants, shortcuts: [['red', 'lb:foo']], ...config })
+      const result = await uno.generate('la:lb:foo la:red la:layered layered', { preflights: false })
+      expect(result.getLayer('la')).toContain('.la\\:lb\\:foo')
+      expect(result.getLayer('la')).toContain('.la\\:red')
+      // the layer of the rule is a default
+      expect(result.getLayer('la')).toContain('.la\\:layered')
+      expect(result.getLayer('rule')).toContain('.layered')
+    }
+  })
+
+  it('gives the handlers of a utility the same `application`', async () => {
+    for (const config of [{}, { variantApplyOrder: 'left-to-right' as const }]) {
+      const seen: { raw: string, application: object | undefined }[] = []
+      const record = (name: string) => variantMatcher(name, (input, ctx) => {
+        seen.push({ raw: ctx.rawSelector, application: input.application })
+        return {}
+      })
+      const uno = await createGenerator({ presets: [], rules, variants: [record('t1'), record('t2')], ...config })
+      await uno.generate('t1:t2:foo t1:foo', { preflights: false })
+
+      const stacked = seen.filter(i => i.raw === 't1:t2:foo').map(i => i.application)
+      const single = seen.filter(i => i.raw === 't1:foo').map(i => i.application)
+      expect(stacked).toHaveLength(2)
+      expect(stacked[0]).toBeDefined()
+      expect(stacked[0]).toBe(stacked[1])
+      expect(single).toHaveLength(1)
+      expect(single[0]).not.toBe(stacked[0])
+    }
+  })
+
+  it('can be set by a preset and overridden by the user config', async () => {
+    const preset = { name: 'test', variantApplyOrder: 'left-to-right' as const }
+
+    const fromDefault = await createGenerator({ presets: [] })
+    expect(fromDefault.config.variantApplyOrder).toBe('right-to-left')
+
+    const fromPreset = await createGenerator({ presets: [preset] })
+    expect(fromPreset.config.variantApplyOrder).toBe('left-to-right')
+
+    const fromUser = await createGenerator({ presets: [preset], variantApplyOrder: 'right-to-left' })
+    expect(fromUser.config.variantApplyOrder).toBe('right-to-left')
+  })
+})

--- a/packages-presets/preset-mini/src/_variants/aria.ts
+++ b/packages-presets/preset-mini/src/_variants/aria.ts
@@ -54,7 +54,10 @@ function taggedAria(tagName: string, combinator: string, options: PresetMiniOpti
                 ].join('')
               }
               else {
-                const prefixGroupIndex = Math.max(input.prefix.indexOf(parent), 0)
+                // insert the new segment before the existing tag or at the start, in `left-to-right` mode append it
+                const prefixGroupIndex = ctx.generator.config.variantApplyOrder === 'left-to-right'
+                  ? input.prefix.length
+                  : Math.max(input.prefix.indexOf(parent), 0)
                 nextPrefix = [
                   input.prefix.slice(0, prefixGroupIndex),
                   parent,

--- a/packages-presets/preset-mini/src/_variants/dark.ts
+++ b/packages-presets/preset-mini/src/_variants/dark.ts
@@ -1,7 +1,7 @@
-import type { Variant } from '@unocss/core'
+import type { Variant, VariantContext, VariantHandlerContext } from '@unocss/core'
 import type { PresetMiniOptions } from '..'
 import { toArray } from '@unocss/core'
-import { variantMatcher, variantParentMatcher } from '../utils'
+import { variantMatcher, variantParentMatcher, variantPrefix } from '../utils'
 
 export function variantColorsMediaOrClass(options: PresetMiniOptions = {}): Variant[] {
   if (options?.dark === 'class' || typeof options.dark === 'object') {
@@ -10,8 +10,8 @@ export function variantColorsMediaOrClass(options: PresetMiniOptions = {}): Vari
       : options.dark
 
     return [
-      variantMatcher('dark', toArray(dark).map(dark => input => ({ prefix: `${dark} $$ ${input.prefix}` }))),
-      variantMatcher('light', toArray(light).map(light => input => ({ prefix: `${light} $$ ${input.prefix}` }))),
+      variantMatcher('dark', toArray(dark).map(dark => (input: VariantHandlerContext, ctx: VariantContext) => ({ prefix: variantPrefix(input, `${dark} $$ `, ctx) }))),
+      variantMatcher('light', toArray(light).map(light => (input: VariantHandlerContext, ctx: VariantContext) => ({ prefix: variantPrefix(input, `${light} $$ `, ctx) }))),
     ]
   }
 

--- a/packages-presets/preset-mini/src/_variants/data.ts
+++ b/packages-presets/preset-mini/src/_variants/data.ts
@@ -54,7 +54,10 @@ function taggedData(tagName: string, combinator: string, options: PresetMiniOpti
                 ].join('')
               }
               else {
-                const prefixGroupIndex = Math.max(input.prefix.indexOf(parent), 0)
+                // insert the new segment before the existing tag or at the start, in `left-to-right` mode append it
+                const prefixGroupIndex = ctx.generator.config.variantApplyOrder === 'left-to-right'
+                  ? input.prefix.length
+                  : Math.max(input.prefix.indexOf(parent), 0)
                 nextPrefix = [
                   input.prefix.slice(0, prefixGroupIndex),
                   parent,

--- a/packages-presets/preset-mini/src/_variants/directions.ts
+++ b/packages-presets/preset-mini/src/_variants/directions.ts
@@ -1,7 +1,7 @@
 import type { Variant } from '@unocss/core'
-import { variantMatcher } from '../utils'
+import { variantMatcher, variantPrefix } from '../utils'
 
 export const variantLanguageDirections: Variant[] = [
-  variantMatcher('rtl', input => ({ prefix: `[dir="rtl"] $$ ${input.prefix}` })),
-  variantMatcher('ltr', input => ({ prefix: `[dir="ltr"] $$ ${input.prefix}` })),
+  variantMatcher('rtl', (input, ctx) => ({ prefix: variantPrefix(input, '[dir="rtl"] $$ ', ctx) })),
+  variantMatcher('ltr', (input, ctx) => ({ prefix: variantPrefix(input, '[dir="ltr"] $$ ', ctx) })),
 ]

--- a/packages-presets/preset-mini/src/_variants/important.ts
+++ b/packages-presets/preset-mini/src/_variants/important.ts
@@ -20,7 +20,7 @@ export function variantImportant(): VariantObject {
           matcher: base,
           body: (body) => {
             body.forEach((v) => {
-              if (v[1] != null)
+              if (typeof v[0] !== 'symbol' && v[1] != null)
                 v[1] += ' !important'
             })
             return body

--- a/packages-presets/preset-mini/src/_variants/misc.ts
+++ b/packages-presets/preset-mini/src/_variants/misc.ts
@@ -106,7 +106,8 @@ export const variantVariables: Variant = {
               parent: `${input.parent ? `${input.parent} $$ ` : ''}${variant}`,
             }
           : {
-              selector: variant.replace(/&/g, input.selector),
+              // the selector may hold the `$$` scope placeholder, keep it out of the replacement patterns
+              selector: variant.replace(/&/g, () => input.selector),
             }
         return next({
           ...input,
@@ -126,6 +127,8 @@ export const variantTheme: Variant = {
 
     return {
       matcher,
+      // substitute `theme()` before the other body transforms (negative, `!important`)
+      order: -2,
       handle(input, next) {
         return next({
           ...input,

--- a/packages-presets/preset-mini/src/_variants/negative.ts
+++ b/packages-presets/preset-mini/src/_variants/negative.ts
@@ -40,6 +40,8 @@ export const variantNegative: Variant = {
 
     return {
       matcher: matcher.slice(1),
+      // negate the values after `theme()` substitution and before `!important`
+      order: -1,
       body: (body) => {
         if (body.some(v => v[0] === CONTROL_MINI_NO_NEGATIVE))
           return

--- a/packages-presets/preset-mini/src/_variants/startingstyle.ts
+++ b/packages-presets/preset-mini/src/_variants/startingstyle.ts
@@ -10,7 +10,7 @@ export const variantStartingStyle: Variant = {
       matcher: matcher.slice(9),
       handle: (input, next) => next({
         ...input,
-        parent: `@starting-style`,
+        parent: input.parent ? `${input.parent} $$ @starting-style` : '@starting-style',
       }),
     }
   },

--- a/packages-presets/preset-wind4/src/index.ts
+++ b/packages-presets/preset-wind4/src/index.ts
@@ -168,6 +168,7 @@ export const presetWind4 = definePreset<PresetWind4Options, Theme>((options = {}
     },
     preflights: preflights(options),
     variants: variants(options),
+    variantApplyOrder: 'left-to-right',
     prefix: options.prefix,
     postprocess: postprocessors(options),
     extractorDefault: options.arbitraryVariants === false

--- a/packages-presets/preset-wind4/src/variants/children.ts
+++ b/packages-presets/preset-wind4/src/variants/children.ts
@@ -3,6 +3,6 @@ import type { Theme } from '../theme'
 import { variantMatcher } from '@unocss/rule-utils'
 
 export const variantChildren: Variant<Theme>[] = [
-  variantMatcher('*', input => ({ selector: `${input.selector} > *` }), { order: -1 }),
-  variantMatcher('**', input => ({ selector: `${input.selector} *` }), { order: -1 }),
+  variantMatcher('*', input => ({ selector: `${input.selector} > *` })),
+  variantMatcher('**', input => ({ selector: `${input.selector} *` })),
 ]

--- a/packages-presets/preset-wind4/src/variants/dark.ts
+++ b/packages-presets/preset-wind4/src/variants/dark.ts
@@ -1,7 +1,7 @@
 import type { Variant } from '@unocss/core'
 import type { PresetWind4Options } from '..'
 import type { Theme } from '../theme'
-import { variantMatcher, variantParentMatcher } from '@unocss/rule-utils'
+import { variantMatcher, variantParentMatcher, variantPrefix } from '@unocss/rule-utils'
 
 export function variantColorsMediaOrClass(options: PresetWind4Options = {}): Variant<Theme>[] {
   if (options?.dark === 'class' || typeof options.dark === 'object') {
@@ -10,8 +10,8 @@ export function variantColorsMediaOrClass(options: PresetWind4Options = {}): Var
       : options.dark
 
     return [
-      variantMatcher('dark', input => ({ prefix: `${dark} $$ ${input.prefix}` })),
-      variantMatcher('light', input => ({ prefix: `${light} $$ ${input.prefix}` })),
+      variantMatcher('dark', (input, ctx) => ({ prefix: variantPrefix(input, `${dark} $$ `, ctx) })),
+      variantMatcher('light', (input, ctx) => ({ prefix: variantPrefix(input, `${light} $$ `, ctx) })),
     ] as Variant<Theme>[]
   }
 
@@ -22,8 +22,8 @@ export function variantColorsMediaOrClass(options: PresetWind4Options = {}): Var
 }
 
 export const variantColorsScheme: Variant<Theme>[] = [
-  variantMatcher('.dark', input => ({ prefix: `.dark $$ ${input.prefix}` })),
-  variantMatcher('.light', input => ({ prefix: `.light $$ ${input.prefix}` })),
+  variantMatcher('.dark', (input, ctx) => ({ prefix: variantPrefix(input, '.dark $$ ', ctx) })),
+  variantMatcher('.light', (input, ctx) => ({ prefix: variantPrefix(input, '.light $$ ', ctx) })),
   variantParentMatcher('@dark', '@media (prefers-color-scheme: dark)'),
   variantParentMatcher('@light', '@media (prefers-color-scheme: light)'),
   variantParentMatcher('not-dark', '@media not (prefers-color-scheme: dark)'),

--- a/packages-presets/preset-wind4/src/variants/directions.ts
+++ b/packages-presets/preset-wind4/src/variants/directions.ts
@@ -1,8 +1,8 @@
 import type { Variant } from '@unocss/core'
 import type { Theme } from '../theme'
-import { variantMatcher } from '@unocss/rule-utils'
+import { variantMatcher, variantPrefix } from '@unocss/rule-utils'
 
 export const variantLanguageDirections = [
-  variantMatcher('rtl', input => ({ prefix: `[dir="rtl"] $$ ${input.prefix}` })),
-  variantMatcher('ltr', input => ({ prefix: `[dir="ltr"] $$ ${input.prefix}` })),
+  variantMatcher('rtl', (input, ctx) => ({ prefix: variantPrefix(input, '[dir="rtl"] $$ ', ctx) })),
+  variantMatcher('ltr', (input, ctx) => ({ prefix: variantPrefix(input, '[dir="ltr"] $$ ', ctx) })),
 ] as Variant<Theme>[]

--- a/packages-presets/preset-wind4/src/variants/important.ts
+++ b/packages-presets/preset-wind4/src/variants/important.ts
@@ -21,7 +21,7 @@ export function variantImportant(): VariantObject<Theme> {
           matcher: base,
           body: (body) => {
             body.forEach((v) => {
-              if (v[1] != null)
+              if (typeof v[0] !== 'symbol' && v[1] != null)
                 v[1] += ' !important'
             })
             return body

--- a/packages-presets/preset-wind4/src/variants/misc.ts
+++ b/packages-presets/preset-wind4/src/variants/misc.ts
@@ -108,7 +108,8 @@ export const variantVariables: Variant<Theme> = {
               parent: `${input.parent ? `${input.parent} $$ ` : ''}${variant}`,
             }
           : {
-              selector: variant.replace(/&/g, input.selector),
+              // the selector may hold the `$$` scope placeholder, keep it out of the replacement patterns
+              selector: variant.replace(/&/g, () => input.selector),
             }
         return next({
           ...input,
@@ -128,6 +129,8 @@ export const variantTheme: Variant<Theme> = {
 
     return {
       matcher,
+      // substitute `theme()` before the other body transforms (negative, `!important`)
+      order: -2,
       handle(input, next) {
         return next({
           ...input,

--- a/packages-presets/preset-wind4/src/variants/negative.ts
+++ b/packages-presets/preset-wind4/src/variants/negative.ts
@@ -54,6 +54,8 @@ export const variantNegative: Variant<Theme> = {
 
     return {
       matcher: matcher.slice(1),
+      // negate the values after `theme()` substitution and before `!important`
+      order: -1,
       body: (body) => {
         if (body.some(v => v[0] === CONTROL_NO_NEGATIVE))
           return

--- a/packages-presets/preset-wind4/src/variants/startingstyle.ts
+++ b/packages-presets/preset-wind4/src/variants/startingstyle.ts
@@ -11,7 +11,7 @@ export const variantStartingStyle: Variant<Theme> = {
       matcher: matcher.slice(9),
       handle: (input, next) => next({
         ...input,
-        parent: `@starting-style`,
+        parent: input.parent ? `${input.parent} $$ @starting-style` : '@starting-style',
       }),
     }
   },

--- a/packages-presets/rule-utils/src/pseudo.ts
+++ b/packages-presets/rule-utils/src/pseudo.ts
@@ -1,9 +1,18 @@
-import type { VariantObject } from '@unocss/core'
+import type { VariantHandlerContext, VariantObject } from '@unocss/core'
 import type { getBracket } from './utilities'
 import type { variantGetBracket } from './variants'
 import { escapeRegExp, escapeSelector } from '@unocss/core'
 
 const PseudoPlaceholder = '__pseudo_placeholder__'
+
+/**
+ * The last simple segment (`.group:hover `) appended to the prefix of a utility in `left-to-right`
+ * mode and the prefix it produced, keyed by the application of the variants to that utility. The
+ * next tagged pseudo class variant of the same tag merges with it (`group-hover:group-focus:` gives
+ * `.group:hover:focus `) as long as the prefix is untouched, also across a shortcut expansion,
+ * while an arbitrary selector such as `group-[&_.group:focus]` is never merged.
+ */
+const lastAppendedSegments = new WeakMap<object, { prefix: string, segment: string }>()
 
 /**
  * Note: the order of following pseudo classes will affect the order of generated css.
@@ -160,7 +169,31 @@ export function createTaggedPseudoClassMatcher<T extends object = object>(
   utils: PseudoVariantUtilities,
 ): VariantObject<T> {
   const { h, variantGetBracket } = utils
+  // merge stacked variants of the same tag: `group-hover:group-focus:` -> `.group:hover:focus`
+  // `right-to-left`: the segment of the current variant is prepended, merge it with the one that follows
   const rawRE = new RegExp(`^(${escapeRegExp(parent)}:)(\\S+)${escapeRegExp(combinator)}\\1`)
+  // `left-to-right`: the segment is appended, merge it with the previous one when both are simple
+  // `${parent}:<pseudo>` segments of the same utility and the prefix has not changed in between
+  const simpleSegmentRE = new RegExp(`^${escapeRegExp(parent)}:\\S+$`)
+  const appendSegment = (input: VariantHandlerContext, prefix: string) => {
+    const simple = simpleSegmentRE.test(prefix)
+    const previous = input.application ? lastAppendedSegments.get(input.application) : undefined
+    let accumulated = input.prefix
+    let segment = `${prefix}${combinator}`
+    if (simple && previous && previous.prefix === accumulated && previous.segment.startsWith(`${parent}:`)) {
+      accumulated = accumulated.slice(0, -previous.segment.length)
+      segment = `${previous.segment.slice(0, -combinator.length)}${prefix.slice(parent.length)}${combinator}`
+    }
+    const result = `${accumulated}${segment}`
+    // rules may probe the handlers with an empty context
+    if (input.application) {
+      if (simple)
+        lastAppendedSegments.set(input.application, { prefix: result, segment })
+      else
+        lastAppendedSegments.delete(input.application)
+    }
+    return result
+  }
   let splitRE: RegExp
   let pseudoRE: RegExp
   let pseudoColonRE: RegExp
@@ -181,7 +214,7 @@ export function createTaggedPseudoClassMatcher<T extends object = object>(
     return [
       label,
       input.slice(input.length - (rest.length - label.length - 1)),
-      bracketValue.includes('&') ? bracketValue.replace(/&/g, prefix) : `${prefix}${bracketValue}`,
+      bracketValue.includes('&') ? bracketValue.replace(/&/g, () => prefix) : `${prefix}${bracketValue}`,
     ]
   }
 
@@ -242,7 +275,9 @@ export function createTaggedPseudoClassMatcher<T extends object = object>(
         matcher,
         handle: (input, next) => next({
           ...input,
-          prefix: `${prefix}${combinator}${input.prefix}`.replace(rawRE, '$1$2:'),
+          prefix: ctx.generator.config.variantApplyOrder === 'left-to-right'
+            ? appendSegment(input, prefix)
+            : `${prefix}${combinator}${input.prefix}`.replace(rawRE, '$1$2:'),
           sort: PseudoClassesKeys.indexOf(pseudoName) ?? PseudoClassesColonKeys.indexOf(pseudoName),
         }),
       }

--- a/packages-presets/rule-utils/src/variants.ts
+++ b/packages-presets/rule-utils/src/variants.ts
@@ -1,8 +1,8 @@
-import type { Arrayable, VariantHandler, VariantHandlerContext, VariantObject } from '@unocss/core'
+import type { Arrayable, VariantContext, VariantHandler, VariantHandlerContext, VariantObject } from '@unocss/core'
 import { escapeRegExp, toArray } from '@unocss/core'
 import { getBracket } from './utilities'
 
-export function variantMatcher<T extends object = object>(name: string, handler: Arrayable<(input: VariantHandlerContext) => Record<string, any>>, options: Omit<VariantObject<T>, 'match'> = {}): VariantObject<T> {
+export function variantMatcher<T extends object = object>(name: string, handler: Arrayable<(input: VariantHandlerContext, ctx: VariantContext<T>) => Record<string, any>>, options: Omit<VariantObject<T>, 'match'> = {}): VariantObject<T> {
   let re: RegExp
   return {
     name,
@@ -17,7 +17,7 @@ export function variantMatcher<T extends object = object>(name: string, handler:
           matcher,
           handle: (input, next) => next({
             ...input,
-            ...handler(input),
+            ...handler(input, ctx),
           }),
           ...options,
         }))
@@ -28,6 +28,17 @@ export function variantMatcher<T extends object = object>(name: string, handler:
     },
     autocomplete: `${name}:`,
   }
+}
+
+/**
+ * Join the prefix of a variant (e.g. `.dark $$ `) with the prefix accumulated by the
+ * variants applied before it, so that the leftmost variant in the utility ends up
+ * leftmost in the generated selector regardless of the `variantApplyOrder` of the generator.
+ */
+export function variantPrefix<T extends object = object>(input: VariantHandlerContext, prefix: string, ctx: VariantContext<T>): string {
+  return ctx.generator.config.variantApplyOrder === 'left-to-right'
+    ? `${input.prefix}${prefix}`
+    : `${prefix}${input.prefix}`
 }
 
 export function variantParentMatcher<T extends object = object>(name: string, parent: string): VariantObject<T> {

--- a/packages-presets/rule-utils/test/pseudo.test.ts
+++ b/packages-presets/rule-utils/test/pseudo.test.ts
@@ -1,3 +1,4 @@
+import type { Rule, VariantHandlerContext } from '@unocss/core'
 import type { PseudoVariantUtilities } from '../src/pseudo'
 import { createGenerator } from '@unocss/core'
 import { h } from '@unocss/preset-wind4/utils'
@@ -8,7 +9,7 @@ import {
   createPseudoClassFunctions,
   createTaggedPseudoClasses,
 } from '../src/pseudo'
-import { variantGetBracket, variantMatcher } from '../src/variants'
+import { variantGetBracket, variantMatcher, variantPrefix } from '../src/variants'
 
 // Create utilities similar to what presets use
 const utils: PseudoVariantUtilities = {
@@ -470,4 +471,138 @@ it('multi pseudo classes', async () => {
       .selection\\:foo-1 *::selection,
       .selection\\:foo-1::selection{content:"1";}"
     `)
+})
+
+// https://github.com/unocss/unocss/issues/5043
+it('tagged pseudo classes keep the written prefix order in both variant apply orders', async () => {
+  for (const variantApplyOrder of ['right-to-left', 'left-to-right'] as const) {
+    const uno = await createGenerator({
+      variantApplyOrder,
+      variants: [
+        ...createTaggedPseudoClasses({}, utils),
+        variantMatcher('dark', (input, ctx) => ({ prefix: variantPrefix(input, '.dark $$ ', ctx) })),
+        // a third-party variant replacing the entries array
+        {
+          name: 'copy',
+          match(matcher) {
+            if (!matcher.startsWith('copy:'))
+              return
+            return {
+              matcher: matcher.slice('copy:'.length),
+              body: entries => entries.map(entry => [...entry] as typeof entry),
+            }
+          },
+        },
+        // a third-party variant rebuilding the context from its documented fields
+        {
+          name: 'plugin',
+          match(matcher) {
+            if (!matcher.startsWith('plugin:'))
+              return
+            return {
+              matcher: matcher.slice('plugin:'.length),
+              handle: (input, next) => next({
+                prefix: input.prefix,
+                selector: `${input.selector}:checked`,
+                pseudo: input.pseudo,
+                entries: input.entries,
+                parent: input.parent,
+                parentOrder: input.parentOrder,
+                layer: input.layer,
+                sort: input.sort,
+                noMerge: input.noMerge,
+              }),
+            }
+          },
+        },
+      ],
+      rules: [
+        [/^foo-(\d+)$/, ([_, a]) => ({ text: `foo-${a}` })],
+      ],
+      shortcuts: [['sc', 'group-focus:foo-14']],
+    })
+
+    const { css } = await uno.generate([
+      'dark:group-hover:foo-1',
+      'group-hover:dark:foo-2',
+      'dark:group-hover:group-focus:foo-3',
+      'group-hover:group-focus:group-active:foo-4',
+      'group-hover:peer-[&_.group:focus_.group:active]:foo-5',
+      'group-[&_.group:focus_.group:active]:foo-6',
+      'group-[&_.group:focus_.group:active]:group-hover:foo-7',
+      'group-hover:group-[&_.group:focus_.group:active]:foo-8',
+      'group-hover:peer-hover:peer-focus:foo-9',
+      'group-hover:plugin:group-focus:foo-0',
+      'group-[&_.foo]:group-hover:group-focus:foo-10',
+      'group-hover:group-[&_.foo]:group-focus:foo-11',
+      'group-[.x&:first-child]:group-last:foo-12',
+      'peer-[.x&:first-child]:peer-last:foo-13',
+      'group-hover:sc',
+      'group-hover:copy:group-focus:foo-16',
+    ], { preflights: false })
+
+    expect(css).toContain('.dark .group:hover .dark\\:group-hover\\:foo-1{')
+    expect(css).toContain('.group:hover .dark .group-hover\\:dark\\:foo-2{')
+    expect(css).toContain('.dark .group:hover:focus .dark\\:group-hover\\:group-focus\\:foo-3{')
+    expect(css).toContain('.group:hover:focus:active .group-hover\\:group-focus\\:group-active\\:foo-4{')
+    // only the segments of stacked simple `group-*` variants are merged, never arbitrary selectors
+    expect(css).toContain('.group:hover .peer .group:focus .group:active~.group-hover\\:peer-')
+    expect(css).toContain('.group .group:focus .group:active .group-\\[')
+    expect(css).toContain('.group .group:focus .group:active .group:hover .group-\\[')
+    expect(css).toContain('.group:hover .group .group:focus .group:active .group-hover\\:group-\\[')
+    expect(css).not.toContain('.group:focus:active')
+    // stacked segments of another tag are merged too
+    expect(css).toContain('.group:hover .peer:hover:focus~.group-hover\\:peer-hover\\:peer-focus\\:foo-9{')
+    // merging does not depend on the variants in between preserving anything but the prefix
+    expect(css).toContain('.group:hover:focus .group-hover\\:plugin\\:group-focus\\:foo-0:checked{')
+    // simple segments following an arbitrary one are merged, an arbitrary one in between is not
+    expect(css).toContain('.group .foo .group:hover:focus .group-\\[')
+    expect(css).toContain('.group:hover .group .foo .group:focus .group-hover\\:group-\\[')
+    // a compound arbitrary segment is never merged with the simple segment that follows it
+    expect(css).toContain('.x.group:first-child .group:last-child .group-\\[')
+    expect(css).toContain('.x.peer:first-child~.peer:last-child~.peer-\\[')
+    // the variants of a shortcut merge with the ones of its utilities
+    expect(css).toContain('.group:hover:focus .group-hover\\:sc{')
+    // merging survives a body transform replacing the entries
+    expect(css).toContain('.group:hover:focus .group-hover\\:copy\\:group-focus\\:foo-16{')
+
+    // merging keeps the scope placeholder of the preceding prefixes
+    const { css: scoped } = await uno.generate(['dark:group-hover:group-focus:foo-3'], { preflights: false, scope: '.scope' })
+    expect(scoped).toContain('.dark .scope .group:hover:focus .dark\\:group-hover\\:group-focus\\:foo-3{')
+  }
+})
+
+// https://github.com/unocss/unocss/issues/5043
+it('only merges the segments appended by tagged pseudo classes of the same utility', async () => {
+  const config = {
+    variantApplyOrder: 'left-to-right' as const,
+    variants: [
+      ...createTaggedPseudoClasses({}, utils),
+      // a third-party variant writing a prefix that looks like a `group-hover` segment
+      {
+        name: 'custom',
+        match(matcher: string) {
+          if (!matcher.startsWith('custom:'))
+            return
+          return {
+            matcher: matcher.slice('custom:'.length),
+            handle: (input: VariantHandlerContext, next: (input: VariantHandlerContext) => VariantHandlerContext) => next({ ...input, prefix: `${input.prefix}.group:hover ` }),
+          }
+        },
+      },
+    ],
+    // a static rule shares its entries array between all the utilities using it
+    rules: [
+      ['bar', [['text', 'bar']]],
+    ] as Rule[],
+  }
+  const uno = await createGenerator(config)
+
+  // the prefix produced by `group-hover:bar` must not be mistaken for the one of the next utility
+  const { css } = await uno.generate(['group-hover:bar', 'custom:group-focus:bar'], { preflights: false })
+  expect(css).toContain('.group:hover .group:focus .custom\\:group-focus\\:bar{')
+
+  // nor across generators
+  const { css: other } = await (await createGenerator(config)).generate(['custom:group-focus:bar'], { preflights: false })
+  expect(other).toContain('.group:hover .group:focus .custom\\:group-focus\\:bar{')
 })

--- a/test/assets/output/preset-wind4-targets.css
+++ b/test/assets/output/preset-wind4-targets.css
@@ -261,10 +261,10 @@
 .text-\[red\]\:50\/display-p3{color:color-mix(in display-p3, red 50%, transparent) /* red */;}
 .text-\[red\]\/50{color:color-mix(in oklab, red 50%, transparent) /* red */;}
 .text-black\/10{color:color-mix(in srgb, var(--colors-black) 10%, transparent) /* #000 */;}
-.aria-busy\:aria-pressed\:text-green-600[aria-pressed="true"][aria-busy="true"],
-.aria-busy\:data-\[bar\]\:text-green-600[data-bar][aria-busy="true"],
+.aria-busy\:aria-pressed\:text-green-600[aria-busy="true"][aria-pressed="true"],
+.aria-busy\:data-\[bar\]\:text-green-600[aria-busy="true"][data-bar],
 .aria-busy\:text-green-600[aria-busy="true"],
-.data-\[foo\=x\]\:data-\[bar\=y\]\:text-green-600[data-bar=y][data-foo=x],
+.data-\[foo\=x\]\:data-\[bar\=y\]\:text-green-600[data-foo=x][data-bar=y],
 .data-\[foo\=x\]\:text-green-600[data-foo=x]{color:color-mix(in srgb, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}
 .dark .dark\:not-odd\:text-red:not(:nth-child(odd)){color:color-mix(in srgb, var(--colors-red-DEFAULT) var(--un-text-opacity), transparent) /* oklch(70.4% 0.191 22.216) */;}
 .text-red-100,
@@ -278,10 +278,10 @@
 .text-red\/\$op-variable\/\$method-variable{color:color-mix(var(--method-variable), var(--colors-red-DEFAULT) var(--op-variable), transparent) /* oklch(70.4% 0.191 22.216) */;}
 .text-red\/display-p3{color:color-mix(in display-p3, var(--colors-red-DEFAULT) var(--un-text-opacity), transparent) /* oklch(70.4% 0.191 22.216) */;}
 .text-rose{color:color-mix(in srgb, var(--colors-rose-DEFAULT) var(--un-text-opacity), transparent) /* oklch(71.2% 0.194 13.428) */;}
-.checked\:next\:text-slate-100+*:checked{color:color-mix(in srgb, var(--colors-slate-100) var(--un-text-opacity), transparent) /* oklch(96.8% 0.007 247.896) */;}
-.next\:checked\:text-slate-200:checked+*{color:color-mix(in srgb, var(--colors-slate-200) var(--un-text-opacity), transparent) /* oklch(92.9% 0.013 255.508) */;}
-.checked\:next\:hover\:text-slate-500:hover+*:checked{color:color-mix(in srgb, var(--colors-slate-500) var(--un-text-opacity), transparent) /* oklch(55.4% 0.046 257.417) */;}
-.next\:checked\:children\:text-slate-600>*:checked+*{color:color-mix(in srgb, var(--colors-slate-600) var(--un-text-opacity), transparent) /* oklch(44.6% 0.043 257.281) */;}
+.checked\:next\:text-slate-100:checked+*{color:color-mix(in srgb, var(--colors-slate-100) var(--un-text-opacity), transparent) /* oklch(96.8% 0.007 247.896) */;}
+.next\:checked\:text-slate-200+*:checked{color:color-mix(in srgb, var(--colors-slate-200) var(--un-text-opacity), transparent) /* oklch(92.9% 0.013 255.508) */;}
+.checked\:next\:hover\:text-slate-500:checked+*:hover{color:color-mix(in srgb, var(--colors-slate-500) var(--un-text-opacity), transparent) /* oklch(55.4% 0.046 257.417) */;}
+.next\:checked\:children\:text-slate-600+*:checked>*{color:color-mix(in srgb, var(--colors-slate-600) var(--un-text-opacity), transparent) /* oklch(44.6% 0.043 257.281) */;}
 .nth-\[2\]\:text-yellow:nth-child(2){color:color-mix(in srgb, var(--colors-yellow-DEFAULT) var(--un-text-opacity), transparent) /* oklch(85.2% 0.199 91.936) */;}
 .c-\[\#157\],
 .c-\#157,
@@ -483,14 +483,16 @@
 .p-unset{padding:unset;}
 .pa{padding:auto;}
 .hover\:\!p-1:hover{padding:calc(var(--spacing) * 1) !important;}
-.\*\:data-\[inline\]\:hover\:p-2 > *:hover[data-inline]{padding:calc(var(--spacing) * 2);}
+.\*\:data-\[inline\]\:hover\:p-2 > *[data-inline]:hover{padding:calc(var(--spacing) * 2);}
 .\*\:hover\:p-2 > *:hover{padding:calc(var(--spacing) * 2);}
-.\*\*\:aria-\[id\=avatar\]\:hover\:p-2 *:hover[aria-id=avatar]{padding:calc(var(--spacing) * 2);}
-.\*\*\:data-\[inline\]\:hover\:p-2 *:hover[data-inline]{padding:calc(var(--spacing) * 2);}
-.\*\*\:hover\:data-\[inline\]\:p-2 *[data-inline]:hover{padding:calc(var(--spacing) * 2);}
+.\*\*\:aria-\[id\=avatar\]\:hover\:p-2 *[aria-id=avatar]:hover{padding:calc(var(--spacing) * 2);}
+.\*\*\:data-\[inline\]\:hover\:p-2 *[data-inline]:hover{padding:calc(var(--spacing) * 2);}
+.\*\*\:hover\:data-\[inline\]\:p-2 *:hover[data-inline]{padding:calc(var(--spacing) * 2);}
 .hover\:p-5:hover{padding:calc(var(--spacing) * 5);}
 .group:focus .group-focus\:p-4{padding:calc(var(--spacing) * 4);}
 .first\:p-2:first-child{padding:calc(var(--spacing) * 2);}
+.\*\:last\:p-2 > *:last-child{padding:calc(var(--spacing) * 2);}
+.last\:\*\:p-2:last-child > *{padding:calc(var(--spacing) * 2);}
 .p-x,
 .px{padding-inline:calc(var(--spacing) * 4);}
 .px-1{padding-inline:calc(var(--spacing) * 1);}
@@ -662,6 +664,7 @@
 .rounded-\[4px\]{border-radius:4px;}
 .rounded-\$variable{border-radius:var(--variable);}
 .rounded-1\/2{border-radius:50%;}
+.\*\:data-\[avatar\]\:rounded-full > *[data-avatar],
 .rounded-full{border-radius:calc(infinity * 1px);}
 .rounded-md{border-radius:var(--radius-md);}
 .rounded-none{border-radius:var(--radius-none);}
@@ -753,10 +756,11 @@
 .first-line\:bg-green-400::first-line{background-color:color-mix(in srgb, var(--colors-green-400) var(--un-bg-opacity), transparent) /* oklch(79.2% 0.209 151.711) */;}
 .peer:checked~.peer-checked\:bg-blue-500{background-color:color-mix(in srgb, var(--colors-blue-500) var(--un-bg-opacity), transparent) /* oklch(62.3% 0.214 259.815) */;}
 .previous\/label:checked+.previous-checked\/label\:bg-red-500{background-color:color-mix(in srgb, var(--colors-red-500) var(--un-bg-opacity), transparent) /* oklch(63.7% 0.237 25.331) */;}
-.focus-within\:has-first\:checked\:bg-gray\/20:checked:has(:first-child):focus-within{background-color:color-mix(in srgb, var(--colors-gray-DEFAULT) 20%, transparent) /* oklch(70.7% 0.022 261.325) */;}
-.focus-within\:where-first\:checked\:bg-gray\/20:checked:where(:first-child):focus-within{background-color:color-mix(in srgb, var(--colors-gray-DEFAULT) 20%, transparent) /* oklch(70.7% 0.022 261.325) */;}
-.hover\:not-first\:checked\:bg-red\/10:checked:not(:first-child):hover{background-color:color-mix(in srgb, var(--colors-red-DEFAULT) 10%, transparent) /* oklch(70.4% 0.191 22.216) */;}
-.hover\:file\:bg-violet-100::file-selector-button:hover{background-color:color-mix(in srgb, var(--colors-violet-100) var(--un-bg-opacity), transparent) /* oklch(94.3% 0.029 294.588) */;}
+.focus-within\:has-first\:checked\:bg-gray\/20:focus-within:has(:first-child):checked{background-color:color-mix(in srgb, var(--colors-gray-DEFAULT) 20%, transparent) /* oklch(70.7% 0.022 261.325) */;}
+.focus-within\:where-first\:checked\:bg-gray\/20:focus-within:where(:first-child):checked{background-color:color-mix(in srgb, var(--colors-gray-DEFAULT) 20%, transparent) /* oklch(70.7% 0.022 261.325) */;}
+.\[\&\>\*\]\:hover\:bg-blue-400>*:hover{background-color:color-mix(in srgb, var(--colors-blue-400) var(--un-bg-opacity), transparent) /* oklch(70.7% 0.165 254.624) */;}
+.hover\:not-first\:checked\:bg-red\/10:hover:not(:first-child):checked{background-color:color-mix(in srgb, var(--colors-red-DEFAULT) 10%, transparent) /* oklch(70.4% 0.191 22.216) */;}
+.hover\:file\:bg-violet-100:hover::file-selector-button{background-color:color-mix(in srgb, var(--colors-violet-100) var(--un-bg-opacity), transparent) /* oklch(94.3% 0.029 294.588) */;}
 .file\:bg-violet-50::file-selector-button{background-color:color-mix(in srgb, var(--colors-violet-50) var(--un-bg-opacity), transparent) /* oklch(96.9% 0.016 293.756) */;}
 .details-content\:bg-green-100::details-content{background-color:color-mix(in srgb, var(--colors-green-100) var(--un-bg-opacity), transparent) /* oklch(96.2% 0.044 156.743) */;}
 .bg-opacity-\[--opacity-variable\],
@@ -1886,8 +1890,8 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .peer-data-\[x\=y\]\/named\:font-17{
 &:is(:where(.peer\/named)[data-x=y] ~ *){--un-font-weight:17;font-weight:17;}
 }
-.previous-aria-\[level\=\"4\"\]\/named\:hover\:font-21:hover{
-:where(*[aria-level="4"] + &){--un-font-weight:21;font-weight:21;}
+.previous-aria-\[level\=\"4\"\]\/named\:hover\:font-21{
+:where(*[aria-level="4"] + &):hover{--un-font-weight:21;font-weight:21;}
 }
 .previous-aria-checked\/label\:bg-red-500{
 :where(*[aria-checked="true"] + &){background-color:color-mix(in srgb, var(--colors-red-500) var(--un-bg-opacity), transparent) /* oklch(63.7% 0.237 25.331) */;}
@@ -1940,9 +1944,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 @media (prefers-contrast: more){
 .contrast-more\:bg-black{background-color:color-mix(in srgb, var(--colors-black) var(--un-bg-opacity), transparent) /* #000 */;}
 }
-@media (prefers-contrast: more){@media (prefers-color-scheme: dark){
-.\@dark\:contrast-more\:p-10{padding:calc(var(--spacing) * 10);}
-}}
 @media (prefers-reduced-motion: no-preference){
 .motion-safe\:transition{transition-property:color,background-color,border-color,text-decoration-color,fill,stroke,--un-gradient-from,--un-gradient-via,--un-gradient-to,opacity,box-shadow,transform,translate,scale,rotate,filter,-webkit-backdrop-filter,backdrop-filter;transition-timing-function:var(--un-ease, var(--default-transition-timingFunction));transition-duration:var(--un-duration, var(--default-transition-duration));}
 }
@@ -1978,10 +1979,10 @@ unocss .scope-\[unocss\]\:block{display:block;}
 }
 @supports (color: color-mix(in lab, red, red)){
 .text-black\/10{color:color-mix(in oklab, var(--colors-black) 10%, transparent) /* #000 */;}
-.aria-busy\:aria-pressed\:text-green-600[aria-pressed="true"][aria-busy="true"]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}
-.aria-busy\:data-\[bar\]\:text-green-600[data-bar][aria-busy="true"]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}
+.aria-busy\:aria-pressed\:text-green-600[aria-busy="true"][aria-pressed="true"]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}
+.aria-busy\:data-\[bar\]\:text-green-600[aria-busy="true"][data-bar]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}
 .aria-busy\:text-green-600[aria-busy="true"]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}
-.data-\[foo\=x\]\:data-\[bar\=y\]\:text-green-600[data-bar=y][data-foo=x]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}
+.data-\[foo\=x\]\:data-\[bar\=y\]\:text-green-600[data-foo=x][data-bar=y]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}
 .data-\[foo\=x\]\:text-green-600[data-foo=x]{color:color-mix(in oklab, var(--colors-green-600) var(--un-text-opacity), transparent) /* oklch(62.7% 0.194 149.214) */;}
 .dark .dark\:not-odd\:text-red:not(:nth-child(odd)){color:color-mix(in oklab, var(--colors-red-DEFAULT) var(--un-text-opacity), transparent) /* oklch(70.4% 0.191 22.216) */;}
 .text-red-100{color:color-mix(in oklab, var(--colors-red-100) var(--un-text-opacity), transparent) /* oklch(93.6% 0.032 17.717) */;}
@@ -1993,10 +1994,10 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .text-red\/\$op-variable{color:color-mix(in oklab, var(--colors-red-DEFAULT) var(--op-variable), transparent) /* oklch(70.4% 0.191 22.216) */;}
 .text-red100{color:color-mix(in oklab, var(--colors-red-100) var(--un-text-opacity), transparent) /* oklch(93.6% 0.032 17.717) */;}
 .text-rose{color:color-mix(in oklab, var(--colors-rose-DEFAULT) var(--un-text-opacity), transparent) /* oklch(71.2% 0.194 13.428) */;}
-.checked\:next\:text-slate-100+*:checked{color:color-mix(in oklab, var(--colors-slate-100) var(--un-text-opacity), transparent) /* oklch(96.8% 0.007 247.896) */;}
-.next\:checked\:text-slate-200:checked+*{color:color-mix(in oklab, var(--colors-slate-200) var(--un-text-opacity), transparent) /* oklch(92.9% 0.013 255.508) */;}
-.checked\:next\:hover\:text-slate-500:hover+*:checked{color:color-mix(in oklab, var(--colors-slate-500) var(--un-text-opacity), transparent) /* oklch(55.4% 0.046 257.417) */;}
-.next\:checked\:children\:text-slate-600>*:checked+*{color:color-mix(in oklab, var(--colors-slate-600) var(--un-text-opacity), transparent) /* oklch(44.6% 0.043 257.281) */;}
+.checked\:next\:text-slate-100:checked+*{color:color-mix(in oklab, var(--colors-slate-100) var(--un-text-opacity), transparent) /* oklch(96.8% 0.007 247.896) */;}
+.next\:checked\:text-slate-200+*:checked{color:color-mix(in oklab, var(--colors-slate-200) var(--un-text-opacity), transparent) /* oklch(92.9% 0.013 255.508) */;}
+.checked\:next\:hover\:text-slate-500:checked+*:hover{color:color-mix(in oklab, var(--colors-slate-500) var(--un-text-opacity), transparent) /* oklch(55.4% 0.046 257.417) */;}
+.next\:checked\:children\:text-slate-600+*:checked>*{color:color-mix(in oklab, var(--colors-slate-600) var(--un-text-opacity), transparent) /* oklch(44.6% 0.043 257.281) */;}
 .nth-\[2\]\:text-yellow:nth-child(2){color:color-mix(in oklab, var(--colors-yellow-DEFAULT) var(--un-text-opacity), transparent) /* oklch(85.2% 0.199 91.936) */;}
 .color-blue{color:color-mix(in oklab, var(--colors-blue-DEFAULT) var(--un-text-opacity), transparent) /* oklch(70.7% 0.165 254.624) */;}
 .color-blue-400{color:color-mix(in oklab, var(--colors-blue-400) var(--un-text-opacity), transparent) /* oklch(70.7% 0.165 254.624) */;}
@@ -2044,10 +2045,11 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .first-line\:bg-green-400::first-line{background-color:color-mix(in oklab, var(--colors-green-400) var(--un-bg-opacity), transparent) /* oklch(79.2% 0.209 151.711) */;}
 .peer:checked~.peer-checked\:bg-blue-500{background-color:color-mix(in oklab, var(--colors-blue-500) var(--un-bg-opacity), transparent) /* oklch(62.3% 0.214 259.815) */;}
 .previous\/label:checked+.previous-checked\/label\:bg-red-500{background-color:color-mix(in oklab, var(--colors-red-500) var(--un-bg-opacity), transparent) /* oklch(63.7% 0.237 25.331) */;}
-.focus-within\:has-first\:checked\:bg-gray\/20:checked:has(:first-child):focus-within{background-color:color-mix(in oklab, var(--colors-gray-DEFAULT) 20%, transparent) /* oklch(70.7% 0.022 261.325) */;}
-.focus-within\:where-first\:checked\:bg-gray\/20:checked:where(:first-child):focus-within{background-color:color-mix(in oklab, var(--colors-gray-DEFAULT) 20%, transparent) /* oklch(70.7% 0.022 261.325) */;}
-.hover\:not-first\:checked\:bg-red\/10:checked:not(:first-child):hover{background-color:color-mix(in oklab, var(--colors-red-DEFAULT) 10%, transparent) /* oklch(70.4% 0.191 22.216) */;}
-.hover\:file\:bg-violet-100::file-selector-button:hover{background-color:color-mix(in oklab, var(--colors-violet-100) var(--un-bg-opacity), transparent) /* oklch(94.3% 0.029 294.588) */;}
+.focus-within\:has-first\:checked\:bg-gray\/20:focus-within:has(:first-child):checked{background-color:color-mix(in oklab, var(--colors-gray-DEFAULT) 20%, transparent) /* oklch(70.7% 0.022 261.325) */;}
+.focus-within\:where-first\:checked\:bg-gray\/20:focus-within:where(:first-child):checked{background-color:color-mix(in oklab, var(--colors-gray-DEFAULT) 20%, transparent) /* oklch(70.7% 0.022 261.325) */;}
+.\[\&\>\*\]\:hover\:bg-blue-400>*:hover{background-color:color-mix(in oklab, var(--colors-blue-400) var(--un-bg-opacity), transparent) /* oklch(70.7% 0.165 254.624) */;}
+.hover\:not-first\:checked\:bg-red\/10:hover:not(:first-child):checked{background-color:color-mix(in oklab, var(--colors-red-DEFAULT) 10%, transparent) /* oklch(70.4% 0.191 22.216) */;}
+.hover\:file\:bg-violet-100:hover::file-selector-button{background-color:color-mix(in oklab, var(--colors-violet-100) var(--un-bg-opacity), transparent) /* oklch(94.3% 0.029 294.588) */;}
 .file\:bg-violet-50::file-selector-button{background-color:color-mix(in oklab, var(--colors-violet-50) var(--un-bg-opacity), transparent) /* oklch(96.9% 0.016 293.756) */;}
 .details-content\:bg-green-100::details-content{background-color:color-mix(in oklab, var(--colors-green-100) var(--un-bg-opacity), transparent) /* oklch(96.2% 0.044 156.743) */;}
 .decoration-purple\/50{text-decoration-color:color-mix(in oklab, var(--colors-purple-DEFAULT) 50%, transparent) /* oklch(71.4% 0.203 305.504) */;}
@@ -2074,6 +2076,32 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .rule-red-500{rule-color:color-mix(in oklab, var(--colors-red-500) var(--un-rule-opacity), transparent) /* oklch(63.7% 0.237 25.331) */;}
 .rule-y-teal-500{column-rule-color:color-mix(in oklab, var(--colors-teal-500) var(--un-column-rule-opacity), transparent) /* oklch(70.4% 0.14 182.503) */;}
 }
+@supports (container-type:inline-size) and ( not (display:grid)){
+.supports-\[\(container-type\:inline-size\)and\(not\(display\:grid\)\)\]\:block{display:block;}
+}
+@supports (display: grid){
+.supports-\[\(display\:_grid\)\]\:block,
+.supports-grid\:block{display:block;}
+}
+@supports (display:grid){
+.supports-\[display\:grid\]\:grid{display:grid;}
+}
+@supports (display:grid) and (display:flex){
+.supports-\[\(display\:grid\)_and_\(display\:flex\)\]\:grid{display:grid;}
+}
+@supports (display:grid) or (display:flex){
+.supports-\[\(display\:grid\)or\(display\:flex\)\]\:grid{display:grid;}
+}
+@supports not (display:grid){
+.supports-\[not\(display\:grid\)\]\:block{display:block;}
+}
+@supports(display:grid){
+.\[\@supports\(display\:grid\)\]\:bg-red\/33{background-color:color-mix(in srgb, var(--colors-red-DEFAULT) 33%, transparent) /* oklch(70.4% 0.191 22.216) */;}
+*+.\[\@supports\(display\:grid\)\]\:\[\*\+\&\]\:bg-red\/34{background-color:color-mix(in srgb, var(--colors-red-DEFAULT) 34%, transparent) /* oklch(70.4% 0.191 22.216) */;}
+}
+@media (prefers-color-scheme: dark){@media (prefers-contrast: more){
+.\@dark\:contrast-more\:p-10{padding:calc(var(--spacing) * 10);}
+}}
 @supports (color: color-mix(in lab, red, red)){.in-\[div\]\:bg-red-400{
 :where(*:is(div)) &{background-color:color-mix(in oklab, var(--colors-red-400) var(--un-bg-opacity), transparent) /* oklch(70.4% 0.191 22.216) */;}
 }}
@@ -2107,29 +2135,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .\[\@supports\(display\:grid\)\]\:bg-red\/33{background-color:color-mix(in oklab, var(--colors-red-DEFAULT) 33%, transparent) /* oklch(70.4% 0.191 22.216) */;}
 *+.\[\@supports\(display\:grid\)\]\:\[\*\+\&\]\:bg-red\/34{background-color:color-mix(in oklab, var(--colors-red-DEFAULT) 34%, transparent) /* oklch(70.4% 0.191 22.216) */;}
 }}
-@supports (container-type:inline-size) and ( not (display:grid)){
-.supports-\[\(container-type\:inline-size\)and\(not\(display\:grid\)\)\]\:block{display:block;}
-}
-@supports (display: grid){
-.supports-\[\(display\:_grid\)\]\:block,
-.supports-grid\:block{display:block;}
-}
-@supports (display:grid){
-.supports-\[display\:grid\]\:grid{display:grid;}
-}
-@supports (display:grid) and (display:flex){
-.supports-\[\(display\:grid\)_and_\(display\:flex\)\]\:grid{display:grid;}
-}
-@supports (display:grid) or (display:flex){
-.supports-\[\(display\:grid\)or\(display\:flex\)\]\:grid{display:grid;}
-}
-@supports not (display:grid){
-.supports-\[not\(display\:grid\)\]\:block{display:block;}
-}
-@supports(display:grid){
-.\[\@supports\(display\:grid\)\]\:bg-red\/33{background-color:color-mix(in srgb, var(--colors-red-DEFAULT) 33%, transparent) /* oklch(70.4% 0.191 22.216) */;}
-*+.\[\@supports\(display\:grid\)\]\:\[\*\+\&\]\:bg-red\/34{background-color:color-mix(in srgb, var(--colors-red-DEFAULT) 34%, transparent) /* oklch(70.4% 0.191 22.216) */;}
-}
 @container (min-width: 10.5rem){
 .\@\[10\.5rem\]-text-red{color:color-mix(in srgb, var(--colors-red-DEFAULT) var(--un-text-opacity), transparent) /* oklch(70.4% 0.191 22.216) */;}
 }
@@ -2168,9 +2173,6 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .lt-sm\:m1,
 .max-sm\:m1{margin:calc(var(--spacing) * 1);}
 }
-@media (max-width: calc(64rem - 0.1px)){@media (min-width: 40rem){
-.sm\:lt-lg\:p-10{padding:calc(var(--spacing) * 10);}
-}}
 @media (min-width: 40rem){
 .sm\:m-1,
 .sm\:m1{margin:calc(var(--spacing) * 1);}
@@ -2180,11 +2182,14 @@ unocss .scope-\[unocss\]\:block{display:block;}
 .\~sm\:m1,
 .at-sm\:m1{margin:calc(var(--spacing) * 1);}
 }
+@media (min-width: 40rem){@media (max-width: calc(64rem - 0.1px)){
+.sm\:lt-lg\:p-10{padding:calc(var(--spacing) * 10);}
+}}
 @media (min-width: 48rem){
 .md\:m-1{margin:calc(var(--spacing) * 1);}
 .md\:\!hidden{display:none !important;}
 }
-@media (min-width: 48rem){@supports not (container-type:inline-size){
+@supports not (container-type:inline-size){@media (min-width: 48rem){
 .supports-\[not\(container-type\:inline-size\)\]\:md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr));}
 }}
 @media (min-width: 64rem) and (max-width: calc(80rem - 0.1px)){

--- a/test/assets/preset-wind4-targets.ts
+++ b/test/assets/preset-wind4-targets.ts
@@ -483,6 +483,10 @@ export const presetWind4Targets: string[] = [
   '**:hover:data-[inline]:p-2',
   '**:aria-[id=avatar]:p-2',
   '**:aria-[id=avatar]:hover:p-2',
+  '*:last:p-2',
+  'last:*:p-2',
+  '*:data-[avatar]:rounded-full',
+  '[&>*]:hover:bg-blue-400',
 
   // variants experimental
   '@hover-text-red',

--- a/test/preset-mini.test.ts
+++ b/test/preset-mini.test.ts
@@ -37,6 +37,41 @@ const uno = await createGenerator({
 })
 
 describe('preset-mini', () => {
+  it('keeps the body transforms pipeline in `left-to-right` variant apply order', async () => {
+    const uno = await createGenerator({
+      mergeSelectors: false,
+      presets: [presetMini()],
+      variantApplyOrder: 'left-to-right',
+    })
+    const { css } = await uno.generate([
+      '!-m-2',
+      '-m-2!',
+      '-m-[theme(spacing.sm)]',
+      'hover:!-m-2',
+      'group-hover:dark:m-2',
+      'dark:group-hover:m-2',
+      'dark:group-data-[x]:m-2',
+      'scope-[.foo]:[&>*]:m-2',
+      'group-hover:group-data-[x]:m-2',
+      'md:starting:m-2',
+    ], { preflights: false })
+
+    // `theme()` substitution, then negation, then `!important`, regardless of the variant apply order
+    expect(css).toContain(`.${escapeSelector('!-m-2')}{margin:-0.5rem !important;}`)
+    expect(css).toContain(`.${escapeSelector('-m-2!')}{margin:-0.5rem !important;}`)
+    expect(css).toContain(`.${escapeSelector('-m-[theme(spacing.sm)]')}{margin:-0.875rem;}`)
+    expect(css).toContain(`.${escapeSelector('hover:!-m-2')}:hover{margin:-0.5rem !important;}`)
+    // the prefixes keep the written ancestor order
+    expect(css).toContain(`.group:hover .dark .${escapeSelector('group-hover:dark:m-2')}{`)
+    expect(css).toContain(`.dark .group:hover .${escapeSelector('dark:group-hover:m-2')}{`)
+    expect(css).toContain(`.dark .group[data-x] .${escapeSelector('dark:group-data-[x]:m-2')}{`)
+    // the scope placeholder survives the replacement of `&`
+    expect(css).toContain(`.foo .${escapeSelector('scope-[.foo]:[&>*]:m-2')}>*{`)
+    expect(css).toContain(`.group:hover .group[data-x] .${escapeSelector('group-hover:group-data-[x]:m-2')}{`)
+    // `starting:` keeps the preceding at-rules
+    expect(css).toContain('@media (min-width: 768px){@starting-style{')
+  })
+
   it('dark customizing selector', async () => {
     const uno = await createGenerator({
       presets: [

--- a/test/preset-wind3.test.ts
+++ b/test/preset-wind3.test.ts
@@ -226,6 +226,11 @@ it('containers with max width', async () => {
 })
 
 describe('important', () => {
+  it('keeps the default output of `mix-*` stacked with `!`', async () => {
+    const { css } = await uno.generate('mix-tint-50:!bg-red', { preflights: false })
+    expect(css).toContain('background-color:rgb(248 113 113 / var(--un-bg-opacity)) !important')
+  })
+
   it(`should add " !important" at the end when "true" unless it's already marked important`, async () => {
     const uno = await createGenerator({
       presets: [

--- a/test/preset-wind4.test.ts
+++ b/test/preset-wind4.test.ts
@@ -1,4 +1,5 @@
-import { createGenerator, escapeSelector } from '@unocss/core'
+import type { VariantHandler } from '@unocss/core'
+import { createGenerator, escapeSelector, symbols } from '@unocss/core'
 import presetWind4 from '@unocss/preset-wind4'
 import { createRemToPxProcessor } from '@unocss/preset-wind4/utils'
 import parserCSS from 'prettier/parser-postcss'
@@ -464,36 +465,421 @@ describe('preset-wind4', () => {
     expect(prettified).toMatchInlineSnapshot(`
       "/* layer: default */
       .has-aria-\\[hidden\\=false\\]\\:in-data-\\[state\\=collapsed\\]\\:b-3 {
-        :where(*[data-state="collapsed"]) & {
-          &:has(*[aria-hidden="false"]) {
+        &:has(*[aria-hidden="false"]) {
+          :where(*[data-state="collapsed"]) & {
             border-width: 3px;
           }
         }
       }
       .peer-aria-checked\\:has-aria-\\[level\\=3\\]\\:b-2 {
-        &:has(*[aria-level="3"]) {
-          &:is(:where(.peer)[aria-checked="true"] ~ *) {
+        &:is(:where(.peer)[aria-checked="true"] ~ *) {
+          &:has(*[aria-level="3"]) {
             border-width: 2px;
           }
         }
       }
       .peer-data-\\[variant\\=inset\\]\\:peer-data-\\[state\\=collapsed\\]\\:b-1 {
-        &:is(:where(.peer)[data-state="collapsed"] ~ *) {
-          &:is(:where(.peer)[data-variant="inset"] ~ *) {
+        &:is(:where(.peer)[data-variant="inset"] ~ *) {
+          &:is(:where(.peer)[data-state="collapsed"] ~ *) {
             border-width: 1px;
           }
         }
       }
-      .md\\:has-aria-\\[hidden\\=false\\]\\:peer-data-\\[dialog\\=open\\]\\:group-data-\\[vv\\=w\\]\\/accordion\\:b-4 {
-        &:is(:where(.group\\/accordion)[data-vv="w"] *) {
-          &:is(:where(.peer)[data-dialog="open"] ~ *) {
-            @media (min-width: 48rem) {
-              &:has(*[aria-hidden="false"]) {
+      @media (min-width: 48rem) {
+        .md\\:has-aria-\\[hidden\\=false\\]\\:peer-data-\\[dialog\\=open\\]\\:group-data-\\[vv\\=w\\]\\/accordion\\:b-4 {
+          &:has(*[aria-hidden="false"]) {
+            &:is(:where(.peer)[data-dialog="open"] ~ *) {
+              &:is(:where(.group\\/accordion)[data-vv="w"] *) {
                 border-width: 4px;
               }
             }
           }
         }
+      }
+      "
+    `)
+  })
+
+  // https://github.com/unocss/unocss/issues/5043
+  // https://github.com/unocss/unocss/issues/4726
+  // https://github.com/unocss/unocss/issues/4962
+  it('applies stacked variants left to right like Tailwind v4', async () => {
+    const uno = await createGenerator({
+      mergeSelectors: false,
+      presets: [
+        presetWind4({
+          preflights: { reset: false },
+        }),
+      ],
+      rules: [
+        // a rule cloning the handlers of its variants
+        [/^copied$/, () => ({ padding: '1px', [symbols.variants]: (variants: VariantHandler[]) => variants.map(v => ({ ...v })) })],
+        // a rule providing the order of its parent
+        [/^gridp$/, () => ({ padding: '20px', [symbols.parent]: ['@supports (display: grid)', -1] })],
+        // a rule providing the same order as the `md` breakpoint
+        [/^gridp2$/, () => ({ padding: '20px', [symbols.parent]: ['@supports (display: grid)', 3002] })],
+        // a rule replacing the handlers of its variants
+        [/^custom$/, () => ({ color: 'red', [symbols.variants]: () => [{ selector: () => '.target' }] })],
+        // a rule appending a handler
+        [/^icon$/, () => ({ color: 'red', [symbols.variants]: (variants: VariantHandler[]) => [...variants, { selector: (s: string) => `${s} > .icon` }] })],
+        // a rule appending a modified copy of a handler
+        [/^micon$/, () => ({ color: 'red', [symbols.variants]: (variants: VariantHandler[]) => [...variants, { ...variants[0], handle: undefined, selector: (s: string) => `${s} > .icon` }] })],
+        // a rule appending a copy of a handler with a property removed
+        [/^dicon$/, () => ({ color: 'red', [symbols.variants]: (variants: VariantHandler[]) => {
+          const { handle: _, ...rest } = variants[0]
+          return [...variants, { ...rest, selector: (s: string) => `${s} > .icon` }]
+        } })],
+      ],
+      shortcuts: [
+        ['child-pad', '*:p-2'],
+        ['fpad', 'group-focus:p-2'],
+        ['card', 'group-hover:container'],
+        ['copied-pad', '*:copied'],
+        ['sc-target', 'hover:custom'],
+        ['plain', 'icon'],
+        ['strong', '!icon'],
+        ['sc-micon', 'focus:micon'],
+        ['sc-dicon', 'focus:dicon'],
+        ['sc-alias', 'hover:icon'],
+        ['red', 'uno-layer-inner:p-2'],
+      ],
+    })
+
+    const result = await uno.generate([
+      '*:last:p-2',
+      'last:*:p-2',
+      '*:data-[avatar]:rounded-full',
+      'data-[avatar]:*:rounded-full',
+      '[&>*]:hover:p-2',
+      'hover:[&>*]:p-2',
+      'dark:group-hover:opacity-50',
+      'group-hover:dark:opacity-50',
+      'md:starting:opacity-0',
+      'md:outline-hidden',
+      'md:text-red-500',
+      'hover:space-x-4',
+      'hover:child-pad',
+      'group-hover:fpad',
+      'card',
+      'hover:copied-pad',
+      'focus:sc-target',
+      'hover:icon',
+      'hover:plain',
+      'hover:strong',
+      'hover:sc-micon',
+      'hover:sc-dicon',
+      'sc-alias',
+      'uno-layer-outer:red',
+      'md:gridp',
+      'md:lt-lg:gridp2',
+      'p-2',
+      '!-rotate-45',
+      '-rotate-45!',
+      '!outline-hidden',
+      '!text-red-500',
+      '-m-[theme(spacing.sm)]',
+      'sm:p-4',
+      'md:lt-lg:p-2',
+      'contrast-more:p-2',
+      '@dark:contrast-more:p-4',
+      'scope-[.foo]:[&>*]:p-2',
+    ])
+
+    const { css } = result
+    // the written order is the nesting order: leftmost variant is the outermost
+    expect(css).toContain(`.${escapeSelector('*:last:p-2')} > *:last-child{`)
+    expect(css).toContain(`.${escapeSelector('last:*:p-2')}:last-child > *{`)
+    expect(css).toContain(`.${escapeSelector('*:data-[avatar]:rounded-full')} > *[data-avatar]{`)
+    expect(css).toContain(`.${escapeSelector('data-[avatar]:*:rounded-full')}[data-avatar] > *{`)
+    expect(css).toContain(`.${escapeSelector('[&>*]:hover:p-2')}>*:hover{`)
+    expect(css).toContain(`.${escapeSelector('hover:[&>*]:p-2')}:hover>*{`)
+    // the scope placeholder survives the replacement of `&`
+    expect(css).toContain(`.foo .${escapeSelector('scope-[.foo]:[&>*]:p-2')}>*{`)
+    // prefix variants keep the written ancestor order
+    expect(css).toContain(`.dark .group:hover .${escapeSelector('dark:group-hover:opacity-50')}{`)
+    expect(css).toContain(`.group:hover .dark .${escapeSelector('group-hover:dark:opacity-50')}{`)
+    // at-rules nest in the written order, the parents set by the rules stay outermost
+    expect(css).toContain('@media (min-width: 48rem){@starting-style{')
+    expect(css).toContain('@media (forced-colors: active){@media (min-width: 48rem){')
+    expect(css).toContain('@supports (color: color-mix(in lab, red, red)){@media (min-width: 48rem){')
+    // variants of a shortcut wrap the variants of its utilities
+    expect(css).toContain(`.${escapeSelector('hover:child-pad')}:hover > *{`)
+    expect(css).toContain(`.group:hover:focus .${escapeSelector('group-hover:fpad')}{`)
+    // the `container` rule probes the handlers with an empty context
+    expect(css).toContain('.group:hover .card{')
+    // handlers cloned by a rule keep being the variants of the utility
+    expect(css).toContain(`.${escapeSelector('hover:copied-pad')}:hover > *{`)
+    // handlers replacing or appended to the ones of the utility are injected by the rule
+    expect(css).toContain(`.target:focus{`)
+    expect(css).toContain(`.${escapeSelector('hover:icon')}:hover > .icon{`)
+    expect(css).toContain(`.${escapeSelector('hover:plain')} > .icon:hover{`)
+    expect(css).toContain(`.${escapeSelector('hover:strong')} > .icon:hover{`)
+    expect(css).toContain(`.${escapeSelector('hover:sc-micon')} > .icon:hover:focus{`)
+    expect(css).toContain(`.${escapeSelector('hover:sc-dicon')} > .icon:hover:focus{`)
+    // a shortcut without variants keeps the order of the utility
+    expect(css).toContain('.sc-alias:hover > .icon{')
+    // the leftmost variant decides the layer
+    expect(result.getLayer('outer')).toContain(`.${escapeSelector('uno-layer-outer:red')}{`)
+    // the `parentOrder` provided by a rule is a default, the breakpoint decides
+    expect(css.indexOf('.p-2{')).toBeLessThan(css.indexOf(`.${escapeSelector('md:gridp')}{`))
+    expect(css.indexOf('@media (min-width: 40rem){')).toBeLessThan(css.indexOf(`.${escapeSelector('md:lt-lg:gridp2')}{`))
+    // body transforms keep their pipeline: theme() before negative before important
+    expect(css).toContain(`.${escapeSelector('!-rotate-45')}{rotate:-45deg !important;}`)
+    expect(css).toContain(`.${escapeSelector('-rotate-45!')}{rotate:-45deg !important;}`)
+    expect(css).toContain(`.${escapeSelector('-m-[theme(spacing.sm)]')}{margin:-0.875rem;}`)
+    expect(css).toContain('outline:2px solid transparent !important')
+    expect(css).not.toContain(' !important){')
+    // the leftmost breakpoint decides the position of the block: the `md`..`lg` range comes after `sm`
+    expect(css.indexOf('@media (min-width: 40rem){')).toBeLessThan(css.indexOf('@media (min-width: 48rem){@media (max-width: calc(64rem - 0.1px)){'))
+    // blocks with more conditions come after the ones with fewer, so `@dark:contrast-more:` wins over `contrast-more:`
+    expect(css.indexOf(`.${escapeSelector('contrast-more:p-2')}{`)).toBeLessThan(css.indexOf(`.${escapeSelector('@dark:contrast-more:p-4')}{`))
+
+    const prettified = await prettier.format(css, {
+      parser: 'css',
+      plugins: [parserCSS],
+    })
+
+    expect(prettified).toMatchInlineSnapshot(`
+      "/* layer: properties */
+      @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or
+        ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+        *,
+        ::before,
+        ::after,
+        ::backdrop {
+          --un-space-x-reverse: initial;
+          --un-text-opacity: 100%;
+        }
+      }
+      @property --un-text-opacity {
+        syntax: "<percentage>";
+        inherits: false;
+        initial-value: 100%;
+      }
+      @property --un-space-x-reverse {
+        syntax: "*";
+        inherits: false;
+        initial-value: 0;
+      }
+      /* layer: theme */
+      :root,
+      :host {
+        --spacing: 0.25rem;
+        --colors-red-500: oklch(63.7% 0.237 25.331);
+      }
+      /* layer: shortcuts */
+      .hover\\:child-pad:hover > * {
+        padding: calc(var(--spacing) * 2);
+      }
+      .group:hover:focus .group-hover\\:fpad {
+        padding: calc(var(--spacing) * 2);
+      }
+      .hover\\:copied-pad:hover > * {
+        padding: 1px;
+      }
+      .target:focus {
+        color: red;
+      }
+      .hover\\:plain > .icon:hover {
+        color: red;
+      }
+      .sc-alias:hover > .icon {
+        color: red;
+      }
+      .hover\\:strong > .icon:hover {
+        color: red !important;
+      }
+      .hover\\:sc-micon > .icon:hover:focus {
+        color: red;
+      }
+      .hover\\:sc-dicon > .icon:hover:focus {
+        color: red;
+      }
+      @media (min-width: 40rem) {
+        .group:hover .card {
+          max-width: 40rem;
+        }
+      }
+      @media (min-width: 48rem) {
+        .group:hover .card {
+          max-width: 48rem;
+        }
+      }
+      @media (min-width: 64rem) {
+        .group:hover .card {
+          max-width: 64rem;
+        }
+      }
+      @media (min-width: 80rem) {
+        .group:hover .card {
+          max-width: 80rem;
+        }
+      }
+      @media (min-width: 96rem) {
+        .group:hover .card {
+          max-width: 96rem;
+        }
+      }
+      /* layer: default */
+      .\\!text-red-500 {
+        color: color-mix(
+          in srgb,
+          var(--colors-red-500) var(--un-text-opacity),
+          transparent
+        ) !important;
+      }
+      .-m-\\[theme\\(spacing\\.sm\\)\\] {
+        margin: -0.875rem;
+      }
+      .foo .scope-\\[\\.foo\\]\\:\\[\\&\\>\\*\\]\\:p-2 > * {
+        padding: calc(var(--spacing) * 2);
+      }
+      .p-2 {
+        padding: calc(var(--spacing) * 2);
+      }
+      .\\[\\&\\>\\*\\]\\:hover\\:p-2 > *:hover {
+        padding: calc(var(--spacing) * 2);
+      }
+      .hover\\:\\[\\&\\>\\*\\]\\:p-2:hover > * {
+        padding: calc(var(--spacing) * 2);
+      }
+      .\\*\\:last\\:p-2 > *:last-child {
+        padding: calc(var(--spacing) * 2);
+      }
+      .last\\:\\*\\:p-2:last-child > * {
+        padding: calc(var(--spacing) * 2);
+      }
+      .\\!outline-hidden {
+        outline-style: none !important;
+      }
+      .\\*\\:data-\\[avatar\\]\\:rounded-full > *[data-avatar] {
+        border-radius: calc(infinity * 1px);
+      }
+      .data-\\[avatar\\]\\:\\*\\:rounded-full[data-avatar] > * {
+        border-radius: calc(infinity * 1px);
+      }
+      .dark .group:hover .dark\\:group-hover\\:opacity-50 {
+        opacity: 50%;
+      }
+      .group:hover .dark .group-hover\\:dark\\:opacity-50 {
+        opacity: 50%;
+      }
+      .-rotate-45\\! {
+        rotate: -45deg !important;
+      }
+      .\\!-rotate-45 {
+        rotate: -45deg !important;
+      }
+      .hover\\:icon:hover > .icon {
+        color: red;
+      }
+      .hover\\:space-x-4:hover {
+        :where(& > :not(:last-child)) {
+          --un-space-x-reverse: 0;
+          margin-inline-start: calc(
+            calc(var(--spacing) * 4) * var(--un-space-x-reverse)
+          );
+          margin-inline-end: calc(
+            calc(var(--spacing) * 4) * calc(1 - var(--un-space-x-reverse))
+          );
+        }
+      }
+      @media (forced-colors: active) {
+        .\\!outline-hidden {
+          outline: 2px solid transparent !important;
+          outline-offset: 2px !important;
+        }
+      }
+      @media (prefers-contrast: more) {
+        .contrast-more\\:p-2 {
+          padding: calc(var(--spacing) * 2);
+        }
+      }
+      @supports (color: color-mix(in lab, red, red)) {
+        .\\!text-red-500 {
+          color: color-mix(
+            in oklab,
+            var(--colors-red-500) var(--un-text-opacity),
+            transparent
+          ) !important;
+        }
+      }
+      @media (prefers-color-scheme: dark) {
+        @media (prefers-contrast: more) {
+          .\\@dark\\:contrast-more\\:p-4 {
+            padding: calc(var(--spacing) * 4);
+          }
+        }
+      }
+      @media (min-width: 40rem) {
+        .sm\\:p-4 {
+          padding: calc(var(--spacing) * 4);
+        }
+      }
+      @media (min-width: 48rem) {
+        .md\\:text-red-500 {
+          color: color-mix(
+            in srgb,
+            var(--colors-red-500) var(--un-text-opacity),
+            transparent
+          );
+        }
+        .md\\:outline-hidden {
+          outline-style: none;
+        }
+      }
+      @media (forced-colors: active) {
+        @media (min-width: 48rem) {
+          .md\\:outline-hidden {
+            outline: 2px solid transparent;
+            outline-offset: 2px;
+          }
+        }
+      }
+      @media (min-width: 48rem) {
+        @media (max-width: calc(64rem - 0.1px)) {
+          .md\\:lt-lg\\:p-2 {
+            padding: calc(var(--spacing) * 2);
+          }
+        }
+      }
+      @media (min-width: 48rem) {
+        @starting-style {
+          .md\\:starting\\:opacity-0 {
+            opacity: 0%;
+          }
+        }
+      }
+      @supports (color: color-mix(in lab, red, red)) {
+        @media (min-width: 48rem) {
+          .md\\:text-red-500 {
+            color: color-mix(
+              in oklab,
+              var(--colors-red-500) var(--un-text-opacity),
+              transparent
+            );
+          }
+        }
+      }
+      @supports (display: grid) {
+        @media (min-width: 48rem) {
+          .md\\:gridp {
+            padding: 20px;
+          }
+        }
+      }
+      @supports (display: grid) {
+        @media (min-width: 48rem) {
+          @media (max-width: calc(64rem - 0.1px)) {
+            .md\\:lt-lg\\:gridp2 {
+              padding: 20px;
+            }
+          }
+        }
+      }
+      /* layer: outer */
+      .uno-layer-outer\\:red {
+        padding: calc(var(--spacing) * 2);
       }
       "
     `)


### PR DESCRIPTION
### Description

In `presetWind4`, `*:last:p-2` and `last:*:p-2` both generate `.sel > *:last-child`. Tailwind CSS v4 applies stacked variants from left to right (the leftmost variant is the outermost one), so `last:*:p-2` should generate `.sel:last-child > *`.

**Root cause.** `matchVariants` collects the handlers from the rightmost variant to the leftmost one and `applyVariants` applies them in that order, so the rightmost variant transforms the selector first, the inverse of Tailwind v4. #4763 worked around it for `*` / `**` with `order: -1`, which pins the children variants first regardless of where they are written and produces #5043. Removing `order: -1` alone only swaps the problem around and regresses #4726 (see #5197).

**Change.** Following the direction given in #5197 ("reverse the variant apply order only for preset-wind4 and adjust related variants to support nested output, add regression tests for both classes of cases"):

- `@unocss/core`: new `variantApplyOrder: 'right-to-left' | 'left-to-right'` config option, default `'right-to-left'` (the current behaviour). Presets can set it, the user config wins. In `left-to-right` mode `matchVariants` stores the handlers in the written order, so `applyVariants` and the `order` of the handlers keep their meaning (`order: -1` still applies first, `order: 1` last). The handlers injected by rules (`symbols.parent`, `symbols.variants`, `symbols.selector`) are applied before the variants of the utility in both orders, also when the utility comes from a shortcut, so rule-level at-rules such as the `@supports` colour fallback keep their place; the variants of the utility are told apart from the injected handlers by an own symbol set on generator-owned copies when they are matched (the objects returned by the variants are never mutated); a handler produced by a `symbols.variants` callback counts as a variant of the utility when it is one of them or a clone / rebuild with the same properties (a missing property and `undefined` being the same), any other handler is injected. A direct utility, or a shortcut without variants, keeps applying the injected handlers where the rule placed them (prepended first, appended last, as on `main`); a shortcut with variants applies them before those variants. In `left-to-right` mode the variants of a shortcut wrap the variants of its utilities (`hover:child-pad` with `child-pad: '*:p-2'` gives `.x:hover > *`), and the leftmost variant keeps deciding the position of the rule (`sort`), of its block (`parentOrder`) and its layer (`layer`) as it does today (`md:lt-lg:p-2` still comes after `sm:p-4` in the stylesheet, `uno-layer-outer:red` stays in `outer` when `red` is `uno-layer-inner:p-2`), while a `parentOrder`, `sort` or `layer` provided by the rule itself is kept aside as a default that the first variant setting the value overrides, even with the same value. Since the at-rules are nested in the written order, blocks with more conditions are emitted after blocks with fewer (`@dark:contrast-more:p-4` after `contrast-more:p-2`) instead of relying on the alphabetical order of the parents. `VariantHandlerContext` gains an `application` object, unique per utility and re-attached by the generator between handlers, so variants can keep state across the handlers of one utility without depending on other handlers preserving it. Output in `right-to-left` mode is unchanged.
- `@unocss/rule-utils`: `variantMatcher` handlers receive the `VariantContext` as second argument, and the new `variantPrefix(input, prefix, ctx)` helper joins prefixes in the configured direction. Tagged pseudo classes (`group-*`, `peer-*`, `parent-*`, `previous-*`) append their segment in `left-to-right` mode and still merge stacked simple segments (`group-hover:group-focus:` → `.group:hover:focus`, also across a shortcut such as `group-hover:sc`): the segment appended last is remembered per `application`, so only adjacent segments written by these variants merge, never arbitrary selectors such as `group-[&_.group:focus]` or prefixes written by other variants, and the state cannot leak between utilities or generators.
- `@unocss/preset-mini` (and therefore `presetWind3`): `theme()` substitution and negation get an explicit `order` so they always run before `!important`, whatever the stacking order. This also fixes `-m-2!` on `main`, which produced no utility because `!important` was appended before the negation ran. The `dark` / `light` / `rtl` / `ltr` prefixes and the tagged `data-` / `aria-` variants follow the configured order too, `starting:` appends to the preceding at-rules instead of replacing them (which also fixes `starting:md:` dropping its media query on `main`), and arbitrary variants keep the `$$` scope placeholder intact when replacing `&`. The option can therefore be enabled with these presets without inverting ancestor selectors, and their default output (including `mix-*` stacked with `!`) is otherwise unchanged.
- `@unocss/preset-wind4`: sets `variantApplyOrder: 'left-to-right'`, drops `order: -1` from `*` / `**`, routes the `dark` / `light` / `rtl` / `ltr` prefixes through `variantPrefix`, `starting:` appends to the parent at-rules instead of replacing them (`md:starting:opacity-0` keeps its media query), and arbitrary variants keep the `$$` scope placeholder intact when replacing `&` (`scope-[.foo]:[&>*]:p-2`). Its `theme()` and negative variants get the same explicit `order` (`!-rotate-45`, `-rotate-45!` and `-m-[theme(spacing.sm)]` keep working).
- Apart from `-m-2!`, `starting:md:` and an arbitrary variant stacked after `scope-[…]` (`[&>*]:scope-[.foo]:p-2` produced an invalid `.foo $ …` selector on `main`), the output of `presetMini` and `presetWind3` is unchanged: their snapshots are byte-identical.

| Class | Before | After |
|---|---|---|
| `*:last:p-2` | `.sel > *:last-child` | `.sel > *:last-child` |
| `last:*:p-2` | `.sel > *:last-child` | `.sel:last-child > *` |
| `*:data-[inline]:p-2` (#4726) | `.sel > *[data-inline]` | `.sel > *[data-inline]` |
| `[&>*]:hover:bg-blue-400` (#4962) | `.sel:hover>*` | `.sel>*:hover` |
| `dark:group-hover:opacity-50` | `.dark .group:hover .sel` | `.dark .group:hover .sel` |
| `md:text-red-500` | `@supports (…){@media (…){` | `@supports (…){@media (…){` |
| `hover:child-pad` (`child-pad: '*:p-2'`) | `.sel > *:hover` | `.sel:hover > *` |

**Other output changes for `presetWind4`**, all towards Tailwind v4's nesting order (opt out with `variantApplyOrder: 'right-to-left'`): stacked attribute / pseudo suffixes follow the written order (`aria-busy:aria-pressed:` → `[aria-busy][aria-pressed]`, `hover:file:` → `:hover::file-selector-button`, `checked:next:` → `:checked+*`), nested at-rules of stacked variants follow the written order (`sm:lt-lg:`, `@dark:contrast-more:`, `supports-[…]:md:`), and blocks with more conditions move after blocks with fewer. The position of the rules inside a block does not change.

**Tests.** `test/preset-wind4.test.ts` gains a regression test for #5043, #4726 and #4962 plus the `dark:` / `group-hover:` prefix order, `md:starting:`, rule-level parents, a shortcut with an inner variant, the `!` / negative / `theme()` pipeline, the cascade position of `md:lt-lg:p-2` after `sm:p-4` and of `@dark:contrast-more:p-4` after `contrast-more:p-2`; it fails on `main` for the #5043 and #4962 cases. `packages-engine/core/test/variant-apply-order.test.ts` covers both orders, `order`, parents, `symbols.parent` / `symbols.variants` / `symbols.selector` injected by rules (directly, through shortcuts, and from a callback mutating the handlers in place), the `sort` / `parentOrder` precedence (including a `parentOrder` provided by the rule), the block order by number of conditions, the `application` object, and config precedence. `packages-presets/rule-utils/test/pseudo.test.ts` checks that tagged pseudo classes keep the prefix order in both modes, merge across shortcuts, context rebuilds and entries replacements, and never merge arbitrary `group-[…]` / `peer-[…]` selectors or prefixes written by other variants (also with static rules sharing their entries, and across generators). `test/preset-mini.test.ts` checks the `!` / negative / `theme()` pipeline and the prefix order with `presetMini` in `left-to-right` mode, and `test/preset-wind3.test.ts` pins the default output of `mix-tint-50:!bg-red`. The wind4 snapshots are regenerated; every changed line is one of the reorderings listed above.

**Docs.** `variantApplyOrder` is documented in the config reference and the `presetWind4` page gains a "Variant stacking order" section.

**Known limitations** (unchanged from `main`, noted in the docs): the variants adding a prefix to the selector (`dark:`, `rtl:`, `group-*`, `peer-*`) and the pseudo elements (`before:`, `after:`) still apply to the whole selector wherever they are written, so `*:group-hover:` equals `group-hover:*:` and `before:hover:` equals `hover:before:`. Making them nest like Tailwind v4 (`.x > *:is(:where(.group):hover *)`) would change their output for every usage and is left for a follow-up.

### Linked Issues

closes #5043

### Additional context

- #4962 was closed as a duplicate of #5043; its `[&>*]:hover:` case is fixed and tested here.
- #4726 and #4718, the reason `order: -1` was introduced in #4763, keep their output.
