### PR TITLE
fix(inspector): request terminal auth codes for untrusted clients

### DIFF
--- a/packages-integrations/inspector/client/components/AuthGate.vue
+++ b/packages-integrations/inspector/client/components/AuthGate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { authError, connectionStatus, isTrusted, submitAuthCode } from '../composables/rpc'
+import { authError, canRequestAuthCode, connectionStatus, isRequestingAuthCode, isTrusted, requestAuthCode, submitAuthCode } from '../composables/rpc'
 
 const code = ref('')
 const isSubmitting = ref(false)
@@ -8,7 +8,7 @@ const isReady = computed(() => connectionStatus.value === 'connected' && isTrust
 const isReconnecting = computed(() => connectionStatus.value === 'disconnected' || connectionStatus.value === 'error')
 
 async function submit() {
-  if (!code.value || isSubmitting.value)
+  if (!code.value || isSubmitting.value || isRequestingAuthCode.value)
     return
   isSubmitting.value = true
   try {
@@ -66,17 +66,26 @@ async function submit() {
             maxlength="6"
             border="~ main rounded"
             bg-transparent px3 py1 w-32 text-center font-mono tracking-widest
-            :disabled="isSubmitting"
+            :disabled="isSubmitting || isRequestingAuthCode"
           >
           <button
             type="submit"
             border="~ main rounded"
             px3 py1 bg-active hover:op80
-            :disabled="isSubmitting || !code"
+            :disabled="isSubmitting || isRequestingAuthCode || !code"
           >
             Unlock
           </button>
         </form>
+        <button
+          v-if="canRequestAuthCode"
+          type="button"
+          text-sm op60 hover:op100
+          :disabled="isSubmitting || isRequestingAuthCode"
+          @click="code = ''; requestAuthCode(true)"
+        >
+          {{ isRequestingAuthCode ? 'Requesting code…' : 'Re-issue code in terminal' }}
+        </button>
         <div v-if="authError" text-red text-sm max-w-70 text-center>
           {{ authError }}
         </div>

--- a/packages-integrations/inspector/client/composables/rpc.ts
+++ b/packages-integrations/inspector/client/composables/rpc.ts
@@ -1,6 +1,7 @@
 import type { DevframeConnectionStatus, DevframeRpcClient } from 'devframe/client'
 import type { InspectorChanges } from '../../types'
 import { connectDevframe } from 'devframe/client'
+import { DEVFRAME_EVENTS } from 'devframe/constants'
 import { ref } from 'vue'
 
 export const connectionStatus = ref<DevframeConnectionStatus>('connecting')
@@ -77,9 +78,9 @@ async function connect(): Promise<DevframeRpcClient> {
     if (status === 'disconnected' || status === 'error')
       scheduleReconnect()
   }
-  rpc.events.on('connection:status', updateStatus)
+  rpc.events.on(DEVFRAME_EVENTS.client.connectionStatus, updateStatus)
   updateStatus(rpc.status)
-  rpc.events.on('rpc:is-trusted:updated', (trusted) => {
+  rpc.events.on(DEVFRAME_EVENTS.client.isTrustedUpdated, (trusted) => {
     isTrusted.value = trusted
     subscribeChanges()
   })

--- a/packages-integrations/inspector/client/composables/rpc.ts
+++ b/packages-integrations/inspector/client/composables/rpc.ts
@@ -19,6 +19,7 @@ export const changeRevision = ref(0)
 export const changedModule = ref('')
 
 const RECONNECT_INTERVAL = 2000
+// TODO: Replace with an upstream constant when Devframe exports this RPC method name.
 const REQUEST_CODE_METHOD = 'anonymous:devframe:auth:request-code'
 
 let client: DevframeRpcClient | undefined

--- a/packages-integrations/inspector/client/composables/rpc.ts
+++ b/packages-integrations/inspector/client/composables/rpc.ts
@@ -174,6 +174,11 @@ export async function requestAuthCode(reissue = false): Promise<void> {
   }
   catch (error: any) {
     if (client === rpc) {
+      // Legacy hosts without a method list report unsupported calls through birpc.
+      // Match its exact message so transport and other request failures stay visible.
+      // This is an implementation detail, not a stable error-code contract:
+      // https://github.com/antfu/birpc/blob/v4.2.0/src/main.ts
+      // TODO: Replace when Devframe exposes reliable capability detection or a typed error.
       if (error?.message === `[birpc] function "${REQUEST_CODE_METHOD}" not found`)
         canRequestAuthCode.value = false
       else

--- a/packages-integrations/inspector/client/composables/rpc.ts
+++ b/packages-integrations/inspector/client/composables/rpc.ts
@@ -1,10 +1,13 @@
 import type { DevframeConnectionStatus, DevframeRpcClient } from 'devframe/client'
 import type { InspectorChanges } from '../../types'
 import { connectDevframe } from 'devframe/client'
+import { ref } from 'vue'
 
 export const connectionStatus = ref<DevframeConnectionStatus>('connecting')
 export const isTrusted = ref(false)
 export const authError = ref<string | null>(null)
+export const canRequestAuthCode = ref(false)
+export const isRequestingAuthCode = ref(false)
 
 /**
  * Reactive change signal mirrored from the server's `changes` shared state.
@@ -15,6 +18,7 @@ export const changeRevision = ref(0)
 export const changedModule = ref('')
 
 const RECONNECT_INTERVAL = 2000
+const REQUEST_CODE_METHOD = 'anonymous:devframe:auth:request-code'
 
 let client: DevframeRpcClient | undefined
 let connectPromise: Promise<DevframeRpcClient> | undefined
@@ -37,8 +41,12 @@ async function connect(): Promise<DevframeRpcClient> {
   })
   client = rpc
 
-  connectionStatus.value = rpc.status
   isTrusted.value = !!rpc.isTrusted
+  authError.value = null
+  isRequestingAuthCode.value = false
+  // Some hosts omit the method list (e.g. initDevframe/Next.js). Probe once
+  // in that case; pre-0.9.14 hosts reject the method and print automatically.
+  canRequestAuthCode.value = rpc.connectionMeta.jsonSerializableMethods?.includes(REQUEST_CODE_METHOD) ?? true
 
   const scoped = rpc.scope('unocss')
 
@@ -62,11 +70,15 @@ async function connect(): Promise<DevframeRpcClient> {
     state.on('updated', apply as any)
   }
 
-  rpc.events.on('connection:status', (status) => {
+  function updateStatus(status: DevframeConnectionStatus) {
     connectionStatus.value = status
+    if (status === 'unauthorized')
+      requestAuthCode()
     if (status === 'disconnected' || status === 'error')
       scheduleReconnect()
-  })
+  }
+  rpc.events.on('connection:status', updateStatus)
+  updateStatus(rpc.status)
   rpc.events.on('rpc:is-trusted:updated', (trusted) => {
     isTrusted.value = trusted
     subscribeChanges()
@@ -146,6 +158,33 @@ export async function shikiHighlight(code: string, lang: string): Promise<string
 }
 
 /**
+ * Ask a supporting host to print its code. Only explicit reissue requests
+ * rotate a still-valid code; ordinary requests are deduplicated by the host.
+ */
+export async function requestAuthCode(reissue = false): Promise<void> {
+  const rpc = client
+  if (!rpc || rpc.status !== 'unauthorized' || rpc.isTrusted || !canRequestAuthCode.value || isRequestingAuthCode.value)
+    return
+  isRequestingAuthCode.value = true
+  authError.value = null
+  try {
+    await rpc.requestAuthCode({ reissue })
+  }
+  catch (error: any) {
+    if (client === rpc) {
+      if (error?.message === `[birpc] function "${REQUEST_CODE_METHOD}" not found`)
+        canRequestAuthCode.value = false
+      else
+        authError.value = error?.message ?? String(error)
+    }
+  }
+  finally {
+    if (client === rpc)
+      isRequestingAuthCode.value = false
+  }
+}
+
+/**
  * Exchange the one-time code printed in the dev server terminal for a
  * persisted auth token.
  */
@@ -154,8 +193,10 @@ export async function submitAuthCode(code: string): Promise<boolean> {
   try {
     const rpc = await ensureClient()
     const ok = await rpc.requestTrustWithCode(code.trim())
-    if (!ok)
-      authError.value = 'Invalid or expired code. Check your dev server terminal for a fresh one.'
+    if (!ok) {
+      await requestAuthCode()
+      authError.value ||= 'Invalid or expired code. Check your dev server terminal for a fresh one.'
+    }
     return ok
   }
   catch (error: any) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,16 +62,16 @@ catalogs:
   devtools:
     '@devframes/service-shiki':
       specifier: ^0.9.11
-      version: 0.9.11
+      version: 0.9.18
     '@devframes/vite':
       specifier: ^0.9.11
-      version: 0.9.11
+      version: 0.9.18
     '@vitejs/devtools-kit':
       specifier: ^0.7.1
       version: 0.7.1
     devframe:
-      specifier: ^0.9.11
-      version: 0.9.11
+      specifier: ^0.9.14
+      version: 0.9.18
   docs:
     '@codemirror/lang-html':
       specifier: ^6.4.12
@@ -1046,10 +1046,10 @@ importers:
     dependencies:
       '@devframes/service-shiki':
         specifier: catalog:devtools
-        version: 0.9.11(devframe@0.9.11)
+        version: 0.9.18(devframe@0.9.18)
       '@devframes/vite':
         specifier: catalog:devtools
-        version: 0.9.11(@devframes/hub@0.9.11)(devframe@0.9.11)(vite@8.2.2)
+        version: 0.9.18(@devframes/hub@0.9.18)(devframe@0.9.18)(vite@8.2.2)
       '@unocss/config':
         specifier: workspace:*
         version: link:../../packages-engine/config
@@ -1061,13 +1061,13 @@ importers:
         version: link:../../packages-presets/rule-utils
       '@vitejs/devtools-kit':
         specifier: catalog:devtools
-        version: 0.7.1(cac@7.0.0)(crossws@0.4.12)(srvx@0.12.7)(vite@8.2.2)
+        version: 0.7.1(cac@7.0.0)(crossws@0.4.12)(srvx@1.0.4)(vite@8.2.2)
       colorette:
         specifier: catalog:utils
         version: 2.0.20
       devframe:
         specifier: catalog:devtools
-        version: 0.9.11(cac@7.0.0)(srvx@0.12.7)
+        version: 0.9.18(cac@7.0.0)(srvx@1.0.4)
       tinyglobby:
         specifier: catalog:utils
         version: 0.2.17
@@ -2597,10 +2597,10 @@ packages:
     peerDependencies:
       devframe: 0.8.2
 
-  '@devframes/hub@0.9.11':
-    resolution: {integrity: sha512-oK93xmp6E5SD+34SdE7eUBRFGREObQHlpiqTQefi/VfXFt1Lo3Sb8cBU8NbekLgsHIiHsmCsXuBWjRmH8TX0nQ==}
+  '@devframes/hub@0.9.18':
+    resolution: {integrity: sha512-sYsJEYiNBPMXRIcte+YNY0wBCV7J4rsh5TUuRC7jnulP/1cFDiHsT4mFxxKbm1VUX38KMAHtGVKBqk+/LYus+g==}
     peerDependencies:
-      devframe: 0.9.11
+      devframe: 0.9.18
 
   '@devframes/json-render@0.8.2':
     resolution: {integrity: sha512-LpIMMXDZGHsIlrNDWo1PbLenZcYRlxZ4lZ/vR/5j8bEh9FsSSY5Sd6RVPL93lyl4jz+2Sc+S2j4BKKzk9Zi8Fg==}
@@ -2611,26 +2611,26 @@ packages:
       '@devframes/hub':
         optional: true
 
-  '@devframes/json-render@0.9.11':
-    resolution: {integrity: sha512-tYIpOZZ5SG0CB71lZHR747IWoWeHwWU5WxqUazGzuber7hOk8UYF80LLSiR+PDoyhWdYUC7l8Ipt1fqSIVka0A==}
+  '@devframes/json-render@0.9.18':
+    resolution: {integrity: sha512-KMfcUxK3t6kbcoojDEXTy+mHZpt00IVXK6Yu9SJiqtLPTKmMsVU2MDkt+reafiX4ZczOycHHZUt5sMhl8tTDyQ==}
     peerDependencies:
-      '@devframes/hub': 0.9.11
-      devframe: 0.9.11
+      '@devframes/hub': 0.9.18
+      devframe: 0.9.18
     peerDependenciesMeta:
       '@devframes/hub':
         optional: true
 
-  '@devframes/service-shiki@0.9.11':
-    resolution: {integrity: sha512-twkWqsrY7dKF/UkxuywEh98bHIIX+Mqr0JHDahRMaEaRO//PeDatMNZxElGaVa0CrjzA74F2M1GAUMbgtoTjHw==}
+  '@devframes/service-shiki@0.9.18':
+    resolution: {integrity: sha512-xox/QfYreuGFS2eJfHbEOzliVdNjwHnrOV7UdA0dXn9YRob3vO0n1OR5iZTylXqkSCkN2v4iMV4OQfWl94sg+A==}
     peerDependencies:
-      devframe: 0.9.11
+      devframe: 0.9.18
 
-  '@devframes/vite@0.9.11':
-    resolution: {integrity: sha512-KfGIBMY9hPcLQ6Vu384bjwde8iw5XPMvhk9L+kyygR6KKMxRZ+j/5FB8nSZNSTHwvIMWYsoWdB7DpdP395OX0A==}
+  '@devframes/vite@0.9.18':
+    resolution: {integrity: sha512-rWV4gwrRlihOgCBsqRomuP9b9urm9F1M3pxUSvpWFhJiA/Afa+7z+3ORs4ntZItZhMeLsOupT/0Fe6EsAui2Hg==}
     peerDependencies:
-      '@devframes/hub': 0.9.11
-      '@devframes/hub-ui': 0.9.11
-      devframe: 0.9.11
+      '@devframes/hub': 0.9.18
+      '@devframes/hub-ui': 0.9.18
+      devframe: 0.9.18
       vite: ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@devframes/hub':
@@ -5674,8 +5674,8 @@ packages:
       cac:
         optional: true
 
-  devframe@0.9.11:
-    resolution: {integrity: sha512-6zCHsycinUV8KAvV/wqWBik7NtD2hxyJIS+kJNeCHun68D0yQdrIQX7ak6QYylVi8vdvBH3k5Pa+oced+ru1MA==}
+  devframe@0.9.18:
+    resolution: {integrity: sha512-SjvL9/MiqaG3m2bpfAb8fMsX6ALcyqFNIZ3VYjhZ/BZxSqkTknt3U6YcQTEAZOpFvGv+MVk6OeWkRW0IhzVxAg==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/client': ^2.0.0
@@ -6353,8 +6353,8 @@ packages:
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
-  h3@2.0.1-rc.29:
-    resolution: {integrity: sha512-woEUYLvpUa9SzbBGOYn3GfsK/EU7JhoUeNc49B2an6mcO1aqg7P8VvWVUfa5Vkb8FxBh9ZAkU+/rJ5m5pTULUA==}
+  h3@2.0.1-rc.31:
+    resolution: {integrity: sha512-AG7qZzF99a0BSYoXT3evJgIhwSIUKow7R+hwkLRZS06WJ9nbSb7QXUDgs1ByBjp6svTvl++N/GKA7I9YPz9cQQ==}
     engines: {node: '>=20.11.1'}
     hasBin: true
     peerDependencies:
@@ -8326,8 +8326,8 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
-  srvx@0.12.7:
-    resolution: {integrity: sha512-PIaq1pDGg3EU2OGSN3pzRfYVu9MJDzLdojlGN6E3lvhAdxqn/lNMJFMA1xGA38jYkBb0V9xw02QEVVMDb0PExA==}
+  srvx@1.0.4:
+    resolution: {integrity: sha512-eZmYaxUfZSo7/8m8UdsHRJNmTLSCTPPom9d7a60vMmuVeZvwhbvflRR+00/CxTCjMOFa5+H8tgBeNDVZ+w7AAQ==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -10606,12 +10606,12 @@ snapshots:
       tinyexec: 1.3.1
       zigpty: 0.2.1
 
-  '@devframes/hub@0.9.11(crossws@0.4.12)(devframe@0.9.11)':
+  '@devframes/hub@0.9.18(crossws@0.4.12)(devframe@0.9.18)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       destr: 2.0.5
-      devframe: 0.9.11(cac@7.0.0)(srvx@0.12.7)
-      h3: 2.0.1-rc.29(crossws@0.4.12)
+      devframe: 0.9.18(cac@7.0.0)(srvx@1.0.4)
+      h3: 2.0.1-rc.31(crossws@0.4.12)
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       tinyexec: 1.3.1
@@ -10630,26 +10630,26 @@ snapshots:
     optionalDependencies:
       '@devframes/hub': 0.8.2(devframe@0.8.2)
 
-  '@devframes/json-render@0.9.11(@devframes/hub@0.9.11)(devframe@0.9.11)':
+  '@devframes/json-render@0.9.18(@devframes/hub@0.9.18)(devframe@0.9.18)':
     dependencies:
       '@json-render/core': 0.20.0(zod@4.5.4)
       '@standard-schema/spec': 1.1.0
-      devframe: 0.9.11(cac@7.0.0)(srvx@0.12.7)
+      devframe: 0.9.18(cac@7.0.0)(srvx@1.0.4)
       zod: 4.5.4
     optionalDependencies:
-      '@devframes/hub': 0.9.11(crossws@0.4.12)(devframe@0.9.11)
+      '@devframes/hub': 0.9.18(crossws@0.4.12)(devframe@0.9.18)
 
-  '@devframes/service-shiki@0.9.11(devframe@0.9.11)':
+  '@devframes/service-shiki@0.9.18(devframe@0.9.18)':
     dependencies:
-      devframe: 0.9.11(cac@7.0.0)(srvx@0.12.7)
+      devframe: 0.9.18(cac@7.0.0)(srvx@1.0.4)
       shiki: 4.4.3
 
-  '@devframes/vite@0.9.11(@devframes/hub@0.9.11)(devframe@0.9.11)(vite@8.2.2)':
+  '@devframes/vite@0.9.18(@devframes/hub@0.9.18)(devframe@0.9.18)(vite@8.2.2)':
     dependencies:
-      devframe: 0.9.11(cac@7.0.0)(srvx@0.12.7)
+      devframe: 0.9.18(cac@7.0.0)(srvx@1.0.4)
       pathe: 2.0.3
     optionalDependencies:
-      '@devframes/hub': 0.9.11(crossws@0.4.12)(devframe@0.9.11)
+      '@devframes/hub': 0.9.18(crossws@0.4.12)(devframe@0.9.18)
       vite: 8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
 
   '@docsearch/css@4.7.0': {}
@@ -12582,11 +12582,11 @@ snapshots:
       - ocache
       - srvx
 
-  '@vitejs/devtools-kit@0.7.1(cac@7.0.0)(crossws@0.4.12)(srvx@0.12.7)(vite@8.2.2)':
+  '@vitejs/devtools-kit@0.7.1(cac@7.0.0)(crossws@0.4.12)(srvx@1.0.4)(vite@8.2.2)':
     dependencies:
-      '@devframes/hub': 0.9.11(crossws@0.4.12)(devframe@0.9.11)
-      '@devframes/json-render': 0.9.11(@devframes/hub@0.9.11)(devframe@0.9.11)
-      devframe: 0.9.11(cac@7.0.0)(srvx@0.12.7)
+      '@devframes/hub': 0.9.18(crossws@0.4.12)(devframe@0.9.18)
+      '@devframes/json-render': 0.9.18(@devframes/hub@0.9.18)(devframe@0.9.18)
+      devframe: 0.9.18(cac@7.0.0)(srvx@1.0.4)
       local-pkg: 1.2.1
       mlly: 1.8.2
       nostics: 1.2.0
@@ -13658,9 +13658,9 @@ snapshots:
     optionalDependencies:
       srvx: 0.11.22
 
-  crossws@0.4.12(srvx@0.12.7):
+  crossws@0.4.12(srvx@1.0.4):
     optionalDependencies:
-      srvx: 0.12.7
+      srvx: 1.0.4
 
   css-select@6.0.0:
     dependencies:
@@ -13789,7 +13789,7 @@ snapshots:
       birpc: 4.2.0
       crossws: 0.4.12(srvx@0.11.22)
       destr: 2.0.5
-      h3: 2.0.1-rc.29(crossws@0.4.12)
+      h3: 2.0.1-rc.31(crossws@0.4.12)
       mrmime: 2.0.1
       nostics: 1.2.0
       pathe: 2.0.3
@@ -13801,13 +13801,13 @@ snapshots:
       - ocache
       - srvx
 
-  devframe@0.9.11(cac@7.0.0)(srvx@0.12.7):
+  devframe@0.9.18(cac@7.0.0)(srvx@1.0.4):
     dependencies:
       '@modelcontextprotocol/server': 2.0.0
       '@standard-schema/spec': 1.1.0
       birpc: 4.2.0
-      crossws: 0.4.12(srvx@0.12.7)
-      h3: 2.0.1-rc.29(crossws@0.4.12)
+      crossws: 0.4.12(srvx@1.0.4)
+      h3: 2.0.1-rc.31(crossws@0.4.12)
       mrmime: 2.0.1
       nostics: 1.2.0
       pathe: 2.0.3
@@ -14532,12 +14532,12 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
-  h3@2.0.1-rc.29(crossws@0.4.12):
+  h3@2.0.1-rc.31(crossws@0.4.12):
     dependencies:
       rou3: 0.9.2
-      srvx: 0.12.7
+      srvx: 1.0.4
     optionalDependencies:
-      crossws: 0.4.12(srvx@0.11.22)
+      crossws: 0.4.12(srvx@1.0.4)
 
   has-flag@4.0.0: {}
 
@@ -17069,7 +17069,7 @@ snapshots:
 
   srvx@0.11.22: {}
 
-  srvx@0.12.7: {}
+  srvx@1.0.4: {}
 
   stackback@0.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ catalogs:
     '@devframes/service-shiki': ^0.9.11
     '@devframes/vite': ^0.9.11
     '@vitejs/devtools-kit': ^0.7.1
-    devframe: ^0.9.11
+    devframe: ^0.9.14
   docs:
     '@codemirror/lang-html': ^6.4.12
     '@codemirror/lang-javascript': ^6.2.5

--- a/test/inspector-auth.test.ts
+++ b/test/inspector-auth.test.ts
@@ -31,6 +31,8 @@ function createClient(options: { supportsRequestCode?: boolean, status?: string 
 
 async function load(rpc = createClient()) {
   connectDevframe.mockResolvedValue(rpc)
+  // After resetModules(), import with this test's mock in place: the module
+  // connects eagerly and holds connection state that must not leak between tests.
   const auth = await import('../packages-integrations/inspector/client/composables/rpc')
   await vi.waitFor(() => expect(auth.connectionStatus.value).toBe(rpc.status))
   return auth

--- a/test/inspector-auth.test.ts
+++ b/test/inspector-auth.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { connectDevframe } = vi.hoisted(() => ({ connectDevframe: vi.fn() }))
+vi.mock('devframe/client', () => ({ connectDevframe }))
+
+function createClient(options: { supportsRequestCode?: boolean, status?: string } = {}) {
+  const listeners = new Map<string, (...args: any[]) => void>()
+  const rpc = {
+    status: options.status ?? 'unauthorized',
+    isTrusted: options.status === 'connected',
+    connectionMeta: {
+      jsonSerializableMethods: options.supportsRequestCode === false
+        ? ['anonymous:devframe:auth', 'anonymous:devframe:auth:exchange']
+        : ['anonymous:devframe:auth', 'anonymous:devframe:auth:exchange', 'anonymous:devframe:auth:request-code'],
+    } as { jsonSerializableMethods?: string[] },
+    events: { on: (name: string, handler: (...args: any[]) => void) => listeners.set(name, handler) },
+    requestAuthCode: vi.fn().mockResolvedValue(undefined),
+    requestTrustWithCode: vi.fn().mockResolvedValue(false),
+    close: vi.fn(),
+    scope: () => ({ rpc: { sharedState: vi.fn().mockResolvedValue({
+      value: () => ({ revision: 0, module: '' }),
+      on: vi.fn(),
+    }) } }),
+    emitStatus(status: string) {
+      rpc.status = status
+      listeners.get('connection:status')?.(status)
+    },
+  }
+  return rpc
+}
+
+async function load(rpc = createClient()) {
+  connectDevframe.mockResolvedValue(rpc)
+  const auth = await import('../packages-integrations/inspector/client/composables/rpc')
+  await vi.waitFor(() => expect(auth.connectionStatus.value).toBe(rpc.status))
+  return auth
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('inspector authentication', () => {
+  it('requests a terminal code when the initial handshake has already refused trust', async () => {
+    const rpc = createClient()
+    await load(rpc)
+    await vi.waitFor(() => expect(rpc.requestAuthCode).toHaveBeenCalledExactlyOnceWith({ reissue: false }))
+  })
+
+  it('waits for the stored-token handshake before requesting a code', async () => {
+    const rpc = createClient({ status: 'connecting' })
+    await load(rpc)
+    expect(rpc.requestAuthCode).not.toHaveBeenCalled()
+    rpc.emitStatus('unauthorized')
+    await vi.waitFor(() => expect(rpc.requestAuthCode).toHaveBeenCalledOnce())
+  })
+
+  it('leaves code printing to pre-0.9.14 hosts', async () => {
+    const rpc = createClient({ supportsRequestCode: false })
+    const auth = await load(rpc)
+    expect(auth.canRequestAuthCode.value).toBe(false)
+    await auth.requestAuthCode(true)
+    expect(rpc.requestAuthCode).not.toHaveBeenCalled()
+    rpc.requestTrustWithCode.mockResolvedValue(true)
+    expect(await auth.submitAuthCode(' 123456 ')).toBe(true)
+    expect(rpc.requestTrustWithCode).toHaveBeenCalledWith('123456')
+  })
+
+  it('does not request a code for trusted or static clients', async () => {
+    const rpc = createClient({ status: 'connected' })
+    const auth = await load(rpc)
+    await auth.requestAuthCode(true)
+    expect(rpc.requestAuthCode).not.toHaveBeenCalled()
+  })
+
+  it('requests a code when a modern host omits the method list', async () => {
+    const rpc = createClient()
+    delete rpc.connectionMeta.jsonSerializableMethods
+    await load(rpc)
+    await vi.waitFor(() => expect(rpc.requestAuthCode).toHaveBeenCalledOnce())
+  })
+
+  it('probes legacy hosts without a method list only once per connection', async () => {
+    const rpc = createClient()
+    delete rpc.connectionMeta.jsonSerializableMethods
+    rpc.requestAuthCode.mockRejectedValue(new Error('[birpc] function "anonymous:devframe:auth:request-code" not found'))
+    const auth = await load(rpc)
+    await vi.waitFor(() => expect(auth.canRequestAuthCode.value).toBe(false))
+    expect(auth.authError.value).toBeNull()
+    await auth.requestAuthCode(true)
+    await auth.submitAuthCode('123456')
+    expect(rpc.requestAuthCode).toHaveBeenCalledOnce()
+    expect(auth.authError.value).toContain('Invalid or expired code')
+  })
+
+  it('does not request a code when a stored token is accepted later', async () => {
+    const rpc = createClient({ status: 'connecting' })
+    await load(rpc)
+    rpc.isTrusted = true
+    rpc.emitStatus('connected')
+    expect(rpc.requestAuthCode).not.toHaveBeenCalled()
+  })
+
+  it('reissues a code only on an explicit request', async () => {
+    const rpc = createClient()
+    const auth = await load(rpc)
+    await vi.waitFor(() => expect(auth.isRequestingAuthCode.value).toBe(false))
+    await auth.requestAuthCode(true)
+    expect(rpc.requestAuthCode.mock.calls).toEqual([[{ reissue: false }], [{ reissue: true }]])
+  })
+
+  it('prints a fresh code after an invalid exchange without forcing rotation', async () => {
+    const rpc = createClient()
+    const auth = await load(rpc)
+    await vi.waitFor(() => expect(auth.isRequestingAuthCode.value).toBe(false))
+    expect(await auth.submitAuthCode('123456')).toBe(false)
+    expect(rpc.requestAuthCode).toHaveBeenLastCalledWith({ reissue: false })
+    expect(rpc.requestAuthCode).toHaveBeenCalledTimes(2)
+    expect(auth.authError.value).toContain('Invalid or expired code')
+  })
+
+  it('surfaces request failures and permits retry', async () => {
+    const rpc = createClient()
+    rpc.requestAuthCode.mockRejectedValueOnce(new Error('Code request failed'))
+    const auth = await load(rpc)
+    await vi.waitFor(() => expect(auth.authError.value).toBe('Code request failed'))
+    await auth.requestAuthCode(true)
+    expect(auth.authError.value).toBeNull()
+    expect(auth.isRequestingAuthCode.value).toBe(false)
+  })
+
+  it('coalesces code requests while one is pending', async () => {
+    const rpc = createClient()
+    const pending = Promise.withResolvers<void>()
+    rpc.requestAuthCode.mockReturnValueOnce(pending.promise)
+    const auth = await load(rpc)
+    await vi.waitFor(() => expect(auth.isRequestingAuthCode.value).toBe(true))
+    await auth.requestAuthCode(true)
+    expect(rpc.requestAuthCode).toHaveBeenCalledOnce()
+    pending.resolve()
+    await vi.waitFor(() => expect(auth.isRequestingAuthCode.value).toBe(false))
+  })
+
+  it('requests a code again after reconnecting to an untrusted host', async () => {
+    const rpc = createClient()
+    const auth = await load(rpc)
+    await vi.waitFor(() => expect(auth.isRequestingAuthCode.value).toBe(false))
+    vi.useFakeTimers()
+    const next = createClient()
+    connectDevframe.mockResolvedValueOnce(next)
+    rpc.emitStatus('disconnected')
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(rpc.close).toHaveBeenCalledOnce()
+    expect(next.requestAuthCode).toHaveBeenCalledExactlyOnceWith({ reissue: false })
+  })
+})


### PR DESCRIPTION
When an untrusted browser opens the Inspector with Devframe's on-demand OTP behavior, the auth screen asks for a terminal code without requesting one. This change requests the code after trust is refused and adds an explicit reissue action, while preserving older hosts' automatic banners.

Fixes #5333

Reproduction: [Vanisper/unocss-inspector-auth-repro](https://github.com/Vanisper/unocss-inspector-auth-repro), with working `baseline-0.9.11` and affected `repro-0.9.18` tags using the same published Inspector 66.10.2 and Vite configuration.

### Changes

- Request a terminal code when the connection becomes unauthorized, including when the initial handshake finishes before event listeners are attached. Trusted connections do not request a code.
- Add a reissue button and prevent overlapping code requests and submissions. After an invalid exchange, request the current valid code without forcing rotation; Devframe handles expiry, failure-limit rotation and per-code banner deduplication.
- Surface request failures so the user can retry, and request again after an untrusted reconnect.
- Use the exported Devframe event constants and add 12 authentication regression tests.

### Compatibility

The bundled client needs Devframe's `requestAuthCode()` API, so its dependency floor becomes `^0.9.14`. The lockfile also aligns the companion packages' exact Devframe peer dependencies. Other declared ranges, including the Next.js example's `@devframes/next: ^0.9.11`, remain unchanged.

Client and host versions can differ. When the host supplies `jsonSerializableMethods`, the Inspector checks for the JSON-serializable request-code method before calling it. Hosts based on `initDevframe` can omit that list, so the Inspector probes once and handles only the exact missing-method response as a legacy-host fallback. That disables further code requests for the connection and hides the reissue button; other failures remain visible. Older hosts continue printing codes automatically.

This fallback temporarily relies on birpc's exact missing-method error message ([v4.2.0 implementation](https://github.com/antfu/birpc/blob/v4.2.0/src/main.ts)), which is an implementation detail rather than a stable error-code contract. Matching the complete message and method name keeps transport and other request failures visible, but a change to that wording would prevent the legacy-host fallback from recognizing the error. The code documents this dependency and includes a TODO to replace it when Devframe exposes reliable capability detection or a typed unsupported-method error.

### Validation

- Full Vitest suite: **739 passed, 3 skipped** across 101 files.
- Inspector tests: **20 passed**, including the 12 new auth tests.
- `pnpm exec tsgo --noEmit` and ESLint on the changed TS/Vue files.
- Inspector server build and production SPA build (`build` and `build-post`).
- Actual built SPA tested in fresh browser sessions against `initDevframe` hosts **0.9.11, 0.9.13, 0.9.14 and 0.9.18**: first-time authentication, unlocking, and trusted reloads. Reissue and code rotation after five failed exchanges were also verified on 0.9.14 and 0.9.18.
- Built the SPA with the minimum client version **0.9.14** and verified code requests, unlocking and trusted reloads against a **0.9.18** host.
